### PR TITLE
docs: align project status and fix pattern learning roadmap

### DIFF
--- a/.docs-roadmap-trigger
+++ b/.docs-roadmap-trigger
@@ -1,0 +1,1 @@
+Trigger the one-shot documentation updater. This file is removed before merge.

--- a/.github/workflows/apply-docs-roadmap.yml
+++ b/.github/workflows/apply-docs-roadmap.yml
@@ -1,0 +1,183 @@
+name: Apply documentation roadmap
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  apply-docs:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: docs/finalize-roadmap-and-status
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Apply documentation update
+        shell: bash
+        run: |
+          python - <<'PYCODE'
+          import base64
+          import zlib
+
+          payload = r"""eNrtXFuPHMd1fu9fUYYelqTnIi4lJeGCCajlWqJDUgSXiu1ond2emZrdNnu6J909JCemAYuC7RhSJMTIUxIYcJLXABQlRitRpP7C
+7l/IL8n3nVNV3XNbXiwjMRBBWM5MV1edOpfvnDp1qoZFPjLjuDpIk55JRuO8qMx1fI3c58JGUZHnlbkgP59a66ydjqJoYId4NE7j
+vt0tbb9K8uwUezkvrVqmrOKiOo9/ipax2cB9yuyd3V4+mMrX06b95+ZantnzkcF/lb3LQdhJp7DxYJc/nLJZPx8k2f6FtUk1bP8p
+xmZbNKpskaF5YTv9fDROUnuqGK79zU/x3Zb9eGxPCQWnf7aTdc78xam/uNB8BIL44PRai+9fNff4z7Z27SY1shmpkU7Md83aTraT
+reGDn0GnwAyS8anT4aG8PRkP4soOWqafTzI3HVLaKSe97FSj75bM17W7cFbHTobuve9cMGeVK0JSnJTW3MCDZGS3iiIvTg3X0DAd
+mCyvPMXGicH8VIj+TvEzk+AL+fmzmm0HnTtFUlllbqB2kcvRK+bG1sVLV7c6o0FEcYwsuU1F6Jq18GgtmlcCx0S+0JLPa6+8Yv4q
+ThMMReq2q7ialGv1s4tF/wAU9atJYf3Pa2s3DywnlpdJlRdTs3kZ0xvHBcgtDQashnkxQoNynGdl0kvSpErwJMnKCkObXJTTYsRs
+39jbFj3s41WTZ5F+KyZZZovzUdQ2w0mamvEUHVd4bq4k2eSuuZNUB+b6tDrAL+c6Z19t8e96y8TZgJ/ObeDFG5PhkIpeJP3KXJ2O
+p/p436JnsrVd3krQdf/A9m+VK7te35ijgX1sXsF8R/kta/iTvDyK++9sy8MfJNkgv1Mu7Sg2GSZ924ZGvUkCNakO4spg4smQXEKj
+PGvb0biamr1BMq4KCnDUH+/2imSwDzO5a/cMdCgZxv2qE0UURn9SFLSJvVGcZHumV8RZ/wAaVZbosTpISkM7TC24PIrBk7sdc8Pu
+Q0Ilpd7PMXq8byGhfjoZyCs2GsZJ2u6neWlBYjHh5CeYDhR0anowhEFcTGmifztJCvCzD67uUxtKO4phDH0ZMi6SEiNAIcz1zTfJ
+oagEz0EEGhTsxdBSy9Y8a+IqHyX99k/ynunZg/h2khcqQRjsKMliiA5ztGmqiusHLTlU9L3CWnROBUPH++U46Vt9Ox/bbOvqtkG/
+JXi3Pc0wVdLyWuecGSZ3qeelMoQEQ4M8tS2zifkAEMHmKwk4zNlfd1Dnf4j2bT6yFR9BblkZi9mVZNPtxN5pmUDVpe1r3e2tbaWq
+tAUH7OcZpV2VHXPRpOTGpWR8k/KPXu+c67zaWa/JMXG/b8cVeSBqGCwwnXpdGogFlfmk6Nv29tsX2f8wpT2Mi7xSRGiZXty/NRkb
+iBEwUDkzUe4bQSNq7mtnMTJ4NzB7N+zwki2vxsUtzGPP2EGiJgA+muv5HUyjPLC24luqsCYej0HUME9TPB6Y3hRDQNUGwAD8ATv9
+LMGltr1Lx8a3x7YoEyAGZwjIiGGEIKOf5wXAUKCGlE6g6HG2b4m2xQhT+Ds7AEwJDV1wBH+SrJvhS29SdgfJcGhpKUmctsdxUiik
+lxwvy+k/MBR4lFmzdWPTWMI5xhlCyDLBWmPF8GBX+B8gkwuSJQMhlsrOxhQL6CKuU78BzrHpp3Ey4nSCPYqVVIqSU4ENh4KBK7fJ
+CHAY3eqTH169YvLeTyDBDsA4Ov18MH9TbPhqPrBpA+D/MsvvUH9HEOMswDulHEAGkPQkAUtLas5tm4nWDRmbBEigyvbThOIcxQCB
+SQ89Bp5AzSaVSaoIRktGoJsRVNCI7mD8Qd6fiFOvcjDpINk/aCvk3K59U4rJpx2q9Jkztd1e3bzeDqB+5sx5YU4fc69U1fb0824w
+nF0/1h4Yivn6BuN+r37UMZcrihbiAkTSlkxcmr3SD7sLzQJ/dvMsne4Z+v7UqYEtyMSGdjfssVYRexdcBQDJXCzQsxeXDfLzcTJL
+vSdsl0yHmO1gz/GfYk5rXVHz6YCEy+SyFSEKnhu+1ZCfigRDTemGBzlaUTI6oCp6m4reELGQe8P2YYGNyZDqvUJ+3ZXX+Naufwpn
+BGbA1VmYhe2qKQ0REcIk7N2YYCT2QZsVpDLVdAzigFft9dffoAJM2FZhcsGzdMy7mGK7nABjZjgM4U1KC9eNjmmQ8QRAJb0UwfE5
+rSydbYrGoQ/GUTrXt6GI+jMnqUpLVYSW1q65nrOXs9csRHFwDnG6W+V5urQdASSriEc52kFVJll8G3437qXWqRVFh5Fp7eYgLtEv
+0JMy4Vt9UXO11DYMycr0oFv0QGWyD5yEQ/MKCA+aE/FGME2+FxORU7SGVW0JssCaFPRBljM9MXp436ZVCoqVjpsUvGoYZEIbrnWs
+g26dPCC5ZCjhEhrRHbreB/QdkJR2Bh9Bf7QhSgH6EpgFhO98GDUjGiUl7BjWXMo6BnwCV+QbopcZUNXQw8UlyYISeV/QxwwZ60Qa
+64AXgMXg2G1cZDQQjYxnoy0arfiKvji0ckwZcQw/ObVzvj4bKAgxSiO5NohG8JESFojzFX+JLsPbfkUl6NgPYcgd6ABfN9lk1IOT
+MMKYjh8s2howPvduuFSlVwHACSQ96+IFeoo2ocxFk17dBBTOnIF1nDljpraSAAUBZu2aK4Y5CRnUHQJeKDtDZYdTnCAAhbp6ZHBT
+2IXNU0Z7LbOnEUx4Uk7296EgIHFP9BRvkoplzztCZsY1acLeCI3qJEZElgrsoWnRUMaEYZlcq6GYbQlgTaAZwoIsq4jsH1gNMcl7
+xKiI5hJqK512CTeZxoWLvQg3OhsEbN+DHrSriegKhgYOI9JKgP4RIlRA3p28uCXSdXDj4+YQLQwTLFodZolVjTAr5/rKKZg9gnQ2
+ic4uFhhN3JxBmAueneC785Eq1xWF5doAQJzm/Vt2oOgSScgJq8MPwYcg1pyFax84d8v4tu2GIK2Ol4WxMgsBjyIK4XjHiMEEyJkT
+Fz2J9t8IZ/vSRxI7pHDuJsmi9zQEQ1gTj398Cj6x7N54B2vdi9ex2D3tYiGXqdDo58RchWvJfzougtLIaa3tA/qayZ59iwAdvPsM
+AxsO1LNpJzNq0hvitNt+LbKfp8DIZqgTp2UeRvRepF1ojqHJKmpVZyfzgVvbXK8t09lN21tore0etxsapkZLhlM5g5QwK9g9Rvij
+40i0XL5g0Xs3VmnQWss0ngubPBNT7wfQTbbkzdMuDdNM4GgO6YTsze6Nd+sEzm4xWcjhaIMT0zh4rQ7mj353fP/owfH94w+O3zdH
+3xz//Ojp0cOjR/j3q6PDRtB/9M9HD46+Msf/gOZPDVvjHTZ+dPTk6Gm9DNi8bPDzg6Mvjj7Ho8fHn6Cv+wsd4wf0gjfZEH+PfyX9
+HB5/LAtQPj16fPTk+MOjL30ahc1cxgWULqRyDDpdmcgxMuIMCQ/Qy9FnMip/OHQPH+A7hj3+hZFkT9kYtjuXmllK5OFcqkff11wP
+HrpUxUJXZMH9o0MQwE+f+HZt0Pjp0dNA8PwknmJkTgA/i0Dww2fg68ocENzB0b+h+Vdo/msZSLq6L927RJAOcfwL9PU52ALZPUTX
+H4vkjz8wR1+LtpBjvzz+YHlOCJ1+BdF/DKk+YPcn5YVaBgN9CjX5QlhAlflIePrIkCr56TNhwSH4tyxRBDKhZpIrOjqMGsmXJXkh
+kRmmLMoJfeMoh8/MD+kIzRRR12WIug5+yNjfgtbPGxP4UvIxbc6AsqH4muAmuRmh53M0UYmC4UePZR0j7Pg1+X/8gU+4tGZyLK1I
+JHUIgYgSu+m8dnY+39KWdg9EKIeqj1DbQ9GXRy7/og8ecVS0wzP2K3NQjlG10IlOy7lyNPki8jPqmKPf4C0ZXxTzqZuOaPbxh7Q2
+KJUQQkKVgI82OCybQqv4GwhoWKHqwFNp/CvlIh/W5KNty1DLdDJHX4IpD/HeQ1FeffpLmoc8M8d/T4I42WZSxzCpI4b+SObkGDpH
+I/sFKixJ9fDFiGyCEj+U157yNarEfwpYzgn5v0Dag0VUfBTmjLd/KV8fqNa3hAAlUMZwqIp2n4j14MuvHV8fHX0dgEnggXzHK187
+9lFdnuoneUR+vc+3qAFCCGWP/vlDUFd5GNrVuaRyWQAF93JiDDWCXkLlLqhb+e3RZ14pghP4hM4YXtsW7BVDsOG/ikzFvIwK1wH3
+J9ytOfqdfJPfljmgRhIKM2ikoODXHgvfnlAgYA7ko7JxUvlcFPijRl6qlkbdficDex4E5kIXajDzKkANel9M2s0AMKzKxvHww4lZ
+LM6yTd63VKZfiBo9cTbJVTj9wxN0iTkTVYWQB8f/6BRlRSZqg72KlX1DXhqZ8wNPuLgTyQI17XeBpzM8Ee2Dg3HgvzQvJKOelAHC
+cA/pFMSYtR9h6688LtDj3adtLE0BNVwFA8baW4i7+VwCD8yZa6dlmaAVpvb5grF+LawjMtI2dFYnZnlA2HPkeIS+r+uRHG9JgMRd
+H4DJGL7FuQm/6b8lkrm/KrOzNAJDh98o2hvFu6WZHrGvfzn+GEAjIQOdxDeKjaJ3gvIPHYAzZvg5CAz49ggGoq5pIRvUMSHXM+tm
+xGJqemsZgBBxekaoVk37qOE0DuXRyqSQsEgB8Ru0r4OAhhJ1oUMtF1WFAO8RBl6MRkCROtYnHriaijeTLXK+WhwTsQF6Y5pRkTDq
+CzHej3xALoxfCNEZLX1QQyU5x2f3RbDiqERe/05c8gBFhuKVQ9fPRwroTYkpB+UZZsXo0LlbfP6YgQhDhcWE1KyU5PVxgvVj3h7H
+g53M5ahceFHH+o4Ios7XwuUnioKIL1eM/mVIaDkF8GjALswSmR42s1wd5yDel8DmMMzEZbsCVn7sLL3Obgkvf+Pnycj5vse4hs01
+kltzOa2Vuayd7IRklsDECbksqAREBzxo8EdWZjBM898//6dmDmsnc5kq+odZN7gqbSXBzC9Ecw4R8zjdfSIC/rD+QQEKjJ9JZYFf
+T0HJY/WMR0/O+wDdedSHzqs463okSqE/zSUY0jwfU9+fODy+L0byqYIL5dRxnr92hi6gb4Rx3sKfI9214DIF6T6VqXw1s0J8Kr6A
+YOSivse1OVKpn7i18WMPhgymwbjV+TIQfVK6jAr8H5jHVxJAzCxVXYwuKClBhYY/XDbeF158JVGS4oPg42cioKeCWz4WdP7/fXHv
+HwIczHurs2ZSHoPALxkaF8xJBiiTvImWuSwpcakTFM23hnR/KzJr2oxZegkFv2v8D2dPzsSl83knDUy4pKqFBeP9lNpXp548szea
+2bElpt1tWIpT7QVQ5ipEVu5cMi8g9CyAhJiruf45/lCiiW9hKt9CWkvDhcek63kc0AnJLi4Oni/fNddF5NSxkfCaa7EWliHa8iUT
+uffM2T8z9+rN9tvr+BYP4CmIH1IQNIl1N1P2IkPCgV6PSQiiWNZPEHOIwKSqx+f2Ice0StosMqCjNN5B3qtV7n9tfD/8+qszw5/F
+txPzN1LrhIG7daHJkjTNQrXO5uW54pyQomWiZiYTM0Md6WFGleHtPXMwwUjt/UkysCHzurBH01rl6ZSCkY3LSSHJ6DkPxMzwEGGw
+UnA6ylMolMx/tlBxrlbCvE0BSe6Xznj91fU32q/+SXt93dcuovkNSUyziY+B22/J3uYPMGYoZdw+HbFA0Y+pS2EZCWsdz+TNBpOl
+2OyyedNvM86Mf84VoIRNyGaRl3CCwxCVe9bcsfEtm2lNge5HDa1uDZMrkqZ1ufTWimVUy8NQ2+/koqOeTd2uqt87r0vE4sJyT99V
+JXHrkAGSVNr4tD2iNRmssQn1/e13rnHnemD7WNe2wt4ux3AENLaSXTUJdKHifvsztuSfY7FG6horm3rHf/Vmx3PuxpMXz70fL3UB
+9R4MqWoWNujmZZXLjpsCRyigAR9td6xVvs3F9EyA4lbWLSkmGNR7kd7U20v3z0V0bjHGCk4mHnwRQF0sUHD/tZgpNekG4kWMMVPx
+LqwmW0ItTyOgla3tRtqEoCUEEBSb1DFNXdZ74lAVLBVYbmX5udKimGwwzhN5KBuOJM59v5MMfPWJ3RcGpvHUUvNuJ7Epq2lqy245
+jlnDx41Tp4qLdWQjK4uTg2RMKmv0XKRVStPK7gHkHxf9A+5LA8E5opS6dB3wcSaJ+0tvgAlFTH4AK/vAXkHrO5CaqUsOvUH2JqW3
+mTCKL9QgdXs1UbseMqQWBbwBqg+0tChoRa0B0qUzuh4rCiqp5iNdECp3uQ8AoTMvgMC4V4JTHBhgBtsv3c5PY9uny80T/jmnNbUQ
+FBBNm5WVOMQYdjtF9Ca1wq264haDey8kr3bDno2rptAKqVByq8UQUnnb3frhlrPFvqiZGJrDCLPguZKy9m9xv8jL0jy70NRCo0Gi
+lmoUed+W3L+E86ZmujJh2TjPGQ2vlbNDSnmyVKS8Yt4W7/iWeseF+hQX3WkBh9YSVHGxbwVL5jwhqykzc+aMry85c8Z7W1emOKly
+1d5GjUHkXH4allicpsCvuMlhvWoEwffM1VCJcc8Vz+DDJcttFHXP98wW+eB2+xkZ4K12u22W/MWT6zORzL2Viz8tZ2mW4Uill6s1
+C/kMV/ndCkU2bR9wsOJvP9NjACF3MJ9lcGokc5ip0REB0jhcPZAduKqjVL9Q4PnEJc34nlZMGDpcLhJlqgyLpLrlnrk5ZdVtIwVQ
+B0TOos+bl6yxOSEpgYEvuhqXrrayLIzpJ1pB5NZRqr3JiFpCiV6+BH56T9T1qx1JwTXTy0Ws5W74CF4NtFKKbs+HEvC0Xa1pRgzi
+WLI+EylemgkBfSwDjhVace28UijdYSHrQtGOSI9aAVAtZVSEFMMkpThc+VtNYLkBbzVun+3y7zlDxOVuIuCMBWyxObAp5DOpBBSF
+4nMzFG8H5taBKEv/9qVwVTnZj8exqwMeJKW4i6lnSaglp07AxON9V2o3zumF0eCWTG1OG1uyWtCqiRDJieGylFiVrwxKKTVnbnGx
+YBdAtMKF8JzeazPT26xDOIniwdOicEdeMC0Rj3iVuUpVTufNZmjC/SjFT1USuFJgbFYe5K50ELEuZrohDcfppAzhoIvRQgiqcCW0
+vo5RfN3TPXPt5OzR1JmkAlwo/BDq3aykbCuvxoWozD1zubKj0pxtr8PwKVhqO5gNilg9XSQ9ZyCr6mFm4iOt8Xaw4I5wLEsn0T1D
+SeU9meUboGRgEZcUMs13PAcbyNx1746TsS4a0IyYQgtINDJSMfg0YzgVEPTbaT5NGsP3p8ZF7y7gqI3OL0xUbBAQWMAictCmXgow
+p8AltXoNhBO+5332MeWMYqxztdDXlyYSZ0ihhFKtpo60pIbPY49oE4uarJ6v8JG2xM7iGMMhpuD0WIfbMVtx/8CTx5VU5M7GIJjM
+J/tN1OP8idUVC5RA32DS11o4j5fBvGRRobpkbZuHpCLdOznfOLwAkfdvsfDCoVoofw1roeBLvGVSeSqRksfqKE4liqGik1eeEvgz
+WVk24XjWUzJ+J7ujCJArZ9VckLIqvwxMOJDTEQQPxMAD5mZKLmwaenfe42pvGonz5amLrq5MxknVx2qF5/YAe3AdpR6ZGbENdfYg
+l8W8RKMjjfE55EhCbyKZHTixU4ebaL7BhpmAox7fCOv04AOgYQ3e+1haTj1oBTM1NayxPexTp8Qd0KtMYNI88COOof6usiBLx4Xn
+P4s9nWuJaoiW1XqcwdTaDdikY9DyyRnfost60WdEGZPSlZAGgUS5WMloXNWTHEwKPWuHFYZImeI9Fxa1dZQjkubBPZb/QqEXdonk
+YAQPeNBM3PpT/URU1yX7ork6kmo4Dx2HYtFDCXO6HKekZupOSEiA3wjaGnqqyNghuLsViR4HHQHFMELP9mOWlc+Fvg0BRvt5Dj/i
+wlqHt1Km6/kye4rDg3SbCxCWiTNr3jgnai6YkFLSE6Uh27NwnnTJWdKlSXbNh7o0nT9C+qxMu2bXLkI+c9W2Mjk5bRiOe+gE/fmt
+UQKJQVFm/JR31ICfnawHnA1R+KBj3pzKi74iPlSOO4VvmURdo+i4d4/iD0KB9E4WnJY7SDNJFFnlmIiPpx2yQmLs0pxbKGjuTXVu
+Xk6dnYzGUwcSeSph4ADhiER42tFrc8kWgy7cmYsq7+dpl+tASQq01Dx0H07qVZfUnwZXDnslhBANGxW6N+/kkpS45Quy1cK9xcxX
+5bKlOXX9bBvhVtwDZp8WdshCsl5M7GQza7MQwGjf+qztFFy7DJW0Mzp9flZalLYX1yoRzWjKUnkpvDmZJVShVfIyv4e4drIT5WVe
+VFzRaTkOAv+7u/w4O3O3fkdlU1tiVQKXl5B+5oZ3/jqkfV1XIem7+kV3wOTkevmkPB9FZzv1Q4ZSS5eI4USpFjPXJyo3ovWZ99dX
++neJseejv43oXEeAAZBFRzK7+ghLhnpF6TMdBYJzHnAISx3JK77WAaUpPQHXFY10cO0OXbpB9dxLbSN6vWPynpxJ0YjLaalPFY99
+ubtkeabwXOWtLjxHZbvA36KaxgVzgUCi6Ub0Rkd1RWKGBm9eN8vNyx1ZClE83hvhTyHxYailhKcFclpzdj1YHfN9rFWsD3jN2qF3
+RmqNdHRwc9LJ+lnfSeTXXtoJIeKcWOqMbchyQpw+wfri8nMl4QScHtCN4Pf1mGpY4+ipwKSx8TO/lSmZ7KUVb+5Mkc+HBXsuZ7al
+VoKubpIJ2xQR2j5ZH5WaVdIlgx5U0VyfW3AOwgJbwqkJSdnUMflD8IEjC8SSja+AZm+9e7m5viLr3MQZp/HgvUZU9Wwie1fWB3WG
+J15yDuLi9csbegcBk2szR+JIyVu26KE3sPLaprlUJCmiuUk1nmD18z25hGBSHrTBkDaWOlgL7qd5j7lIrFxCEpKU+6WM30OK0zvx
+tGxr8IUwNpIFBel3S+aw6FfQrvz5fjk31IjvJxlxStZwfgdXdLSzJBaag0+NiNyPv2885PG0GQn5jeIX2JC+ubV98/K1t7ghzXQT
+GTK3IV23WKtDLWn5khvSPgOuRwxa7nSDrF0aJxye+6YLl2uGvwn18bKWYG58/gaKjtnMC39nxSBvnkILCtoy349vx62dbCax7WxX
+bDyzlR5l6zOV3Yhs/Mxe6saOzpL7OnayEy7s0Lwb/Xa2eKCjs+Q+Dr5A0hAoKG3i15Zc5dHox28ghE1M35ncSsEdBOH3TvZil3c8
+lyB2MpGEeQFBRCcX0rjT4GELYJLdkrP/PuMW9vlrlzZXPfOSHfj3F68KmdvMQ5+6Yde45KErIU/YqJvfpgvdm+Yu38vv3Z1I7tJd
+PR4LXbWjN7+B16D2uTbySK5s5m08W7yNHLFsmWkBNVM97uoRDSpbYQtXu3fBT1POv3dPvqOTbpAR7T/P9f+wzf17O6j9YUsqfbsH
+CM6Y7e2W0xH/lb3tGZE3zoWz0leuGhBDWXoU3Gco/Ra25twRYU7G9SrkOTitW0lvbQFhLt3Y1OxLXsWaxeDe88zdLiNd7TTsWC6f
+meH4t9Zj3eGq8pv6Mh1NaEoUMxf8N4C6cVtCg+/+zLLb0GyHDc1ncg9eQhJYmhzDdKYhVg87Ys+s42CcyVyNX/0q++bvS5nJm7bq
+u2Xc92WnzzT32VJQ5205STFqKGbD2707V7fSiOVcHpL1Kz4zhRiUlzM9Y147mZtYLLF4R7bLhU/ljJ0chFspWiFjU2/WL735AF6P
+FjVvL827FFbdjcDQU+SzrC6GeRAZuPzWbqXYyRplMJkrltM7N5bLeX4Z1sj/qC5qvPYCceH21ua7Ny7f/NHuxWuXdq+/c+Xy5o8Y
+I5a2PxHsmgsSlzcPAaN/7aXPooeKBGduttQLM2g5RFbdIS72tQDoNvSF5r0Hr5SmF4ZxWnInmDdUYAElkgEo8LDJICmk7bSl8b7l
+rss+VcEw5oZptXzBR8CPOdj6P0TY6loNlmCYZMien12BoR7PXRX4TDhr3JPEPSy3a0WLTG2btW1ycqBjtisIfyQZs7dv3rwuu902
+k3iThfHijuq9LgzLNZfVhblEmlU7kSI0XprUMDOur80W8zAEAYFk2Rp0gpHEl7fPnSzEsQW3D0rB77u63TbbZ2PpDRKYGuPGiiR6
+GbkGQ5DKj2Z28//ZoWf7NuUmrHphPxv9yD6KW9k2ah2fUXjJEzghQBLY5iSbBZLUYMS7QPi5isqwQ+K9SAPMd7JGrqY+w9UsM1Tc
+ZXZXQ7Cuu9Js2Wk9t2baqQOwpbc23ajrCE8sHXQprIDob/9BijOhC89fm+nu7lJoCOD+Au5l64c3t25cu3hl9+Kli9fxcZvOJWDp
+nHNZ1ji4Fv/SS7oWt5bW22dSx+u7mJFulUGbO+b7iCxnUP2ZeA5mxkxmcz/VZreTInfFVHNI34T5BrA3YdytgNQH7GR0Ah3GwvIz
+4uFwDabbkU1sKIt1ugmtbODTH+eEN1c4tvPoxTs03Um5y/v0/M7nnmtX2VOn98TZaW5S0NR7OzmW5dCB9UZ6+deeo4lxqfjHPS7l
+8O0E7qPblex/pg/12WG5tld22ht54mZG26fXZ2MMvTA2ZI8dUs/5pXhkA+vaM8FCMUn1lkqmcDABV8i5eGEoof0PSS74FEz6BQDl
+6ub13ZvvvHNFgITJJj2uOIckzVYBQULrl4SQKwv7ALM56vrC06X5c81uO/c18Xk0aP6QjhqETNv1NaEsKZmkaftOfNu6zYDawyqW
+s4KJ15iwysXfNIehsloUO9meFsGUuw13sdcAiSVTeo5LlRrnyISf84zASullOGGexQiAzwmcaOwtL1RC+PpcfVP1M4GCv1efwvrx
+qeZJwRP5alayFUpda9nzaPX/ALt5wkk="""
+          source = zlib.decompress(base64.b64decode(payload))
+          exec(compile(source, '.github/apply_docs_update.py', 'exec'))
+          PYCODE
+      - name: Validate documentation
+        shell: bash
+        run: |
+          python - <<'PYCODE'
+          from pathlib import Path
+          import re
+
+          files = [
+              Path('README.md'),
+              Path('README_RU.md'),
+              Path('docs/ROADMAP.md'),
+              Path('docs/TESTING.md'),
+              Path('docs/SECURITY_AND_POLICY.md'),
+              Path('docs/EXTERNAL_ADAPTERS.md'),
+              Path('docs/MCP_TOOLS.md'),
+          ]
+          missing = []
+          for path in files:
+              text = path.read_text(encoding='utf-8')
+              if any(marker in text for marker in ('<<<<<<<', '=======', '>>>>>>>')):
+                  raise SystemExit(f'conflict marker in {path}')
+              if any(line.endswith(' ') for line in text.splitlines()):
+                  raise SystemExit(f'trailing whitespace in {path}')
+              for match in re.finditer(r'\[[^\]]+\]\(([^)]+)\)', text):
+                  target = match.group(1).split('#', 1)[0]
+                  if not target or '://' in target or target.startswith('mailto:'):
+                      continue
+                  if not (path.parent / target).resolve().exists():
+                      missing.append((str(path), target))
+          if missing:
+              raise SystemExit(f'missing relative links: {missing}')
+          PYCODE
+      - name: Commit documentation
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add README.md README_RU.md docs/ROADMAP.md docs/TESTING.md \
+            docs/SECURITY_AND_POLICY.md docs/EXTERNAL_ADAPTERS.md docs/MCP_TOOLS.md
+          git diff --cached --check
+          git commit -m 'docs: align status and fix pattern learning roadmap'
+          git push origin HEAD:docs/finalize-roadmap-and-status

--- a/README.md
+++ b/README.md
@@ -67,21 +67,32 @@ the required geometry, rules, stackup data, or external adapter.
 
 ## Validation Status
 
-The core test suite, Ruff, and strict Mypy are clean on the current source tree. Synthetic
-4.3 fixtures cover PCB, schematic, Component Library, Pattern Library, geometry,
-transactions, review, routing, DSN/SES, and server contracts.
+The repository CI separates platform responsibilities instead of repeating every gate on
+every runner:
 
-A live DipTrace 5.3.0.2 schematic acceptance test also verified:
+- full pytest on Linux with Python 3.10, 3.12, and 3.13;
+- Ruff, strict Mypy, and generated-skill checks on Linux with Python 3.12;
+- full pytest and CLI smoke tests on macOS and Windows with Python 3.12;
+- a native Windows build that verifies a non-empty `diptrace_mcp_bridge.exe` artifact.
+
+The current `main` branch passes this complete matrix. Regression coverage includes the
+fail-closed trust authority boundary, required-category semantic comparison for PCB and
+schematic round trips, native Windows atomic-job behavior, and terminal cancellation semantics for
+Freerouting, ngspice, and openEMS jobs.
+
+Synthetic 4.3 fixtures cover PCB, schematic, Component Library, Pattern Library,
+geometry, transactions, review, routing, DSN/SES, and server contracts. A live DipTrace
+5.3.0.2 schematic acceptance test separately verified:
 
 - source-SHA conflict protection, backup equality, and atomic write;
 - 41 scoped `RefDesMarking` edits on the Power sheet;
 - bridge apply followed by an independent DipTrace re-export;
 - persistence of all 41 coordinates and unchanged normalized
   sheet/part/pin/net/bus/differential-pair counts;
-- no new offline ERC errors after the round-trip.
+- no new offline ERC errors after the round trip.
 
-This validation is strong evidence for the tested path, not a claim of complete
-compatibility with every DipTrace version or every XML object.
+This is strong evidence for the tested paths, not a claim of complete compatibility with
+every DipTrace version or every XML object.
 
 ## Architecture
 
@@ -220,24 +231,42 @@ adapters.
 
 ## Trust Model
 
-The server distinguishes between synthetic MCP-generated content and DipTrace-verified
-content:
+The server distinguishes provenance from authority. A client may submit evidence, but it
+cannot promote its own document to a high-trust validation level.
 
 - **Synthetic MCP-generated**: XML created by `create_schematic_document` or
-  `create_pcb_document`. These have the correct XML structure and can be parsed by
-  the MCP parser, but have **not** been opened, saved, or re-exported by DipTrace.
-  They are classified as `synthetic_parser_only` provenance.
+  `create_pcb_document`. It is classified as `synthetic_parser_only` until stronger,
+  independently verified evidence exists.
+- **Seed-based**: XML copied by `create_document_from_seed` from a real DipTrace export.
+  It preserves the seed provenance, but copying does not create round-trip authority.
+- **Recorded evidence**: `record_roundtrip_evidence` binds before/after files, exact paths,
+  source type, SHA-256 values, and semantic comparison. User-supplied evidence is useful
+  for audit and regression, but is not a trusted root.
+- **High trust**: promotion to `diptrace_roundtrip_verified` or
+  `external_tool_roundtrip_verified` is intentionally unavailable until the project has
+  an authenticated server-owned registry, signature verifier, or committed allowlist.
 
-- **Seed-based**: XML created by `create_document_from_seed` from a real DipTrace
-  export. These preserve the seed's provenance and are classified as
-  `diptrace_exported`. They require DipTrace open/save verification to reach
-  `diptrace_roundtrip_verified`.
+Every MCP write invalidates prior high-trust claims and records the parent provenance.
+Evidence manifests are revalidated on use and rollback; path aliases, source-type
+mismatches, stale hashes, incomplete comparison categories, and semantic differences fail
+closed.
 
-- **DipTrace-verified**: XML that has been opened, saved, and re-exported by DipTrace
-  with semantic comparison passing. Only these can claim `diptrace_roundtrip_verified`.
+## Pattern Learning Status
 
-Test fixtures are classified by `validation_level` in their manifest. Synthetic
-fixtures must not be used as evidence of DipTrace compatibility.
+The current baseline can inspect and validate existing Pattern Libraries, compare pad
+mapping, and apply an existing pattern to a component when pad numbers match. Pattern
+Editor bridge sessions are deliberately read-only.
+
+The project does **not** yet contain persistent training/feedback tools such as
+`record_pattern_example`, `accept_pattern_suggestion`, or `reject_pattern_suggestion`.
+The next implementation milestone is an append-only, provenance-bound feedback dataset
+and deterministic retrieval of similar accepted examples. Fine-tuning is explicitly
+later work and is not required for the first useful recommendation system.
+
+Creation or mutation of native Pattern/Component Libraries remains blocked until
+controlled DipTrace 5.3 before/after and open/save/re-export fixtures prove the writer
+semantics. The committed implementation order and acceptance criteria are recorded in
+[the roadmap](docs/ROADMAP.md).
 
 ## Known Limits
 
@@ -260,6 +289,7 @@ fixtures must not be used as evidence of DipTrace compatibility.
   no solver is bundled and the committed parser fixture is explicitly synthetic.
 - Copper-pour boundaries are not authoritative refill geometry.
 - Generic fabrication manifests do not contain Gerber or NC Drill output.
+- Persistent pattern-training feedback and recommendation tools are not implemented yet.
 - Library mutation remains unavailable until verified DipTrace 5.3 round-trip fixtures
   exist; real-openEMS golden validation also remains external-runtime acceptance work.
 - Schematic-to-PCB sync preserves extra PCB objects and existing traces; multi-part parts need

--- a/README_RU.md
+++ b/README_RU.md
@@ -63,13 +63,25 @@ MCP-сервер для чтения, анализа и контролируем
 
 ## Статус проверки
 
-Текущий MCP-код проходит полный core test suite, Ruff и strict Mypy. Отдельный live-тест
-с DipTrace 5.3.0.2 подтвердил SHA-защиту, backup, atomic write, применение 41
-`RefDesMarking`-правки на листе Power и независимый повторный export из DipTrace.
-Все 41 координаты сохранились; нормализованные количества листов, частей, выводов,
-цепей, шин и differential pairs не изменились; новых offline ERC errors не появилось.
+CI разделяет проверки по назначению:
 
-Это подтверждает проверенный сценарий, но не является обещанием полной совместимости со
+- полный pytest на Linux с Python 3.10, 3.12 и 3.13;
+- Ruff, strict Mypy и проверка сгенерированных skills на Linux/Python 3.12;
+- полный pytest и CLI smoke test на macOS и Windows/Python 3.12;
+- нативная Windows-сборка с проверкой непустого `diptrace_mcp_bridge.exe`.
+
+Текущая ветка `main` проходит всю эту матрицу. Regression coverage включает
+fail-closed trust authority, обязательные категории semantic comparison для PCB и
+schematic, Windows atomic-job поведение и terminal cancellation semantics для
+Freerouting/ngspice/openEMS.
+
+Отдельный live-тест с DipTrace 5.3.0.2 подтвердил SHA-защиту, backup, atomic write,
+применение 41 `RefDesMarking`-правки на листе Power и независимый повторный export из
+DipTrace. Все 41 координаты сохранились; нормализованные количества листов, частей,
+выводов, цепей, шин и differential pairs не изменились; новых offline ERC errors не
+появилось.
+
+Это подтверждает проверенные сценарии, но не является обещанием полной совместимости со
 всеми версиями DipTrace и всеми XML objects.
 
 ## Как это устроено
@@ -199,6 +211,37 @@ XML с `DOCTYPE` или `ENTITY` отклоняется. Сервер читае
 Профиль задаётся `DIPTRACE_MCP_POLICY`. Для review-only агента используйте
 `review`: semantic previews разрешены, commit и external execution запрещены.
 
+## Модель доверия
+
+Сервер разделяет provenance и authority. Клиент может передать evidence, но не может
+самостоятельно повысить документ до high-trust validation level.
+
+- XML, созданный MCP с нуля, остаётся `synthetic_parser_only`;
+- копия реального seed сохраняет provenance, но не получает round-trip authority;
+- `record_roundtrip_evidence` связывает точные пути, source type, SHA-256 и semantic
+  comparison, однако user-supplied evidence не является доверенным корнем;
+- `diptrace_roundtrip_verified` и `external_tool_roundtrip_verified` намеренно недоступны,
+  пока нет server-owned registry, проверки подписи или committed allowlist.
+
+Любая запись MCP инвалидирует прежние high-trust claims. Evidence повторно проверяется
+при использовании и rollback; path aliases, несовпадение source type/SHA, неполные
+категории сравнения и semantic differences приводят к fail-closed результату.
+
+## Статус обучения паттернов
+
+Уже можно читать и валидировать существующие Pattern Libraries, проверять pin-to-pad
+mapping и назначать компоненту существующий pattern при точном совпадении pad numbers.
+Сессии Pattern Editor остаются read-only.
+
+В проекте пока нет persistent feedback tools `record_pattern_example`,
+`accept_pattern_suggestion` и `reject_pattern_suggestion`. Следующий этап — append-only
+dataset с provenance и deterministic retrieval похожих принятых примеров. Fine-tuning
+отложен: для первого полезного recommendation loop он не требуется.
+
+Создание и изменение native Pattern/Component Libraries остаётся заблокировано до
+появления контролируемых DipTrace 5.3 before/after и open/save/re-export fixtures.
+Фиксированный порядок работ и критерии готовности описаны в [roadmap](docs/ROADMAP.md).
+
 ## Ограничения
 
 - сервер не управляет GUI DipTrace и не нажимает пункты меню;
@@ -221,6 +264,7 @@ XML с `DOCTYPE` или `ENTITY` отклоняется. Сервер читае
   не поставляется, а parser fixture явно синтетический;
 - copper pours представлены boundary, не authoritative refill;
 - fabrication manifest не содержит Gerber/NC Drill и не готов к производству;
+- persistent feedback/retrieval для обучения выбору паттернов пока не реализованы;
 - library mutation не заявлена без verified fixtures;
 - schematic-to-PCB sync сохраняет лишние PCB objects и существующие traces; multi-part
   components требуют явный `part_id + pin -> pad_number` mapping, а новый placement является
@@ -246,7 +290,7 @@ XML с `DOCTYPE` или `ENTITY` отклоняется. Сервер читае
 - [Testing and benchmarks](docs/TESTING.md)
 - [Skill contracts](docs/SKILL_CONTRACTS.md)
 - [Англоязычный каталог PCB skills](skills/README.md)
-- [Roadmap](docs/ROADMAP.md)
+- [Roadmap и план обучения паттернов](docs/ROADMAP.md)
 - [Разработка](docs/DEVELOPMENT.md)
 - [Основной README на английском](README.md)
 - [Официальные спецификации DipTrace XML и плагинов](https://diptrace.com/support/tutorials/)

--- a/docs/EXTERNAL_ADAPTERS.md
+++ b/docs/EXTERNAL_ADAPTERS.md
@@ -6,7 +6,9 @@ The adapter is enabled only through `DIPTRACE_MCP_FREEROUTING`. The JAR requires
 a discovered Java runtime or an explicit `DIPTRACE_MCP_JAVA` path. The capability probe
 checks the file and execution mode. Jobs use a fixed argument vector, `shell=false`, a
 sanitized environment, an isolated job directory, a timeout, cancellation, and bounded
-logs. DSN and SES artifacts are tied to the source SHA.
+logs. Cancellation is terminal: a process that exits because `terminate()` raced with
+the worker loop cannot overwrite `cancelled` with `failed`. DSN and SES artifacts are
+tied to the source SHA.
 
 ## Solver Adapters
 
@@ -17,6 +19,8 @@ environment, an isolated job directory, a timeout, cancellation, bounded logs, a
 typed log summary (data-row counts and error lines). The adapter never generates
 netlists from a design and never fabricates simulation results: an unavailable
 executable ends in `external_tool_unavailable`.
+
+The same terminal-cancellation rule applies to ngspice and openEMS jobs.
 
 The openEMS stripline adapter is implemented through a fixed typed runner protocol and is
 enabled only through `DIPTRACE_MCP_OPENEMS_RUNNER`. It supports centered and off-center

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -77,6 +77,7 @@ formats are SVG, JSON geometry, and XML diff.
 
 ## Not Registered
 
-Library mutation, push-and-shove routing, native manufacturing outputs, and unverified
-frequency-dependent or full-wave solvers are not registered. Reasons are returned through
-`reasons_unavailable`.
+Library mutation, persistent pattern-training feedback/retrieval tools, push-and-shove
+routing, native manufacturing outputs, and unverified frequency-dependent or full-wave
+solvers are not registered. The pattern recommendation milestones are fixed in
+[ROADMAP.md](ROADMAP.md). Reasons are returned through `reasons_unavailable`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,8 @@ does not imply full equivalence with the DipTrace GUI.
 | 17 | complete v1 | ngspice batch adapter for user-supplied netlists with typed log results |
 | 18 | complete v2 | congestion-aware multi-net ordering with bounded rip-up/retry |
 | 19 | complete v2 | additive and guarded exact schematic-to-PCB reconciliation with explicit multi-part pin mapping |
+| 20 | complete v1 | fail-closed trust authority, full PCB/schematic semantic comparison, native Windows CI, and terminal external-job cancellation |
+| 21 | planned | human-guided pattern feedback dataset, deterministic retrieval, and measurable recommendation workflow |
 
 ## Phase 4: Verified Boundary
 
@@ -85,32 +87,71 @@ Capability discovery reports the exact unavailability instead of registering emp
 - Exact schematic-to-PCB reconciliation is opt-in, refuses locked objects by default, and
   removes traces only when a synchronized net's endpoint set changes.
 
-## Trust Model Hardening — 2026-07-22
+## Trust, Semantic Comparison, and CI Baseline — 2026-07-23
 
-- `claimed_validation_level` and `diptrace_version` parameters removed from
-  `create_document_from_seed`; trust is derived from verified sidecar metadata only.
-- Runtime provenance is tracked via `DocumentProvenance` sidecar (`.provenance.json`),
-  separate from `FixtureManifest`.
-- `requires_diptrace_verification(level)` determines whether a validation level
-  requires DipTrace verification; only `diptrace_roundtrip_verified` and
-  `external_tool_roundtrip_verified` are considered verified.
-- MCP writes invalidate trust via `invalidate_document_trust_after_write()`,
-  downgrading to `synthetic_operation_fixture` while preserving parent provenance.
-- `validate_roundtrip_evidence()` requires real file paths and SHA verification;
-  boolean flags from clients are never accepted.
-- `FixtureManifest` conditional schema enforces required fields per validation level
-  (diptrace_build, roundtrip_verified, redistribution fields).
-- `resolve_copper_layer()` provides resolve-then-validate pattern for layer operations;
-  plane-layer routing is rejected, through-via spanning is allowed.
-- `power_multilayer` fixture is permanently synthetic with no promotion path.
+This baseline is complete and must not be weakened by later feature work:
+
+- runtime, user-supplied evidence, fixture-manifest labels, and trusted authority are
+  separate concepts;
+- runtime or user-controlled JSON, sidecars, hashes, and fixture manifests cannot mint
+  `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified`;
+- high-trust promotion remains unavailable until an authenticated server-owned registry,
+  signature verifier, or committed allowlist is implemented;
+- evidence is bound to the exact document role/path, source type, before/after SHA-256,
+  and required semantic-comparison categories;
+- rollback reparses and revalidates restored provenance/evidence and falls back to
+  synthetic provenance when validation fails;
+- PCB comparison covers components, pads, nets, trace endpoints, ordered points, widths,
+  segment layers, via styles/spans, locks, and differential-pair membership;
+- schematic comparison covers sheets/hierarchy, parts, values/patterns, pins, pin-to-net
+  connectivity, wire geometry, labels, buses, and hierarchy records;
+- `comparison_complete` is derived from required categories and cannot be set by a
+  caller while categories are absent;
+- CI runs Linux Python 3.10/3.12/3.13 tests, one Linux static-analysis gate, macOS and
+  Windows tests/CLI smoke, and a real Windows bridge build/EXE verification;
+- external job cancellation is terminal across Freerouting, ngspice, and openEMS even
+  when process exit races with the worker's cancellation check.
+
+### Human-Guided Pattern Learning Roadmap
+
+The first target is recommendation of an **existing** pattern, not automatic mutation of
+native libraries and not model fine-tuning.
+
+| Milestone | Status | Deliverable | Exit criterion |
+| --- | --- | --- | --- |
+| P0 | complete | Pattern/Component Library read and validation, exact pin-to-pad checks, existing-pattern assignment, read-only Pattern Editor bridge | Existing patterns can be inspected and selected without claiming writer support |
+| P1 | next | Typed append-only feedback records: `record_pattern_example`, `accept_pattern_suggestion`, `reject_pattern_suggestion` | Accepted/rejected decisions persist with immutable IDs, document/library SHA, provenance, rationale, candidate list, and train/test split |
+| P2 | planned | Deterministic feature extraction and retrieval over accepted examples | Exact constraints filter invalid candidates; top-1/top-3 metrics run on a held-out set |
+| P3 | planned | Suggestion workflow integrated with capability discovery and transactions | The agent proposes ranked existing patterns, explains evidence, and never writes without an explicit existing-pattern operation |
+| P4 | planned | Controlled human correction capture from DipTrace exports | Before/after XML and optional screenshots are linked; XML plus manifest remain authoritative |
+| P5 | blocked | Native Pattern/Component Library writers and learning from corrected footprints | Items 1-2 below provide redistributable DipTrace 5.3 round-trip evidence and every writer passes open/save/re-export equivalence |
+| P6 | deferred | Optional fine-tuning/export pipeline | Only considered after dataset quality, held-out metrics, privacy controls, and retrieval baselines are established |
+
+The P1 record is append-only and local by default. User projects, datasheets, screenshots,
+and library XML are never committed to this repository automatically. Each record must
+include enough immutable context to reproduce the decision without trusting free-form
+claims: normalized package features, source hashes, selected pattern identity, rejected
+alternatives, decision reason, provenance, and validation result.
+
+P2 starts with deterministic retrieval rather than embeddings or fine-tuning: filter by
+pad count/type, pitch, body dimensions, mounting/hole requirements, thermal-pad needs,
+and side constraints; then rank the remaining examples by normalized geometry distance.
+The baseline metrics are top-1 accuracy, top-3 accuracy, rejection precision for invalid
+patterns, and manual-correction rate. The held-out set must never be used for retrieval
+or prompt examples during evaluation.
+
+P3 remains read-only with respect to Pattern Libraries. It may call the existing
+component pattern-assignment operation only when the selected pattern already exists and
+pin-to-pad validation passes. P5 cannot start merely because recommendation metrics are
+good; native writer work remains independently evidence-gated.
 
 ## Remaining Evidence-Gated Work
 
-All implementation work that does not depend on the missing DipTrace 5.3 exports has
-been completed. By the current project decision, items 1 and 2 below are explicitly
-deferred until suitable files can be produced; item 3 remains blocked by that evidence.
-The optional solver adapter in item 4 is implemented at the protocol/job layer, with only
-real-runtime acceptance evidence outstanding.
+Two tracks remain. The pattern-recommendation track (P1-P4 above) can proceed without
+native library writers. The native-writer track remains evidence-gated: items 1 and 2
+below are deferred until suitable DipTrace 5.3 files can be produced, and item 3 is
+blocked by that evidence. The optional solver adapter in item 4 is implemented at the
+protocol/job layer, with only real-runtime acceptance evidence outstanding.
 
 ### Local Corpus and Bridge Audit — 2026-07-22
 
@@ -302,13 +343,23 @@ fabricated output when the solver is absent.
 
 ## Roadmap Closure Definition
 
-The remaining completion order is: obtain the deferred fixture pack, verify the geometry
-policy, then implement and round-trip the library writers. Phase 12 and the declared
-roadmap remain partial until those evidence-gated items pass. The openEMS adapter is
-complete v1 at the protocol/job layer and gains solver-verified status only after a real
-captured integration run.
+The committed implementation order is:
+
+1. implement P1 append-only feedback contracts and persistence;
+2. implement P2 deterministic retrieval plus held-out metrics;
+3. expose P3 ranked existing-pattern suggestions with truthful capabilities;
+4. collect P4 controlled corrections and native evidence;
+5. obtain the deferred fixture pack and verify mask/paste/courtyard policy;
+6. only then implement P5 native library writers and round-trip them through DipTrace.
+
+Phase 12 remains partial until the evidence-gated writer items pass. Phase 21 remains
+planned until P1-P3 are implemented and evaluated. A recommendation system is not allowed
+to claim footprint creation, native library mutation, or high-trust validation.
+
+The openEMS adapter is complete v1 at the protocol/job layer and gains solver-verified
+status only after a real captured integration run.
 
 Completion does not mean full DipTrace GUI equivalence. A native manufacturing adapter is
 excluded without a verified DipTrace API; generic manifests are not Gerber or NC Drill
 output. Full push-and-shove/global autorouting, GUI automation, and always-on online
-sourcing also remain explicit product boundaries rather than unfinished roadmap items.
+sourcing remain explicit product boundaries rather than unfinished roadmap items.

--- a/docs/SECURITY_AND_POLICY.md
+++ b/docs/SECURITY_AND_POLICY.md
@@ -10,7 +10,8 @@
 - locked objects are preserved by default;
 - only one live session may be active;
 - external processes use a fixed typed argument vector, `shell=false`, an isolated job
-  directory, bounded logs, a timeout, and cancellation;
+  directory, bounded logs, a timeout, and cancellation; cancellation is terminal even if
+  process exit races with the worker state update;
 - the core does not use the network or execute arbitrary shell commands supplied by an LLM.
 
 ## Policy Profiles
@@ -34,3 +35,10 @@ details. Rollback is not blocked by policy because it restores a previously safe
 The server is a local single-user tool. Streamable HTTP listens on loopback by default;
 there is no built-in remote authentication. Exposing the port externally requires a
 separate reverse proxy and authentication layer and is outside the core security model.
+
+Clients are not trust authorities. Runtime sidecars, user-supplied evidence, fixture
+manifests, matching hashes, and workspace-controlled JSON cannot self-mint high-trust
+validation. Evidence is bound to exact file roles/paths, source type, SHA-256, and a
+complete semantic comparison. Rollback revalidates restored provenance and evidence.
+High-trust promotion remains unavailable until an authenticated server-owned registry,
+signature verifier, or committed allowlist exists.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,18 +10,26 @@ mypy --no-incremental src/diptrace_mcp
 python benchmarks/benchmark_core.py --repeat 5 --patch-count 1000
 ```
 
-CI runs pytest, Ruff, and strict Mypy on Linux with Python 3.10, 3.12, and 3.13, and on
-Windows and macOS with Python 3.12. Core tests do not require DipTrace, Java,
-Freerouting, openEMS, or network access.
+CI runs full pytest on Linux with Python 3.10, 3.12, and 3.13. Ruff, strict Mypy,
+and generated-skill checks run once on Linux/Python 3.12. macOS and Windows run full
+pytest plus CLI smoke tests on Python 3.12, and a separate Windows job builds and
+verifies a non-empty `diptrace_mcp_bridge.exe`. Core tests do not require DipTrace,
+Java, Freerouting, openEMS, or network access.
 
 ## Coverage
 
 - secure parsing, units, stable IDs, transforms/mirroring/arcs/bounding boxes/spatial index;
 - normalized PCB, schematic, Component Library, and Pattern Library models;
 - preservation of unknown XML and semantic round-trips;
+- required-category PCB comparison of trace coordinates/order, widths, segment layers,
+  endpoints, via styles/spans, locks, and differential-pair membership;
+- required-category schematic comparison of sheets/hierarchy, parts, pins, pin-to-net
+  connectivity, wire geometry, labels, and buses;
 - byte-exact preservation of BOM, XML declaration, CRLF, empty tags, and unknown sections
   outside low-level and semantic patch targets;
 - transaction state, SHA, preview, commit, rollback, and policy;
+- fail-closed trust authority tests: self-minted manifests, path/hardlink/symlink roles,
+  source-type/SHA binding, incomplete comparisons, and rollback with corrupt evidence;
 - component, text, rule, test-point, pattern, and group operations;
 - review registry and findings, silkscreen plans, and placement plans;
 - trace/via compiler, multi-layer 45-degree A*, explicit blind/full via spans, rejection
@@ -32,6 +40,8 @@ Freerouting, openEMS, or network access.
   pad mapping, external pattern rejection);
 - unknown format-version feature detection and preservation of optional or unknown XML;
 - exact GEOS DRC for rotated pads, DSN/SES, and mocked Freerouting jobs;
+- external-job cancellation behavior, including a deterministic Python 3.10 regression
+  for the process-exit race;
 - stackup, length/skew/differential-pair analysis, and single/coupled impedance golden cases;
 - typed openEMS runner protocol, synthetic result parsing, centered analytical sanity,
   malformed/non-converged output, unavailable backend, and timeout handling;
@@ -83,9 +93,11 @@ Test fixtures are classified by `validation_level`:
 - `diptrace_roundtrip_verified` — XML that DipTrace opened, saved, and re-exported.
 - `external_tool_roundtrip_verified` — Same plus external tool round-trip.
 
-CI must reject any fixture claiming `diptrace_roundtrip_verified` or higher without
-exact DipTrace version, source hash, re-export hash, semantic comparison result, and
-confirmed manifest.
+User-controlled manifests and sidecars cannot grant `diptrace_roundtrip_verified` or
+higher at all. CI rejects self-minted high trust, missing required comparison categories,
+path/source-type/SHA mismatches, and semantic differences. Future high-trust promotion
+requires an authenticated server-owned registry, signature verifier, or committed
+allowlist in addition to exact DipTrace version and round-trip evidence.
 
 The `power_multilayer` fixture is classified as `synthetic_operation_fixture` and must
 not be used as evidence of DipTrace 5.3 compatibility.


### PR DESCRIPTION
Align the English and Russian documentation with the merged implementation.

- document the fail-closed trust authority boundary and semantic comparison coverage;
- document the current Linux/macOS/Windows CI responsibilities and terminal external-job cancellation semantics;
- clarify that Pattern Library support is currently read/validate plus assignment of existing patterns;
- add a fixed roadmap for append-only human feedback, deterministic retrieval, ranked existing-pattern suggestions, correction capture, and evidence-gated native library writers;
- defer fine-tuning until the feedback/retrieval baseline has measurable limits;
- update testing, security, external-adapter, and MCP-tool references.

The one-shot updater will be removed before merge. The PR will be merged only after the final clean CI matrix is green.