### PR TITLE
docs: refresh roadmap and documentation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,118 +2,89 @@
 
 **English** | [Русский](README_RU.md)
 
-DipTrace MCP is a local Model Context Protocol server for reading, analyzing, reviewing,
-and safely editing DipTrace designs through the official XML formats. The repository
-contains two cooperating components:
+DipTrace MCP is a local Model Context Protocol server for reading, analyzing, reviewing, and safely editing DipTrace designs through the official XML formats. The repository contains two cooperating components:
 
 - `diptrace-mcp`, the MCP server used by Codex, Claude Desktop, and other MCP clients;
-- `diptrace_mcp_bridge.exe`, the executable plug-in that connects the server to a
-  design currently open in PCB Layout or Schematic Capture.
+- `diptrace_mcp_bridge.exe`, the executable plug-in that connects the server to a design currently open in PCB Layout or Schematic Capture.
+
+## Current Readiness
+
+The project is already usable as a human-in-the-loop engineering tool for PCB/schematic reading and review, guarded semantic edits, schematic authoring, schematic-to-PCB synchronization, bounded placement/routing, differential-pair analysis, and release-review workflows.
+
+It is not yet a full replacement for DipTrace's interactive EDA engine. The main remaining gap is no longer MCP tool count; it is broad, automated, redistributable evidence that all important write paths survive real DipTrace 5.3 open/save/re-export cycles with the intended semantics.
+
+Native Component/Pattern Library mutation and native manufacturing output generation are therefore intentionally not presented as completed capabilities.
+
+See [the roadmap](docs/ROADMAP.md) for the current priority order and exit criteria. Runtime truth for a specific document always comes from `get_capabilities`.
 
 ## Current Capabilities
 
-- runtime capability discovery through `get_capabilities`, including precise
-  unavailability reasons;
-- project scaffolding: brand-new schematic and PCB XML documents with sheets, outline,
-  layers, stackup, via styles, net classes, and DRC (`create_schematic_document`,
-  `create_pcb_document`); **note: these produce synthetic MCP-generated XML, not
-  DipTrace-verified files**;
-- seed-based project creation: copy a real DipTrace-exported XML seed to start a new
-  project with preserved provenance (`create_document_from_seed`);
-- schematic authoring: sheets, part placement by library `ComponentStyle`, pin/net
-  connectivity, official `Wire`/`Points` wires, and net labels (`add_sheet`, `place_part`,
-  `connect_pins`, `disconnect_pins`, `add_wire`, `delete_wire`, `add_net_label`);
-- schematic-to-PCB synchronization of RefDes/value/fields, footprint references,
-  pin-to-pad connectivity, nets, and ratlines, with additive-by-default and guarded exact
-  reconciliation modes plus verified pattern-library subtree copying;
-- official DipTrace panelization parameters (`Panel`, V-Scoring / Tab Routing) through
-  `set_panelization` and `clear_panelization`;
+- runtime capability discovery through `get_capabilities`, including precise unavailability reasons;
+- project scaffolding: brand-new schematic and PCB XML documents with sheets, outline, layers, stackup, via styles, net classes, and DRC (`create_schematic_document`, `create_pcb_document`); **these produce synthetic MCP-generated XML, not DipTrace-verified files**;
+- seed-based project creation from a real DipTrace-exported XML seed with preserved provenance (`create_document_from_seed`);
+- schematic authoring: sheets, part placement by library `ComponentStyle`, pin/net connectivity, official `Wire`/`Points` wires, and net labels (`add_sheet`, `place_part`, `connect_pins`, `disconnect_pins`, `add_wire`, `delete_wire`, `add_net_label`);
+- schematic-to-PCB synchronization of RefDes/value/fields, footprint references, pin-to-pad connectivity, nets, and ratlines, with additive-by-default and guarded `exact` reconciliation modes;
+- verified pattern-library subtree copying for synchronization workflows;
+- official DipTrace panelization parameters (`Panel`, V-Scoring / Tab Routing) through `set_panelization` and `clear_panelization`;
 - normalized PCB, schematic, Component Library, and Pattern Library domain models;
-- stable object references, structured selectors, connectivity graphs, and spatial
-  queries;
-- millimeter-normalized geometry, transforms, mirroring, arcs, exact optional GEOS
-  geometry, and SVG/JSON previews;
-- raw-preserving XML patches that retain unknown XML, BOM, line endings, and formatting
-  outside targeted nodes;
-- semantic transactions with plan, preview, validation, expected SHA-256, commit,
-  backup, and rollback;
-- component/part move, rotate, side, lock, property, pattern, alignment, distribution,
-  and grouping operations;
-- board-text edits, documented net-class rules, and standalone-pad test points;
+- stable object references, structured selectors, connectivity graphs, and spatial queries;
+- millimeter-normalized geometry, transforms, mirroring, arcs, optional exact GEOS geometry, and SVG/JSON previews;
+- raw-preserving XML patches that retain unknown XML, BOM, line endings, and formatting outside targeted nodes;
+- semantic transactions with plan, preview, validation, expected SHA-256, commit, backup, and rollback;
+- component/part move, rotate, side, lock, property, pattern, alignment, distribution, and grouping operations;
+- board-text edits, documented NetClass rules, and standalone-pad test points;
 - Component/Pattern Library reading, validation, and pin-to-pad checks;
-- machine-readable serializer reference for exact XML enums, defaults, aliases, and import
-  semantics derived from the supplied documentation archives; it is explicitly reference-only
-  and cannot grant DipTrace round-trip trust;
+- a machine-readable serializer reference for exact XML enums, defaults, aliases, and import semantics derived from supplied documentation archives; it is reference-only and cannot grant DipTrace round-trip trust;
 - registry-based offline DRC/ERC reviews with persistent structured findings;
 - deterministic silkscreen and bounded local placement planners;
-- explicit trace/via operations, bounded multi-layer 45-degree A*, and symmetric via
-  insertion;
-- congestion-ordered multi-net routing with bounded rip-up/retry (`route_connections`)
-  and read-only priority evidence (`analyze_routing_congestion`);
+- explicit trace/via operations, bounded multi-layer 45-degree A*, and symmetric via insertion;
+- congestion-ordered multi-net routing with bounded rip-up/retry (`route_connections`) and read-only priority evidence (`analyze_routing_congestion`);
 - atomic coupled differential-pair routing from a centerline;
 - bounded DSN export, Freerouting jobs, and guarded SES inspection/import;
-- stackup, net length/skew, differential-pair geometry, return-path heuristics, and
-  preliminary analytical impedance: Hammerstad-Jensen microstrip (single and
-  differential) plus IPC-2141 centered symmetric stripline;
+- stackup, net length/skew, differential-pair geometry, return-path heuristics, and preliminary analytical impedance: Hammerstad-Jensen microstrip (single and differential) plus IPC-2141 centered symmetric stripline;
 - ngspice batch adapter for user-supplied netlists with typed log results;
-- typed optional openEMS-runner adapter for frequency-dependent centered/off-center
-  stripline results, with bounded jobs and strict result parsing;
+- typed optional openEMS-runner adapter for frequency-dependent centered/off-center stripline results, with bounded jobs and strict result parsing;
 - BOM, DFM/DFA/DFT, thermal-metadata, assembly, and design-comparison reviews;
 - generic BOM, fabrication-review, and assembly-review manifests;
-- policy profiles: `read_only`, `review`, `interactive_edit`, `automation`, and
-  `manufacturing`;
+- policy profiles: `read_only`, `review`, `interactive_edit`, `automation`, and `manufacturing`;
 - live and offline operation over MCP stdio or Streamable HTTP.
 
-`get_capabilities` is the authoritative source for a particular installation and
-document. A registered tool may still be unavailable when the active source type lacks
-the required geometry, rules, stackup data, or external adapter.
+`get_capabilities` is authoritative for a particular installation and document. A registered tool may still be unavailable when the active source type lacks required geometry, rules, stackup data, or an external adapter.
 
 ## Validation Status
 
-The repository CI separates platform responsibilities instead of repeating every gate on
-every runner:
+The repository CI separates platform responsibilities:
 
 - full pytest on Linux with Python 3.10, 3.12, and 3.13;
-- Ruff, strict Mypy, and generated-skill checks on Linux with Python 3.12;
-- full pytest and CLI smoke tests on macOS and Windows with Python 3.12;
+- Ruff, strict Mypy, and generated-skill checks on Linux/Python 3.12;
+- full pytest and CLI smoke tests on macOS and Windows/Python 3.12;
 - a native Windows build that verifies a non-empty `diptrace_mcp_bridge.exe` artifact.
 
-The current `main` branch passes this complete matrix. Regression coverage includes the
-fail-closed trust authority boundary, required-category semantic comparison for PCB and
-schematic round trips, native Windows atomic-job behavior, and terminal cancellation semantics for
-Freerouting, ngspice, and openEMS jobs.
+The current `main` branch passes this matrix. Regression coverage includes the fail-closed trust authority boundary, required semantic-comparison categories for PCB/schematic, native Windows atomic-job behavior, and terminal cancellation semantics for Freerouting, ngspice, and openEMS jobs.
 
-Synthetic 4.3 fixtures cover PCB, schematic, Component Library, Pattern Library,
-geometry, transactions, review, routing, DSN/SES, and server contracts. A live DipTrace
-5.3.0.2 schematic acceptance test separately verified:
+Synthetic 4.3 fixtures cover PCB, schematic, Component Library, Pattern Library, geometry, transactions, review, routing, DSN/SES, and server contracts. A separate live DipTrace 5.3.0.2 schematic acceptance test verified:
 
 - source-SHA conflict protection, backup equality, and atomic write;
 - 41 scoped `RefDesMarking` edits on the Power sheet;
 - bridge apply followed by an independent DipTrace re-export;
-- persistence of all 41 coordinates and unchanged normalized
-  sheet/part/pin/net/bus/differential-pair counts;
+- persistence of all 41 coordinates and unchanged normalized sheet/part/pin/net/bus/differential-pair counts;
 - no new offline ERC errors after the round trip.
 
-This is strong evidence for the tested paths, not a claim of complete compatibility with
-every DipTrace version or every XML object. The bundled serializer reference further constrains
-parser behavior, but does not replace real DipTrace open/save/re-export evidence.
+This is strong evidence for the tested paths, not a claim of complete compatibility with every DipTrace version or XML object. The bundled serializer reference constrains parser behavior but does not replace real DipTrace open/save/re-export evidence.
 
 ## Architecture
 
 ```text
 MCP client                    diptrace-mcp
 (Codex/Claude)  <-------->    analysis and guarded XML edits
-                                     |
-                                     | shared state directory
-                                     v
+                                      |
+                                      | shared state directory
+                                      v
 DipTrace       <-------->    diptrace_mcp_bridge.exe
                temporary plugin_exchange.xml
 ```
 
-DipTrace starts the plug-in as a separate executable and passes a temporary XML path.
-The bridge stores a working copy under `%LOCALAPPDATA%\DipTraceMCP`, waits for an MCP
-`apply` or `cancel` request, verifies the expected SHA-256, and exits only after the
-session is finalized. DipTrace then imports the exchange XML on `apply`.
+DipTrace starts the plug-in as a separate executable and passes a temporary XML path. The bridge stores a working copy under `%LOCALAPPDATA%\DipTraceMCP`, waits for an MCP `apply` or `cancel` request, verifies the expected SHA-256, and exits only after the session is finalized. DipTrace then imports the exchange XML on `apply`.
 
 ## Requirements
 
@@ -121,8 +92,7 @@ session is finalized. DipTrace then imports the exchange XML on `apply`.
 - Windows 10/11 for live integration with desktop DipTrace;
 - a DipTrace build that supports executable XML plug-ins;
 - an MCP client such as Codex or Claude Desktop;
-- PowerShell and administrator access only when installing the plug-in under
-  `C:\Program Files\DipTrace`.
+- PowerShell and administrator access only when installing the plug-in under `C:\Program Files\DipTrace` or `DipTrace5`.
 
 Offline XML analysis also works on Linux, macOS, and WSL.
 
@@ -137,8 +107,7 @@ py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -e .
 ```
 
-Install the optional GEOS geometry backend when exact polygon, ellipse, obround, swept
-trace, and spatial DRC operations are needed:
+Install the optional GEOS geometry backend when exact polygon, ellipse, obround, swept-trace geometry, and spatial DRC are needed:
 
 ```powershell
 .\.venv\Scripts\python.exe -m pip install -e ".[geometry]"
@@ -158,24 +127,19 @@ Build the unsigned executable locally from this repository:
 powershell -ExecutionPolicy Bypass -File .\plugin\build_bridge.ps1
 ```
 
-Close all DipTrace modules, open PowerShell as Administrator, and install the bridge in
-PCB Layout, Schematic Capture, Component Editor, and Pattern Editor:
+Close all DipTrace modules, open PowerShell as Administrator, and install the bridge in PCB Layout, Schematic Capture, Component Editor, and Pattern Editor:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\plugin\install_plugin.ps1
 ```
 
-The installer checks `C:\Program Files\DipTrace5` first and then the legacy
-`C:\Program Files\DipTrace` directory. Override it when necessary:
+The installer checks `C:\Program Files\DipTrace5` first and then the legacy `C:\Program Files\DipTrace` directory. Override it when necessary:
 
 ```powershell
 .\plugin\install_plugin.ps1 -DipTraceDir "D:\Apps\DipTrace" -Mode All
 ```
 
-`-Mode Both` installs only PCB and Schematic support. `-Mode Libraries` installs the
-Component and Pattern Editor bridges. Library sessions export the complete active
-library for inspection, but use `ImpMode=None`; finish them with `cancel` because native
-library mutation remains evidence-gated.
+`-Mode Both` installs only PCB/Schematic support. `-Mode Libraries` installs only Component/Pattern Editor bridges. Library sessions export the complete active library for inspection but use `ImpMode=None`; finish them with `cancel` because native library mutation remains evidence-gated.
 
 ### 3. Connect Codex
 
@@ -187,21 +151,18 @@ codex mcp add diptrace `
 codex mcp list
 ```
 
-Alternatively, merge [`examples/codex-config.toml`](examples/codex-config.toml) into
-`~/.codex/config.toml` and replace the example paths.
+Alternatively, merge [`examples/codex-config.toml`](examples/codex-config.toml) into `~/.codex/config.toml` and replace the example paths.
 
 ### 4. Start a live session
 
 1. Open and save a design or library in DipTrace.
 2. Select `Tools > Plugins > DipTrace MCP Bridge`.
 3. Leave the bridge window open while the MCP client performs reads, plans, and edits.
-4. Ask the client to inspect the document before requesting any write.
-5. Require a dry-run/transaction preview and review the changed object IDs.
-6. Commit with the preview SHA, run post-write checks, then call
-   `finish_live_session(action="apply")` or cancel the session.
+4. Ask the client to inspect the document before requesting a write.
+5. Require a dry-run/transaction preview and inspect changed object IDs.
+6. Commit with the preview SHA, run post-write checks, then call `finish_live_session(action="apply")` or cancel the session.
 
-The bridge buttons provide the same explicit apply/cancel controls. Component and
-Pattern Editor bridge profiles are read-only and must be cancelled after inspection.
+The bridge buttons provide the same explicit apply/cancel controls. Component and Pattern Editor bridge profiles are read-only and should be cancelled after inspection.
 
 ## Offline Mode
 
@@ -209,9 +170,7 @@ Pass a path inside `DIPTRACE_MCP_WORKSPACE` or `DIPTRACE_MCP_ALLOWED_ROOTS`:
 
 > Run `summarize_design` for `boards/controller.xml`, then list the power nets.
 
-Legacy binary `.dip` and `.dch` files must first be exported with
-`File > Export > DipTrace XML`. A native XML `.dip` or `.dch` can be read directly
-only when the file actually begins with an official DipTrace XML root.
+Legacy binary `.dip`/`.dch` files must first be exported with `File > Export > DipTrace XML`. A native XML `.dip`/`.dch` can be read directly only when the file actually begins with an official DipTrace XML root.
 
 ## Write Safety
 
@@ -225,54 +184,33 @@ High-level writes default to preview/dry-run behavior. A safe workflow is:
 6. reparse the modified XML and run post-write checks;
 7. apply the live session explicitly, or roll back/cancel.
 
-`apply_xml_edits` remains an expert escape hatch. It requires exact match counts,
-preserves bytes outside targets, reparses the result, creates a backup before commit,
-and rejects SHA conflicts.
+`apply_xml_edits` remains an expert escape hatch. It requires exact match counts, preserves bytes outside targets, reparses the result, creates a backup before commit, and rejects SHA conflicts.
 
-XML containing `DOCTYPE` or `ENTITY` is rejected. Filesystem access is constrained to
-configured roots. External processes are available only through typed, allowlisted
-adapters.
+XML containing `DOCTYPE` or `ENTITY` is rejected. Filesystem access is constrained to configured roots. External processes are available only through typed allowlisted adapters.
 
 ## Trust Model
 
-The server distinguishes provenance from authority. A client may submit evidence, but it
-cannot promote its own document to a high-trust validation level.
+The server distinguishes provenance from authority. A client may submit evidence but cannot promote its own document to a high-trust validation level.
 
-- **Synthetic MCP-generated**: XML created by `create_schematic_document` or
-  `create_pcb_document`. It is classified as `synthetic_parser_only` until stronger,
-  independently verified evidence exists.
-- **Seed-based**: XML copied by `create_document_from_seed` from a real DipTrace export.
-  It preserves the seed provenance, but copying does not create round-trip authority.
-- **Recorded evidence**: `record_roundtrip_evidence` binds before/after files, exact paths,
-  source type, SHA-256 values, and semantic comparison. User-supplied evidence is useful
-  for audit and regression, but is not a trusted root.
-- **Serializer reference**: the bundled rule set fingerprints and distills the supplied XML
-  documentation. It can constrain parser/writer implementation and tests, but has no trust effect.
-- **High trust**: promotion to `diptrace_roundtrip_verified` or
-  `external_tool_roundtrip_verified` is intentionally unavailable until the project has
-  an authenticated server-owned registry, signature verifier, or committed allowlist.
+- **Synthetic MCP-generated**: XML created by `create_schematic_document` or `create_pcb_document` is classified as `synthetic_parser_only` until stronger independently verified evidence exists.
+- **Seed-based**: XML copied by `create_document_from_seed` from a real DipTrace export preserves seed provenance but does not create round-trip authority.
+- **Recorded evidence**: `record_roundtrip_evidence` binds before/after files, exact paths, source type, SHA-256 values, and semantic comparison. User-supplied evidence is useful for audit/regression but is not a trusted root.
+- **Serializer reference**: the bundled rule set fingerprints and distills XML documentation. It constrains parser/writer implementation and tests but has no trust effect.
+- **High trust**: promotion to `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified` is intentionally unavailable until the project has an authenticated server-owned registry, signature verifier, or committed allowlist.
 
-Every MCP write invalidates prior high-trust claims and records the parent provenance.
-Evidence manifests are revalidated on use and rollback; path aliases, source-type
-mismatches, stale hashes, incomplete comparison categories, and semantic differences fail
-closed.
+Trust invalidation is implemented for the main verified mutation paths, but the capability layer intentionally does **not** claim complete coverage for every write path yet. Current explicitly reported gaps are `plan_apply`, `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`. Closing these fail-closed trust paths is a near-term roadmap priority.
 
-## Pattern Learning Status
+Evidence manifests are revalidated on use and rollback; path aliases, source-type mismatches, stale hashes, incomplete comparison categories, and semantic differences fail closed.
 
-The current baseline can inspect and validate existing Pattern Libraries, compare pad
-mapping, and apply an existing pattern to a component when pad numbers match. Pattern
-Editor bridge sessions are deliberately read-only.
+## Pattern Recommendation Status
 
-The project does **not** yet contain persistent training/feedback tools such as
-`record_pattern_example`, `accept_pattern_suggestion`, or `reject_pattern_suggestion`.
-The next implementation milestone is an append-only, provenance-bound feedback dataset
-and deterministic retrieval of similar accepted examples. Fine-tuning is explicitly
-later work and is not required for the first useful recommendation system.
+The current baseline can inspect and validate existing Pattern Libraries, compare pad mapping, and assign an existing pattern to a component when pad numbers match. Pattern Editor bridge sessions are deliberately read-only.
 
-Creation or mutation of native Pattern/Component Libraries remains blocked until
-controlled DipTrace 5.3 before/after and open/save/re-export fixtures prove the writer
-semantics. The committed implementation order and acceptance criteria are recorded in
-[the roadmap](docs/ROADMAP.md).
+Persistent feedback/recommendation tools such as `record_pattern_example`, `accept_pattern_suggestion`, and `reject_pattern_suggestion` are not implemented yet. The revised roadmap prioritizes DipTrace 5.3 evidence closure, trust-path coverage, and mask/paste/courtyard verification before this recommendation layer.
+
+After that baseline is stronger, the planned path is an append-only provenance-bound feedback dataset, deterministic retrieval of similar accepted examples, and measurable ranked existing-pattern suggestions. Fine-tuning is later optional work.
+
+Native Pattern/Component Library creation or mutation remains blocked until controlled DipTrace 5.3 before/after and open/save/re-export fixtures prove writer semantics.
 
 ## Known Limits
 
@@ -280,30 +218,39 @@ semantics. The committed implementation order and acceptance criteria are record
 - DipTrace synchronously waits while a live plug-in session is active.
 - One live session is supported at a time.
 - A language model still needs visual review, ERC/DRC, and engineering judgment.
-- The local router does not implement push-and-shove, free-angle routing, or dynamic
-  neck-down; congestion-aware ordering and bounded rip-up/retry are available via
-  `route_connections`.
+- The local router does not implement push-and-shove, free-angle routing, or dynamic neck-down; congestion-aware ordering and bounded rip-up/retry are available through `route_connections`.
 - Automatic via routing requires a confirmed `Lay1`/`Lay2` span on multilayer boards.
-- The coupled router requires compatible endpoint spacing/orientation and does not
-  synthesize arbitrary uncoupled escapes.
-- `calculate_impedance` remains a preliminary analytical estimate. Field-solver results
-  are available only from a configured `run_openems_stripline_analysis` backend.
-- `place_part` references a library `ComponentStyle` by name; DipTrace resolves symbol
-  graphics and pin mapping from its own libraries on import.
-- The ngspice adapter runs user-supplied netlists in batch mode and does not generate
-  netlists from a design. The openEMS adapter requires a compatible external JSON runner;
-  no solver is bundled and the committed parser fixture is explicitly synthetic.
+- The coupled router requires compatible endpoint spacing/orientation and does not synthesize arbitrary uncoupled escapes.
+- `calculate_impedance` remains a preliminary analytical estimate; field-solver results are available only through a configured `run_openems_stripline_analysis` backend.
+- `place_part` references a library `ComponentStyle` by name; DipTrace resolves symbol graphics and pin mapping from its own libraries on import.
+- The ngspice adapter runs user-supplied netlists and does not generate netlists from a design.
+- The openEMS adapter requires a compatible external JSON runner; no solver is bundled and the committed parser fixture is synthetic.
 - Copper-pour boundaries are not authoritative refill geometry.
 - Generic fabrication manifests do not contain Gerber or NC Drill output.
-- Persistent pattern-training feedback and recommendation tools are not implemented yet.
-- Library mutation remains unavailable until verified DipTrace 5.3 round-trip fixtures
-  exist; real-openEMS golden validation also remains external-runtime acceptance work.
+- Persistent pattern-feedback/recommendation tools are not implemented yet.
+- Native Component/Pattern Library mutation remains unavailable until verified DipTrace 5.3 round-trip fixtures exist.
+- Authored schematic wires and generated ratlines still need broader real DipTrace 5.3 round-trip evidence.
+- Real-openEMS golden validation remains external-runtime acceptance work.
 
 ## Documentation
 
 - [Roadmap and actual status](docs/ROADMAP.md)
 - [Serializer reference](docs/SERIALIZER_REFERENCE.md)
 - [XML compatibility](docs/XML_COMPATIBILITY.md)
-- [Testing](docs/TESTING.md)
-- [Security and policy](docs/SECURITY_AND_POLICY.md)
+- [Complete usage guide](docs/USAGE.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Domain model](docs/DOMAIN_MODEL.md)
+- [Geometry engine](docs/GEOMETRY_ENGINE.md)
+- [Transactions](docs/TRANSACTIONS.md)
 - [MCP tools](docs/MCP_TOOLS.md)
+- [Review engine](docs/REVIEW_ENGINE.md)
+- [Placement engine](docs/PLACEMENT_ENGINE.md)
+- [Routing engine](docs/ROUTING_ENGINE.md)
+- [Impedance and SI](docs/IMPEDANCE_AND_SI.md)
+- [External adapters](docs/EXTERNAL_ADAPTERS.md)
+- [Security and policy](docs/SECURITY_AND_POLICY.md)
+- [Testing and benchmarks](docs/TESTING.md)
+- [Skill contracts](docs/SKILL_CONTRACTS.md)
+- [PCB skills](skills/README.md)
+- [Development](docs/DEVELOPMENT.md)
+- [Russian README](README_RU.md)

--- a/README_RU.md
+++ b/README_RU.md
@@ -2,111 +2,97 @@
 
 [English](README.md) | **Русский**
 
-MCP-сервер для чтения, анализа и контролируемого изменения проектов DipTrace через официальный XML-формат. Репозиторий содержит два связанных компонента:
+DipTrace MCP — локальный Model Context Protocol сервер для чтения, анализа, инженерного ревью и контролируемого изменения проектов DipTrace через официальные XML-форматы. Репозиторий содержит два связанных компонента:
 
-- `diptrace-mcp` — локальный Model Context Protocol сервер для Codex, Claude Desktop и других MCP-клиентов;
-- `diptrace_mcp_bridge.exe` — плагин-мост для работы с проектом, который прямо сейчас открыт в PCB Layout или Schematic Capture.
+- `diptrace-mcp` — MCP-сервер для Codex, Claude Desktop и других MCP-клиентов;
+- `diptrace_mcp_bridge.exe` — исполняемый плагин-мост для проекта, открытого в PCB Layout или Schematic Capture.
+
+## Текущий уровень готовности
+
+Проект уже пригоден для инженерного использования с человеком в контуре: чтения и ревью PCB/schematic, безопасных semantic edits, schematic authoring, синхронизации schematic → PCB, локального placement/routing, анализа differential pairs и подготовки review-артефактов.
+
+Это пока не полная замена интерактивному EDA-движку DipTrace. Наиболее важный незакрытый слой — не количество MCP tools, а доказанная совместимость write-paths с реальным DipTrace 5.3 через контролируемые open/save/re-export fixtures. Создание/изменение native Component/Pattern Libraries и native manufacturing outputs пока намеренно не заявлены как готовые возможности.
+
+Актуальный порядок работ и критерии завершения находятся в [roadmap](docs/ROADMAP.md). Фактическую доступность конкретной операции всегда определяет `get_capabilities`.
 
 ## Что уже работает
 
-- capability discovery (`get_capabilities`) с явным описанием доступных и недоступных возможностей;
-- normalized document/model layer для PCB и schematic на основе DipTrace XML fixtures;
-- project scaffolding: создание новых schematic/PCB XML-документов с нуля (листы, контур,
-  слои, стекап, via styles, net classes, DRC) через `create_schematic_document` и `create_pcb_document`;
-- schematic-authoring: листы, размещение part по ComponentStyle, соединение пинов в цепи,
-  провода по официальной схеме `Wire/Points`, net labels — `add_sheet`, `place_part`,
-  `connect_pins`, `disconnect_pins`, `add_wire`, `delete_wire`, `add_net_label`;
-- schematic-to-PCB synchronization: перенос RefDes/value/fields, footprint, pin-to-pad
-  connectivity, nets и ratlines через `sync_schematic_to_pcb`; по умолчанию режим additive,
-  а guarded `exact` reconciliation удаляет подтверждённые расхождения; footprint definitions
-  могут копироваться из проверенных Component/Pattern Library документов;
-- официальная панелизация DipTrace (`Panel`, V-Scoring / Tab Routing): `set_panelization` и `clear_panelization`;
-- query API по объектам, включая document models, connectivity graph и spatial selectors;
-- сводка по схеме или плате: компоненты, части, выводы, цепи, слои и дифференциальные пары;
-- поиск компонентов по `RefDes`, имени, значению и дополнительным полям;
-- просмотр цепей с конечными точками `RefDes + pin/pad`;
-- чтение настроек ERC, DRC, net classes, via styles и routing defaults;
-- ограниченное чтение исходного XML по XPath;
-- безопасные XML-правки с обязательным числом совпадений;
-- raw-preserving byte-span compiler: unknown XML, BOM и форматирование вне targets
-  не пересериализуются;
-- режим предварительного просмотра `dry_run` с diff;
-- защита от одновременного изменения через `SHA-256`;
-- автоматическая резервная копия перед каждой записью;
-- semantic transactions with preview/commit/rollback for all high-level writes;
-- component/part move/rotate/side/lock/properties/pattern/align/distribute/group operations;
-- documented net-class edits and standalone-pad testpoint add/move/remove;
-- Component/Pattern Library normalized read, validation and pin-to-pad checks;
-- registry-based offline DRC/ERC review v1 with persistent structured findings;
-- deterministic silkscreen planning with locked-label preservation, previews and transactional apply;
-- bounded local component placement with score breakdown, legalization and post-plan DRC comparison;
-- explicit trace/via operations, bounded multi-layer 45-degree A* and symmetric vias;
-- congestion-ordered multi-net routing with bounded rip-up/retry (`route_connections`) и
-  read-only evidence через `analyze_routing_congestion`;
-- atomic coupled differential-pair routing from one centerline with plan/preview/rollback;
-- bounded DSN export, Freerouting jobs and guarded SES inspect/import;
-- stackup, net length/skew, differential-pair geometry and preliminary single/differential
-  microstrip impedance plus IPC-2141 symmetric stripline;
-- ngspice batch adapter for user-supplied netlists with typed log results;
-- опциональный typed openEMS-runner adapter для frequency-dependent centered/off-center
-  stripline с bounded jobs и строгой проверкой результата;
-- return-path/plane heuristics, advanced DFM/DFA/DFT/BOM review and design comparison;
-- generic BOM/fabrication/assembly manifests with bounded resource artifacts;
+- runtime capability discovery через `get_capabilities`, включая точные причины недоступности;
+- project scaffolding: новые schematic/PCB XML-документы с листами, контуром, слоями, stackup, via styles, net classes и DRC (`create_schematic_document`, `create_pcb_document`); **это synthetic MCP-generated XML, а не DipTrace-verified файлы**;
+- seed-based создание проекта: копирование реального DipTrace-exported XML seed с сохранением provenance (`create_document_from_seed`);
+- schematic authoring: листы, размещение part по библиотечному `ComponentStyle`, pin/net connectivity, провода по официальной структуре `Wire`/`Points` и net labels (`add_sheet`, `place_part`, `connect_pins`, `disconnect_pins`, `add_wire`, `delete_wire`, `add_net_label`);
+- schematic-to-PCB synchronization RefDes/value/fields, footprint references, pin-to-pad connectivity, nets и ratlines; по умолчанию используется additive mode, а guarded `exact` reconciliation может удалять подтверждённые расхождения и затронутые traces только при изменении endpoint set;
+- копирование проверенных pattern-library subtrees при schematic-to-PCB sync;
+- официальные параметры панелизации DipTrace (`Panel`, V-Scoring / Tab Routing) через `set_panelization` и `clear_panelization`;
+- нормализованные domain models для PCB, schematic, Component Library и Pattern Library;
+- стабильные object references, structured selectors, connectivity graph и spatial queries;
+- геометрия в миллиметрах, transforms, mirroring, arcs, optional exact GEOS geometry и SVG/JSON preview;
+- raw-preserving XML patches: unknown XML, BOM, line endings и форматирование вне изменяемых узлов сохраняются;
+- semantic transactions с plan, preview, validation, expected SHA-256, commit, backup и rollback;
+- move/rotate/side/lock/property/pattern/alignment/distribution/group operations для компонентов и частей;
+- board-text edits, документированные NetClass rules и standalone-pad test points;
+- чтение и validation Component/Pattern Libraries, включая pin-to-pad checks;
+- machine-readable serializer reference с XML enums, defaults, aliases и import semantics, извлечёнными из документации; reference ограничивает parser/writer поведение, но сам по себе не создаёт DipTrace round-trip trust;
+- registry-based offline DRC/ERC review с persistent structured findings;
+- deterministic silkscreen planner и bounded local placement planner;
+- explicit trace/via operations, bounded multi-layer 45-degree A* и symmetric via insertion;
+- congestion-ordered multi-net routing с bounded rip-up/retry (`route_connections`) и read-only priority evidence (`analyze_routing_congestion`);
+- atomic coupled differential-pair routing от centerline;
+- bounded DSN export, Freerouting jobs и guarded SES inspect/import;
+- stackup, net length/skew, differential-pair geometry, return-path heuristics и preliminary analytical impedance: Hammerstad-Jensen microstrip (single/differential) и IPC-2141 centered symmetric stripline;
+- ngspice batch adapter для пользовательских netlists с typed log results;
+- optional typed openEMS-runner adapter для frequency-dependent centered/off-center stripline с bounded jobs и строгим parsing результата;
+- BOM, DFM/DFA/DFT, thermal-metadata, assembly и design-comparison reviews;
+- generic BOM, fabrication-review и assembly-review manifests;
 - policy profiles `read_only`, `review`, `interactive_edit`, `automation`, `manufacturing`;
-- live-сессия с явным завершением `apply` или `cancel`;
-- offline-работа с экспортированным или нативным XML без запуска DipTrace;
-- `stdio` и Streamable HTTP транспорты MCP.
+- live- и offline-работа через MCP stdio или Streamable HTTP.
 
-`get_capabilities` — авторитетный источник возможностей для конкретной установки и
-активного документа. Наличие зарегистрированного tool не означает, что операция
-доступна без требуемой геометрии, правил, stackup или внешнего adapter.
+`get_capabilities` — авторитетный источник для конкретной установки и документа. Зарегистрированный MCP tool может быть недоступен, если активный source type не содержит требуемую геометрию, rules, stackup или внешний adapter.
 
 ## Статус проверки
 
-CI разделяет проверки по назначению:
+CI разделяет проверки по платформам и назначению:
 
 - полный pytest на Linux с Python 3.10, 3.12 и 3.13;
-- Ruff, strict Mypy и проверка сгенерированных skills на Linux/Python 3.12;
-- полный pytest и CLI smoke test на macOS и Windows/Python 3.12;
+- Ruff, strict Mypy и generated-skill checks на Linux/Python 3.12;
+- полный pytest и CLI smoke tests на macOS и Windows/Python 3.12;
 - нативная Windows-сборка с проверкой непустого `diptrace_mcp_bridge.exe`.
 
-Текущая ветка `main` проходит всю эту матрицу. Regression coverage включает
-fail-closed trust authority, обязательные категории semantic comparison для PCB и
-schematic, Windows atomic-job поведение и terminal cancellation semantics для
-Freerouting/ngspice/openEMS.
+Текущая ветка `main` проходит эту матрицу. Regression coverage включает fail-closed trust authority boundary, обязательные категории semantic comparison для PCB и schematic, Windows atomic-job поведение и terminal cancellation semantics для Freerouting, ngspice и openEMS.
 
-Отдельный live-тест с DipTrace 5.3.0.2 подтвердил SHA-защиту, backup, atomic write,
-применение 41 `RefDesMarking`-правки на листе Power и независимый повторный export из
-DipTrace. Все 41 координаты сохранились; нормализованные количества листов, частей,
-выводов, цепей, шин и differential pairs не изменились; новых offline ERC errors не
-появилось.
+Synthetic 4.3 fixtures покрывают PCB, schematic, Component Library, Pattern Library, geometry, transactions, review, routing, DSN/SES и MCP contracts. Отдельный live acceptance test с DipTrace 5.3.0.2 подтвердил:
 
-Это подтверждает проверенные сценарии, но не является обещанием полной совместимости со
-всеми версиями DipTrace и всеми XML objects.
+- защиту от source-SHA conflict, равенство backup и atomic write;
+- 41 scoped `RefDesMarking`-правку на листе Power;
+- bridge apply и независимый повторный export из DipTrace;
+- сохранение всех 41 координат и неизменность нормализованных количеств sheet/part/pin/net/bus/differential-pair;
+- отсутствие новых offline ERC errors после round trip.
 
-## Как это устроено
+Это сильное доказательство для проверенных путей, но не обещание полной совместимости со всеми версиями DipTrace и всеми XML objects. Serializer reference дополнительно ограничивает parser behavior, но не заменяет реальные DipTrace open/save/re-export fixtures.
+
+## Архитектура
 
 ```text
-MCP-клиент                  diptrace-mcp
-(Codex/Claude)  <-------->  анализ и безопасные XML-правки
-                                  |
-                                  | shared state directory
-                                  v
-DipTrace  <-------->  diptrace_mcp_bridge.exe
-          temporary plugin_exchange.xml
+MCP-клиент                    diptrace-mcp
+(Codex/Claude)  <-------->    анализ и guarded XML edits
+                                      |
+                                      | shared state directory
+                                      v
+DipTrace       <-------->    diptrace_mcp_bridge.exe
+               temporary plugin_exchange.xml
 ```
 
-DipTrace официально запускает плагин как отдельный `.exe`, передаёт ему путь к временному XML-файлу, а после завершения процесса импортирует XML обратно. Мост сохраняет рабочую копию в `%LOCALAPPDATA%\DipTraceMCP`, ждёт команды MCP-сервера и только после явного `apply` возвращает изменённый XML в DipTrace.
+DipTrace запускает плагин отдельным `.exe` и передаёт путь к временному XML. Bridge хранит рабочую копию в `%LOCALAPPDATA%\DipTraceMCP`, ждёт MCP `apply` или `cancel`, проверяет expected SHA-256 и завершает процесс только после финализации сессии. После `apply` DipTrace импортирует exchange XML обратно.
 
 ## Требования
 
-- Windows 10/11 для live-интеграции с настольным DipTrace;
-- DipTrace с поддержкой XML-плагинов;
 - Python 3.10 или новее;
-- MCP-клиент: Codex, Claude Desktop или совместимое приложение;
-- PowerShell и доступ администратора только для установки плагина в `C:\Program Files\DipTrace`.
+- Windows 10/11 для live-интеграции с настольным DipTrace;
+- DipTrace build с поддержкой executable XML plug-ins;
+- MCP-клиент, например Codex или Claude Desktop;
+- PowerShell и права администратора только для установки плагина в `C:\Program Files\DipTrace`/`DipTrace5`.
 
-Offline-анализ XML работает также в Linux, macOS и WSL.
+Offline XML analysis также работает в Linux, macOS и WSL.
 
 ## Быстрый старт на Windows
 
@@ -119,13 +105,13 @@ py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -e .
 ```
 
-Для exact polygon/ellipse/obround geometry и GEOS spatial DRC установите optional extra:
+Для exact polygon/ellipse/obround/swept-trace geometry и spatial DRC установите optional GEOS backend:
 
 ```powershell
 .\.venv\Scripts\python.exe -m pip install -e ".[geometry]"
 ```
 
-Проверка запуска:
+Проверка entry point:
 
 ```powershell
 .\.venv\Scripts\diptrace-mcp.exe --help
@@ -133,35 +119,27 @@ py -3.12 -m venv .venv
 
 ### 2. Собрать и установить DipTrace-плагин
 
-Сборка выполняется локально, поэтому вы сами получаете неподписанный `.exe` из исходного кода этого репозитория:
+Соберите неподписанный executable локально из исходного кода:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\plugin\build_bridge.ps1
 ```
 
-Закройте все модули DipTrace. Затем откройте PowerShell **от имени администратора**.
-По умолчанию мост устанавливается в PCB Layout, Schematic Capture, Component Editor и
-Pattern Editor:
+Закройте все модули DipTrace, откройте PowerShell от имени администратора и установите bridge в PCB Layout, Schematic Capture, Component Editor и Pattern Editor:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\plugin\install_plugin.ps1
 ```
 
-Installer сначала ищет `C:\Program Files\DipTrace5`, затем legacy-каталог
-`C:\Program Files\DipTrace`. Для другой установки передайте `-DipTraceDir`.
-
-Для нестандартного каталога:
+Installer сначала проверяет `C:\Program Files\DipTrace5`, затем legacy `C:\Program Files\DipTrace`. Для другой установки:
 
 ```powershell
 .\plugin\install_plugin.ps1 -DipTraceDir "D:\Apps\DipTrace" -Mode All
 ```
 
-`-Mode Both` ставит только PCB/Schematic, а `-Mode Libraries` — только Component/Pattern
-Editor. Библиотечные профили экспортируют активную библиотеку целиком, но используют
-`ImpMode=None`: это read-only сессии, которые следует завершать через `cancel`, пока
-нативная запись библиотек остаётся evidence-gated.
+`-Mode Both` устанавливает только PCB/Schematic. `-Mode Libraries` — только Component/Pattern Editor bridges. Library sessions экспортируют активную библиотеку целиком, но используют `ImpMode=None`; завершайте их через `cancel`, потому что native library mutation пока evidence-gated.
 
-### 3. Подключить к Codex
+### 3. Подключить Codex
 
 ```powershell
 codex mcp add diptrace `
@@ -171,112 +149,95 @@ codex mcp add diptrace `
 codex mcp list
 ```
 
-Или добавьте содержимое `examples/codex-config.toml` в `~/.codex/config.toml`, заменив пути на свои.
+Либо перенесите настройки из [`examples/codex-config.toml`](examples/codex-config.toml) в `~/.codex/config.toml` и замените пути.
 
 ### 4. Открыть live-сессию
 
-1. Откройте и сохраните проект или библиотеку в DipTrace.
-2. Выберите `Tools → Plugins → DipTrace MCP Bridge`.
-3. Оставьте окно моста открытым. В это время DipTrace ожидает завершения плагина — это нормально.
-4. В MCP-клиенте напишите, например:
+1. Откройте и сохраните design или library в DipTrace.
+2. Выберите `Tools > Plugins > DipTrace MCP Bridge`.
+3. Оставьте окно bridge открытым, пока MCP-клиент выполняет чтение, planning и edits.
+4. Сначала попросите клиента прочитать и проверить документ.
+5. Для write-operation сначала требуйте dry-run/transaction preview и проверьте changed object IDs.
+6. Commit выполняйте с SHA из preview, затем запустите post-write checks и вызовите `finish_live_session(action="apply")` либо отмените сессию.
 
-   > Проверь активную плату: дай сводку, найди неподключённые цепи и покажи DRC. Ничего не изменяй.
-
-5. Для изменения попросите сначала показать diff:
-
-   > Измени значение R1 на 22k. Сначала сделай dry-run и объясни diff, затем примени правку.
-
-6. После анализа завершите live-сессию через `finish_live_session(action="apply")` или `cancel`. Кнопки в окне моста делают то же самое вручную.
+Кнопки bridge выполняют те же явные apply/cancel действия. Component и Pattern Editor profiles остаются read-only и после inspection должны завершаться через `cancel`.
 
 ## Offline-режим
 
-Передайте инструментам путь к XML-файлу внутри разрешённого workspace:
+Передайте путь внутри `DIPTRACE_MCP_WORKSPACE` или `DIPTRACE_MCP_ALLOWED_ROOTS`:
 
-> Вызови `summarize_design` для `boards/controller.xml`, затем покажи все цепи питания.
+> Запусти `summarize_design` для `boards/controller.xml`, затем покажи цепи питания.
 
-Для старых бинарных `.dip`/`.dch` сначала используйте в DipTrace `File → Export → DipTrace XML`. В версиях с нативным XML `.dip` или `.dch` можно анализировать напрямую, если сам файл действительно начинается с `<Source Type="DipTrace-...">`.
+Legacy binary `.dip`/`.dch` сначала экспортируйте через `File > Export > DipTrace XML`. Native XML `.dip`/`.dch` можно читать напрямую только если файл действительно начинается с официального DipTrace XML root.
 
 ## Безопасность изменений
 
-`apply_xml_edits` по умолчанию ничего не записывает:
+High-level writes по умолчанию работают в preview/dry-run режиме. Рекомендуемый workflow:
 
-1. первый вызов использует `dry_run=true`;
-2. сервер возвращает diff, `before_sha256` и `after_sha256`;
-3. второй вызов повторяет те же операции с `dry_run=false` и `expected_sha256=<before_sha256>`;
-4. перед записью создаётся `.bak`;
-5. live-проект импортируется в DipTrace только после отдельного `finish_live_session(action="apply")`.
+1. загрузить документ и зафиксировать SHA-256;
+2. создать или staged scoped semantic operations;
+3. проверить diff и SVG/JSON preview;
+4. проверить connectivity и локальный DRC/ERC;
+5. commit с `expected_sha256`;
+6. повторно распарсить изменённый XML и выполнить post-write checks;
+7. явно применить live session либо выполнить rollback/cancel.
 
-XML с `DOCTYPE` или `ENTITY` отклоняется. Сервер читает явный workspace и дополнительные каталоги из `DIPTRACE_MCP_ALLOWED_ROOTS`, а не произвольную файловую систему.
+`apply_xml_edits` остаётся expert escape hatch. Он требует exact match counts, сохраняет bytes вне target nodes, reparses результат, создаёт backup перед commit и отклоняет SHA conflicts.
 
-Профиль задаётся `DIPTRACE_MCP_POLICY`. Для review-only агента используйте
-`review`: semantic previews разрешены, commit и external execution запрещены.
+XML с `DOCTYPE` или `ENTITY` отклоняется. Доступ к файловой системе ограничен configured roots. Внешние процессы запускаются только через typed allowlisted adapters.
 
 ## Модель доверия
 
-Сервер разделяет provenance и authority. Клиент может передать evidence, но не может
-самостоятельно повысить документ до high-trust validation level.
+Сервер разделяет provenance и authority. Клиент может передать evidence, но не может сам повысить документ до high-trust validation level.
 
-- XML, созданный MCP с нуля, остаётся `synthetic_parser_only`;
-- копия реального seed сохраняет provenance, но не получает round-trip authority;
-- `record_roundtrip_evidence` связывает точные пути, source type, SHA-256 и semantic
-  comparison, однако user-supplied evidence не является доверенным корнем;
-- `diptrace_roundtrip_verified` и `external_tool_roundtrip_verified` намеренно недоступны,
-  пока нет server-owned registry, проверки подписи или committed allowlist.
+- **Synthetic MCP-generated**: XML из `create_schematic_document`/`create_pcb_document` имеет `synthetic_parser_only`, пока нет более сильного независимо проверенного evidence.
+- **Seed-based**: `create_document_from_seed` копирует реальный DipTrace export и сохраняет provenance, но копирование само по себе не создаёт round-trip authority.
+- **Recorded evidence**: `record_roundtrip_evidence` связывает before/after files, точные paths, source type, SHA-256 и semantic comparison. User-supplied evidence полезен для audit/regression, но не является trusted root.
+- **Serializer reference**: bundled rule set фиксирует и нормализует правила из XML documentation. Он ограничивает parser/writer implementation и tests, но не влияет на trust level.
+- **High trust**: повышение до `diptrace_roundtrip_verified`/`external_tool_roundtrip_verified` недоступно до появления authenticated server-owned registry, signature verifier или committed allowlist.
 
-Любая запись MCP инвалидирует прежние high-trust claims. Evidence повторно проверяется
-при использовании и rollback; path aliases, несовпадение source type/SHA, неполные
-категории сравнения и semantic differences приводят к fail-closed результату.
+Trust invalidation после MCP write реализован для основных проверенных путей, но capability layer намеренно **не заявляет полное покрытие всех write paths**. Отдельно остаются неполностью закрытыми `plan_apply`, `ses_import`, `schematic_to_pcb_sync` и `live_session_apply`; их полное fail-closed trust invalidation входит в ближайший roadmap. Поэтому `get_capabilities` имеет приоритет над более общими описаниями документации.
 
-## Статус обучения паттернов
+Evidence manifests повторно валидируются при использовании и rollback; path aliases, source-type mismatch, stale hashes, неполные comparison categories и semantic differences приводят к fail-closed результату.
 
-Уже можно читать и валидировать существующие Pattern Libraries, проверять pin-to-pad
-mapping и назначать компоненту существующий pattern при точном совпадении pad numbers.
-Сессии Pattern Editor остаются read-only.
+## Статус pattern recommendation
 
-В проекте пока нет persistent feedback tools `record_pattern_example`,
-`accept_pattern_suggestion` и `reject_pattern_suggestion`. Следующий этап — append-only
-dataset с provenance и deterministic retrieval похожих принятых примеров. Fine-tuning
-отложен: для первого полезного recommendation loop он не требуется.
+Текущий baseline умеет читать и валидировать существующие Pattern Libraries, сравнивать pad mapping и назначать компоненту уже существующий pattern при точном совпадении pad numbers. Pattern Editor bridge sessions намеренно read-only.
 
-Создание и изменение native Pattern/Component Libraries остаётся заблокировано до
-появления контролируемых DipTrace 5.3 before/after и open/save/re-export fixtures.
-Фиксированный порядок работ и критерии готовности описаны в [roadmap](docs/ROADMAP.md).
+Persistent feedback/recommendation tools — `record_pattern_example`, `accept_pattern_suggestion`, `reject_pattern_suggestion` — пока не реализованы. До их разработки roadmap ставит выше закрытие реального DipTrace 5.3 evidence layer: fixture pack, trust-invalidation coverage и mask/paste/courtyard semantics.
 
-## Ограничения
+После evidence closure планируется append-only provenance-bound feedback dataset, deterministic retrieval похожих принятых примеров и измеримый ranked recommendation workflow. Fine-tuning остаётся более поздней необязательной стадией.
 
-- сервер не управляет GUI DipTrace и не нажимает пункты меню;
-- DipTrace блокирует текущий документ, пока live-плагин ожидает `apply`/`cancel`;
-- MCP не заменяет визуальную проверку, ERC/DRC и инженерное ревью;
-- универсальные XML-операции позволяют менять структуру, но модель должна соблюдать официальную схему DipTrace;
-- старые бинарные проекты требуют экспорта в XML;
+Создание или изменение native Pattern/Component Libraries остаётся заблокировано до controlled DipTrace 5.3 before/after и open/save/re-export fixtures, подтверждающих writer semantics.
+
+## Известные ограничения
+
+- сервер не автоматизирует GUI DipTrace;
+- DipTrace синхронно ждёт завершения live plug-in session;
 - одновременно поддерживается одна live-сессия;
-- local router не реализует push-and-shove, free-angle и dynamic neck-down; rip-up/retry
-  и congestion-aware ordering доступны в bounded multi-net режиме `route_connections`;
-- automatic via routing требует подтверждённый `Lay1`/`Lay2`; omitted span допустим
-  только на двухслойной плате;
-- coupled router требует согласованных pad-pair spacing/orientation и не строит uncoupled escapes;
-- `calculate_impedance` остаётся preliminary analytical estimate; field-solver result
-  доступен только через настроенный `run_openems_stripline_analysis` backend;
-- `place_part` ссылается на библиотечный ComponentStyle по имени — графику символа и
-  распиновку DipTrace подставляет из своих библиотек при импорте;
-- ngspice-адаптер запускает пользовательские нетлисты в batch-режиме и не генерирует
-  нетлисты из дизайна; openEMS adapter требует внешний совместимый JSON runner, solver
-  не поставляется, а parser fixture явно синтетический;
-- copper pours представлены boundary, не authoritative refill;
-- fabrication manifest не содержит Gerber/NC Drill и не готов к производству;
-- persistent feedback/retrieval для обучения выбору паттернов пока не реализованы;
-- library mutation не заявлена без verified fixtures;
-- schematic-to-PCB sync сохраняет лишние PCB objects и существующие traces; multi-part
-  components требуют явный `part_id + pin -> pad_number` mapping, а новый placement является
-  стартовой детерминированной сеткой и требует legalization;
-- неподписанный bridge `.exe` может потребовать разрешения Windows Defender/SmartScreen.
+- LLM не заменяет visual review, ERC/DRC и инженерное решение;
+- local router не реализует push-and-shove, free-angle routing или dynamic neck-down; congestion-aware ordering и bounded rip-up/retry доступны через `route_connections`;
+- automatic via routing на multilayer board требует подтверждённый `Lay1`/`Lay2` span;
+- coupled router требует совместимых endpoint spacing/orientation и не синтезирует произвольные uncoupled escapes;
+- `calculate_impedance` остаётся preliminary analytical estimate; field-solver result доступен только через настроенный `run_openems_stripline_analysis` backend;
+- `place_part` ссылается на library `ComponentStyle` по имени; symbol graphics и pin mapping DipTrace разрешает из собственных libraries при import;
+- ngspice adapter запускает user-supplied netlists и не генерирует netlist из design;
+- openEMS adapter требует совместимый внешний JSON runner; solver не bundled, а committed parser fixture синтетический;
+- copper-pour boundaries не считаются authoritative refill geometry;
+- generic fabrication manifests не содержат Gerber или NC Drill;
+- persistent pattern-training/recommendation tools пока отсутствуют;
+- native Component/Pattern Library mutation недоступна до verified DipTrace 5.3 round-trip fixtures;
+- schematic wire authoring и ratline generation требуют дополнительного real DipTrace 5.3 round-trip evidence;
+- real-openEMS golden validation остаётся внешней acceptance-задачей.
 
 ## Документация
 
+- [Roadmap и фактический статус](docs/ROADMAP.md)
+- [Serializer reference](docs/SERIALIZER_REFERENCE.md)
+- [XML compatibility](docs/XML_COMPATIBILITY.md)
 - [Полное руководство](docs/USAGE.md)
 - [Архитектура](docs/ARCHITECTURE.md)
 - [Domain model](docs/DOMAIN_MODEL.md)
-- [XML compatibility matrix](docs/XML_COMPATIBILITY.md)
 - [Geometry engine](docs/GEOMETRY_ENGINE.md)
 - [Transactions](docs/TRANSACTIONS.md)
 - [MCP tools](docs/MCP_TOOLS.md)
@@ -285,17 +246,12 @@ dataset с provenance и deterministic retrieval похожих принятых
 - [Routing engine](docs/ROUTING_ENGINE.md)
 - [Impedance and SI](docs/IMPEDANCE_AND_SI.md)
 - [External adapters](docs/EXTERNAL_ADAPTERS.md)
-- [Field-solver runner protocol](docs/FIELD_SOLVER_PROTOCOL.md)
 - [Security and policy](docs/SECURITY_AND_POLICY.md)
 - [Testing and benchmarks](docs/TESTING.md)
 - [Skill contracts](docs/SKILL_CONTRACTS.md)
-- [Англоязычный каталог PCB skills](skills/README.md)
-- [Roadmap и план обучения паттернов](docs/ROADMAP.md)
+- [PCB skills](skills/README.md)
 - [Разработка](docs/DEVELOPMENT.md)
-- [Основной README на английском](README.md)
-- [Официальные спецификации DipTrace XML и плагинов](https://diptrace.com/support/tutorials/)
-- [Официальный Python SDK MCP](https://github.com/modelcontextprotocol/python-sdk)
-- [Подключение MCP к Codex](https://learn.chatgpt.com/docs/extend/mcp)
+- [English README](README.md)
 
 ## Разработка
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,83 +1,89 @@
 # MCP Tools and Resources
 
-The complete runtime tool list should always be requested through MCP `tools/list`.
-Actual availability for a specific document is reported by `get_capabilities`.
+The complete runtime tool list must be requested through MCP `tools/list`. Actual availability for a specific document, source type, geometry set, policy profile, and external-adapter configuration is reported by `get_capabilities`.
+
+A registered tool is not the same as a DipTrace-verified write path. The project intentionally distinguishes implementation, runtime availability, and real DipTrace round-trip evidence.
 
 ## Read and Query
 
-- status, information, scan, summary, and capabilities;
-- board, schematic, and library models, plus `query_objects` and `get_object`;
-- components, nets, rules, stackup, and the connectivity graph;
-- BOM, copper pours, unrouted connections, and route details;
-- net lengths, differential pairs, and preliminary single-ended/differential impedance.
+- status, document information, scanning, summaries, and capabilities;
+- normalized PCB, schematic, Component Library, and Pattern Library models;
+- `query_objects`, `get_object`, structured selectors, spatial queries, and stable IDs;
+- components, nets, rules, stackup, connectivity graph, and XML fragments;
+- BOM, copper-pour boundaries, unrouted connections, and route details;
+- net lengths, differential pairs, and preliminary single-ended/differential impedance;
+- library component/pattern lookup and validation, including pin-to-pad checks.
 
 ## Semantic Writes
 
-- document creation: `create_schematic_document` and `create_pcb_document` generate new
-  valid DipTrace XML documents (sheets, outline, layers, stackup, via styles, net classes,
-  DRC) inside the workspace;
+- document creation: `create_schematic_document` and `create_pcb_document` generate synthetic DipTrace-shaped XML with sheets, outline, layers, stackup, via styles, net classes, and DRC;
+- seed-based document creation through `create_document_from_seed` for workflows that need to preserve a real DipTrace-exported XML structure and provenance;
 - components: move, rotate, side, lock, properties, pattern, align, distribute, and group;
 - board text: list, move, rotate, visibility, and style;
-- schematic: value, fields, no-connect, and net rename;
-- schematic authoring: `add_sheet`, `place_part`, `connect_pins`, `disconnect_pins`,
-  `add_wire`, `delete_wire`, and `add_net_label` using the official XML structures;
-- schematic-to-PCB: `sync_schematic_to_pcb` creates or updates PCB components, copies
-  referenced pattern/pad-style definitions from allowed library documents, maps pins to pads,
-  and creates nets and ratlines; the default is additive, while opt-in `exact` reconciliation
-  removes unmatched components/nets/ratlines and traces only on changed nets;
+- schematic properties: value, fields, no-connect, and net rename;
+- schematic authoring: `add_sheet`, `place_part`, `connect_pins`, `disconnect_pins`, `add_wire`, `delete_wire`, and `add_net_label`;
+- schematic-to-PCB: `sync_schematic_to_pcb` creates/updates PCB components, copies allowed pattern/pad-style subtrees, maps pins to pads, and creates nets/ratlines; default mode is additive, while opt-in `exact` reconciliation can remove unmatched synchronized objects and traces on nets whose endpoint set changed;
 - rules: NetClass assignment, widths, gaps, and length constraints;
-- panelization: `set_panelization` and `clear_panelization` write official DipTrace
-  `Panel` parameters (V-Scoring / Tab Routing, rails, tabs, holes);
+- panelization: `set_panelization` / `clear_panelization` write official DipTrace `Panel` parameters;
 - standalone test points;
-- trace and via primitives, bounded multi-layer local route plans, and symmetric via insertion;
-- `analyze_routing_congestion` returns deterministic corridor congestion and priority evidence;
-- `route_connections` routes multiple nets most-constrained-first by default with bounded
-  rip-up/retry, or preserves caller order with `ordering="input"`;
-- `plan_diff_pair_route` and `route_diff_pair` using a coupled centerline and atomic pair metadata.
+- trace/via primitives, bounded multi-layer route plans, and symmetric via insertion;
+- `analyze_routing_congestion` for deterministic routing-priority evidence;
+- `route_connections` for congestion-ordered multi-net routing with bounded batch-local rip-up/retry;
+- `plan_diff_pair_route` and `route_diff_pair` for coupled centerline-based differential-pair routing.
 
-All writes use a plan or dry-run transaction, expected SHA, preview, reparse,
-connectivity/DRC regression gate, commit, and rollback. `apply_xml_edits` is retained as
-an expert escape hatch and is not the recommended API.
+High-level writes use dry-run or transaction planning, expected source SHA, preview, reparse, targeted connectivity/DRC/ERC regression checks, commit, backup, and rollback. `apply_xml_edits` remains an expert escape hatch rather than the preferred API.
+
+## Trust and Verification Caveat
+
+The capability layer intentionally does **not** claim that every write path has fully proven trust invalidation and real DipTrace round-trip coverage.
+
+At the current baseline, `get_capabilities` explicitly reports remaining trust-coverage work for:
+
+- `plan_apply`;
+- `ses_import`;
+- `schematic_to_pcb_sync`;
+- `live_session_apply`.
+
+These operations may be implemented and tested while still lacking the same trust/evidence closure as the strongest paths. Runtime capability discovery takes precedence over broad documentation summaries.
 
 ## Analysis and Review
 
 - registry-based DRC, ERC, connectivity, board, and schematic review;
 - manufacturing, assembly, testability, BOM, and thermal profiles;
-- silkscreen and placement planners;
-- return-path and plane-continuity analysis;
-- BOM and design comparison;
-- DSN and SES inspection.
+- silkscreen and bounded local placement planners;
+- return-path and plane-continuity heuristics;
+- BOM and schematic/PCB comparison;
+- DSN/SES inspection;
+- persistent structured findings and bounded review artifacts.
 
-## Exports and Jobs
+## Exports and External Jobs
 
-- bounded DSN export, Freerouting jobs, and SES import;
-- ngspice batch jobs for user-supplied netlists (`run_ngspice_simulation`), with typed
-  log parsing; requires `DIPTRACE_MCP_NGSPICE` or ngspice on `PATH`;
-- typed centered/off-center stripline solver jobs (`run_openems_stripline_analysis`),
-  including frequency-dependent complex impedance and propagation data; requires
-  `DIPTRACE_MCP_OPENEMS_RUNNER`;
+- bounded DSN export, Freerouting jobs, guarded SES inspection/import;
+- ngspice batch jobs for user-supplied netlists (`run_ngspice_simulation`), requiring `DIPTRACE_MCP_NGSPICE` or ngspice on `PATH`;
+- typed centered/off-center stripline solver jobs (`run_openems_stripline_analysis`) with frequency-dependent complex impedance/propagation results, requiring `DIPTRACE_MCP_OPENEMS_RUNNER`;
 - generic BOM CSV;
-- generic fabrication and assembly review manifests;
-- job status, result, cancel, and list operations, plus export listing.
+- generic fabrication-review and assembly-review manifests;
+- job status, result, cancel, list, log, DSN, SES, and export-artifact resources.
 
-Generic manifests do not generate Gerber, NC Drill, ODB++, IPC-2581, or vendor-specific
-component-placement files. A request for native output ends with
-`capability_unavailable`, not false success.
+Generic manifests do **not** generate Gerber, NC Drill, ODB++, IPC-2581, or vendor-native placement packages. Native-output requests fail explicitly instead of returning false success.
 
 ## Resources
 
 - `diptrace://status`, `diptrace://capabilities`;
-- document summary, board, schematic, stackup, connectivity, library, review, and findings;
-- transaction and plan summary, diff, SVG, and JSON;
-- job status, result, log, DSN, SES, and manifest;
+- document summary, board, schematic, stackup, connectivity, library, review, and findings resources;
+- transaction/plan summary, operations, diff, SVG, and JSON previews;
+- job status, result, log, DSN, SES, and field-solver resources;
 - `diptrace://export/{export_id}/{artifact}`.
 
-Large payloads are exposed through bounded resources. PNG is not available. Preview
-formats are SVG, JSON geometry, and XML diff.
+Large payloads are exposed through bounded resources. Preview formats are SVG, JSON geometry, and XML diff; PNG preview is not currently registered.
 
-## Not Registered
+## Deliberately Not Registered
 
-Library mutation, persistent pattern-training feedback/retrieval tools, push-and-shove
-routing, native manufacturing outputs, and unverified frequency-dependent or full-wave
-solvers are not registered. The pattern recommendation milestones are fixed in
-[ROADMAP.md](ROADMAP.md). Reasons are returned through `reasons_unavailable`.
+- native Component/Pattern Library mutation;
+- persistent pattern feedback/retrieval/recommendation tools;
+- push-and-shove, free-angle, or full global autorouting;
+- native Gerber/NC Drill/ODB++/IPC-2581 manufacturing generation;
+- unverified full-wave or frequency-dependent solver backends presented as built-in capability;
+- arbitrary shell execution or unrestricted network-backed sourcing.
+
+Reasons are returned through `reasons_unavailable`. See [ROADMAP.md](ROADMAP.md) for evidence-gated work and implementation order.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,85 @@
 # Roadmap and Actual Status
 
-The statuses below mean that production code, typed contracts, and tests exist. `v1`
-does not imply full equivalence with the DipTrace GUI.
+This document separates three things that were previously easy to mix together:
+
+1. **implemented code** — production code, typed contracts, and tests exist;
+2. **runtime availability** — the feature is available for the active document and configured adapters;
+3. **DipTrace-verified compatibility** — the write path has controlled open/save/re-export evidence from a real DipTrace build.
+
+`complete v1/v2/v3` below means that the implementation exists and is covered by the repository test suite. It does **not** imply full equivalence with the DipTrace GUI or complete DipTrace 5.3 round-trip evidence.
+
+The authoritative runtime source remains `get_capabilities`.
+
+## Current Readiness — 2026-07-25
+
+The project has moved beyond a parser/MCP prototype. The strongest areas are read/query, engineering review, guarded semantic edits, transactions, schematic-to-PCB comparison/synchronization, and bounded routing/placement workflows.
+
+The main remaining risk is no longer missing MCP surface area. It is the gap between synthetic/fixture-tested writer behavior and broad, redistributable, automated evidence from real DipTrace 5.3 open/save/re-export cycles.
+
+Current practical classification:
+
+| Area | Status | Main remaining gap |
+| --- | --- | --- |
+| PCB/schematic read/query | mature beta | broader redistributable DipTrace 5.3 fixtures |
+| Component/Pattern Library read/validate | mature beta | more 5.3 mask/paste/courtyard fixtures |
+| Guarded semantic edits | mature beta | close all trust-invalidation/write-path evidence gaps |
+| Schematic authoring | beta | live round-trip evidence for authored wires and more operations |
+| Schematic → PCB synchronization | beta | full trust-path coverage and broader real 5.3 round trips |
+| Placement | beta, bounded | no global placer/legalizer equivalent to a full EDA engine |
+| Local/multi-net routing | beta, bounded | no push-and-shove/free-angle/global router |
+| Differential-pair/SI analysis | beta | external solver validation remains optional/runtime-dependent |
+| Native Component/Pattern Library mutation | blocked | controlled 5.3 writer fixtures and semantics |
+| Native manufacturing output | out of current core scope | no verified DipTrace API for Gerber/NC Drill generation |
+| Pattern recommendation | planned | feedback dataset, deterministic retrieval, held-out metrics |
+
+## Revised Priority Order
+
+Feature count is no longer the bottleneck. New high-level tools should not outrun compatibility evidence. The implementation priority is therefore:
+
+### Priority A — Close compatibility and trust evidence
+
+1. close trust invalidation coverage for every write path currently reported as untested by `get_capabilities`:
+   - `plan_apply`;
+   - `ses_import`;
+   - `schematic_to_pcb_sync`;
+   - `live_session_apply`;
+2. collect a redistributable DipTrace 5.3 fixture pack covering PCB, schematic, Component Library, Pattern Library, controlled before/after writer cases, and a real DSN/SES pair;
+3. add explicit real-DipTrace acceptance for authored schematic wires and generated ratlines;
+4. verify mask/paste/courtyard/`Common` semantics with one-setting-at-a-time exports;
+5. make these cases executable in CI without requiring DipTrace to be installed.
+
+Exit condition: the project can distinguish parser-tested, operation-tested, DipTrace-exported, and DipTrace-roundtrip-verified paths without relying on broad documentation claims.
+
+### Priority B — Native library writers
+
+Only after Priority A supplies writer evidence:
+
+- create/update patterns;
+- create/update components, parts, pins, graphics, and fields;
+- attach a pattern to a component;
+- maintain explicit pin-to-pad mapping;
+- preserve unknown/unsupported library XML;
+- prove idempotence and DipTrace 5.3 open/save/re-export equivalence.
+
+### Priority C — Human-guided pattern recommendation
+
+After the compatibility baseline is stable:
+
+1. append-only feedback records;
+2. deterministic package feature extraction and retrieval;
+3. held-out top-1/top-3/rejection metrics;
+4. ranked existing-pattern suggestions;
+5. controlled human correction capture.
+
+The first useful recommendation system should select among **existing** patterns. Fine-tuning is explicitly later work and is not required for the initial system.
+
+### Priority D — Optional external validation
+
+- capture a real openEMS result and integration run;
+- optionally broaden Freerouting integration fixtures;
+- keep external-solver availability separate from core parser/writer trust.
+
+## Phase Summary
 
 | Phase | Status | Implemented |
 | --- | --- | --- |
@@ -17,7 +95,7 @@ does not imply full equivalence with the DipTrace GUI.
 | 9 | complete v1 | bounded DSN export, Freerouting job, SES inspect/import, and post-review |
 | 10 | complete v3 | coupled-pair routing, lengths/skew, microstrip and IPC-2141 symmetric stripline impedance |
 | 11 | complete v1 | return-path/plane heuristics, BOM/design comparison, DFM/DFA/DFT, and thermal skips |
-| 12 | partial v2 | library validation, generic release manifests, and typed optional openEMS jobs; library mutation and native fabrication remain unavailable |
+| 12 | partial v2 | library validation, generic release manifests, typed optional openEMS jobs; library mutation and native fabrication remain unavailable |
 | 13 | complete v1 | workflow prompts, skill contracts, CI matrix, benchmark harness, truthful discovery |
 | 14 | complete v1 | project scaffolding: new schematic/PCB XML documents with stackup, rules, and sheets |
 | 15 | complete v1 | schematic authoring: sheets, part placement, pin connectivity, wires, and net labels |
@@ -25,197 +103,98 @@ does not imply full equivalence with the DipTrace GUI.
 | 17 | complete v1 | ngspice batch adapter for user-supplied netlists with typed log results |
 | 18 | complete v2 | congestion-aware multi-net ordering with bounded rip-up/retry |
 | 19 | complete v2 | additive and guarded exact schematic-to-PCB reconciliation with explicit multi-part pin mapping |
-| 20 | complete v1 | fail-closed trust authority, full PCB/schematic semantic comparison, native Windows CI, and terminal external-job cancellation |
-| 21 | planned | human-guided pattern feedback dataset, deterministic retrieval, and measurable recommendation workflow |
+| 20 | complete implementation baseline | fail-closed authority boundary, PCB/schematic semantic comparison, native Windows CI, external-job cancellation; full write-path trust invalidation still has explicitly reported gaps |
+| 21 | planned | human-guided pattern feedback dataset, deterministic retrieval, measurable recommendation workflow |
 
-## Phase 4: Verified Boundary
+## Implemented Boundary
 
-Implemented operations include move, rotate, side, lock, value, properties, pattern,
-align, distribute, group, board text, no-connect, net rename, NetClass rules, and
-standalone test points. Pattern swap requires exact pad-number matching. Component and
-Pattern Libraries are available for reading and validation.
+Implemented semantic operations include move, rotate, side, lock, value, properties, pattern, align, distribute, group, board text, no-connect, net rename, NetClass rules, standalone test points, trace/via primitives, local routing, differential-pair routing, schematic authoring, panelization, and schematic-to-PCB synchronization.
 
-Library create/update and attach-pattern mutation are not implemented because the
-repository does not contain verified round-trip writer fixtures for those structures.
-Capability discovery reports the exact unavailability instead of registering empty tools.
+Pattern swap requires exact pad-number compatibility. Component and Pattern Libraries are available for reading and validation.
 
-## Phases 8-10: Strict Limits
+Native library create/update and attach-pattern mutation are intentionally unavailable because the repository does not yet contain sufficient controlled DipTrace 5.3 writer fixtures. Capability discovery must continue to report this as unavailable rather than registering placeholder tools.
 
-- The local router supports bounded vias and multi-layer routing with orthogonal and
-  45-degree segments, but not push-and-shove. Sequential multi-net routing with bounded
-  rip-up/retry is available through `route_connections`.
-- The DSN serializer rejects unsupported geometry instead of silently losing data.
-- SES always passes internal inspection, preview, and review before import.
+## Routing and SI Limits
+
+- The local router supports bounded vias and multi-layer routing with orthogonal/45-degree segments.
+- `route_connections` provides congestion-aware ordering and bounded batch-local rip-up/retry.
+- It is not push-and-shove, free-angle, dynamic neck-down, or a global autorouter.
+- The DSN serializer rejects unsupported geometry rather than silently dropping data.
+- SES import always passes internal inspection, preview, and review before commit.
 - Differential-pair synthesis writes both traces and the pair `Segment` atomically.
-- Impedance uses preliminary-only Hammerstad-Jensen single/coupled microstrip and the
-  IPC-2141 centered symmetric stripline closed form; frequency-dependent and off-center
-  stripline analysis requires an external solver.
+- Analytical impedance is preliminary: Hammerstad-Jensen single/coupled microstrip and IPC-2141 centered symmetric stripline.
+- Frequency-dependent/off-center stripline analysis requires the optional external openEMS runner.
 
-## Phases 11-12: Strict Limits
+## Review and Manufacturing Limits
 
-- The copper-pour adapter reads the boundary, not the final refill.
+- Copper-pour handling reads the boundary, not authoritative refilled copper geometry.
 - Return-path analysis is a geometry heuristic with confidence reporting, not full-wave SI.
-- A generic fabrication manifest is not a Gerber/NC Drill package.
-- Generic placement CSV requires mapping to the selected assembler's coordinate convention.
-- The ngspice adapter runs user-supplied netlists in batch mode; it does not generate
-  netlists from a design. The openEMS runner adapter has a typed fixed protocol, bounded
-  jobs, strict parsing, and failure tests, but no solver is bundled and its current parser
-  fixture is explicitly synthetic.
+- Generic fabrication manifests are not Gerber/NC Drill/ODB++/IPC-2581 packages.
+- Generic placement CSV must be mapped to the selected assembler's coordinate convention.
+- The ngspice adapter runs user-supplied netlists; it does not generate a netlist from a DipTrace design.
 - Online component sourcing is disabled by default.
 
-## Phases 14-19: Strict Limits
+## Project Creation and Synchronization Limits
 
-- Scaffolding generates **synthetic** 4.3-era XML structures; DipTrace import may
-  canonicalize numeric values and derived fields, as with any other XML import.
-  These are classified as `synthetic_parser_only` and must not be treated as
-  DipTrace-compatible without independent verification.
-- `create_document_from_seed` copies a real DipTrace-exported XML seed, preserving
-  all unknown XML. The copy inherits the seed's provenance (`diptrace_exported`)
-  but is not automatically upgraded to `diptrace_roundtrip_verified`.
-- `place_part` references a library `ComponentStyle` by name; the symbol graphics and pin
-  mapping are resolved by DipTrace from the configured libraries on import, not by the MCP.
-- Schematic wires follow the official `Wire`/`Points` schema; pin-to-net connectivity is
-  maintained separately via `connect_pins`/`disconnect_pins`.
-- Panelization writes official `Panel` parameters only; tab coordinates are recomputed by
-  DipTrace (`TabsDone="N"`), and no panel geometry is expanded by the MCP.
-- The ngspice adapter never fabricates simulation results: an unavailable executable ends
-  in `external_tool_unavailable`.
-- Multi-net rip-up/retry is bounded to batch-local candidates and never rips traces that
-  were routed outside the current call.
-- Congestion-aware ordering is a deterministic corridor/bounding-box heuristic, not a global
-  router or push-and-shove engine.
-- Exact schematic-to-PCB reconciliation is opt-in, refuses locked objects by default, and
-  removes traces only when a synchronized net's endpoint set changes.
+- `create_schematic_document` and `create_pcb_document` generate **synthetic** 4.3-era XML structures. They are classified as `synthetic_parser_only` until independent DipTrace evidence exists.
+- `create_document_from_seed` copies a real DipTrace-exported XML seed and preserves unknown XML and provenance, but does not auto-upgrade round-trip trust.
+- `place_part` references a library `ComponentStyle`; DipTrace resolves symbol graphics and pin mapping from configured libraries during import.
+- Schematic wires use the official `Wire`/`Points` structure, while logical pin-to-net connectivity is maintained separately through `connect_pins`/`disconnect_pins`.
+- Panelization writes official `Panel` parameters; tab coordinates are recomputed by DipTrace and MCP does not expand final panel geometry.
+- Exact schematic-to-PCB reconciliation is opt-in, refuses locked objects by default, and removes traces only when a synchronized net's endpoint set changes.
+- Multi-net rip-up/retry is limited to traces produced within the current routing batch.
 
-## Trust, Semantic Comparison, and CI Baseline — 2026-07-23
+## Trust, Semantic Comparison, and CI Baseline
 
-This baseline is complete and must not be weakened by later feature work:
+The following baseline must not be weakened by later feature work:
 
-- runtime, user-supplied evidence, fixture-manifest labels, and trusted authority are
-  separate concepts;
-- runtime or user-controlled JSON, sidecars, hashes, and fixture manifests cannot mint
-  `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified`;
-- high-trust promotion remains unavailable until an authenticated server-owned registry,
-  signature verifier, or committed allowlist is implemented;
-- evidence is bound to the exact document role/path, source type, before/after SHA-256,
-  and required semantic-comparison categories;
-- rollback reparses and revalidates restored provenance/evidence and falls back to
-  synthetic provenance when validation fails;
-- PCB comparison covers components, pads, nets, trace endpoints, ordered points, widths,
-  segment layers, via styles/spans, locks, and differential-pair membership;
-- schematic comparison covers sheets/hierarchy, parts, values/patterns, pins, pin-to-net
-  connectivity, wire geometry, labels, buses, and hierarchy records;
-- `comparison_complete` is derived from required categories and cannot be set by a
-  caller while categories are absent;
-- CI runs Linux Python 3.10/3.12/3.13 tests, one Linux static-analysis gate, macOS and
-  Windows tests/CLI smoke, and a real Windows bridge build/EXE verification;
-- external job cancellation is terminal across Freerouting, ngspice, and openEMS even
-  when process exit races with the worker's cancellation check.
+- runtime state, user-supplied evidence, fixture labels, and trusted authority are separate concepts;
+- user-controlled JSON, sidecars, hashes, and fixture manifests cannot mint `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified`;
+- high-trust promotion remains unavailable until an authenticated server-owned registry, signature verifier, or committed allowlist exists;
+- evidence is bound to exact document role/path, source type, before/after SHA-256, and required semantic-comparison categories;
+- rollback reparses and revalidates restored provenance/evidence;
+- PCB comparison covers components, pads, nets, trace endpoints, ordered points, widths, segment layers, via styles/spans, locks, and differential-pair membership;
+- schematic comparison covers sheets/hierarchy, parts, values/patterns, pins, pin-to-net connectivity, wire geometry, labels, buses, and hierarchy records;
+- `comparison_complete` is derived from required categories and cannot be asserted by a caller while categories are absent;
+- CI runs Linux Python 3.10/3.12/3.13, Linux static analysis, macOS/Windows tests and CLI smoke, plus a real Windows bridge build;
+- external-job cancellation is terminal across Freerouting, ngspice, and openEMS.
 
-### Human-Guided Pattern Learning Roadmap
+### Known trust-coverage gap
 
-The first target is recommendation of an **existing** pattern, not automatic mutation of
-native libraries and not model fine-tuning.
+The capability report currently does **not** claim `all_write_paths_invalidate_trust=true`. The explicitly listed untested paths are:
+
+- `plan_apply`;
+- `ses_import`;
+- `schematic_to_pcb_sync`;
+- `live_session_apply`.
+
+Closing this list is Priority A work. Documentation must not summarize the trust model as if every possible write path has already been proven equivalent.
+
+## Human-Guided Pattern Recommendation
+
+The existing baseline can inspect/validate libraries and assign an existing compatible pattern. Pattern Editor bridge sessions remain read-only.
 
 | Milestone | Status | Deliverable | Exit criterion |
 | --- | --- | --- | --- |
-| P0 | complete | Pattern/Component Library read and validation, exact pin-to-pad checks, existing-pattern assignment, read-only Pattern Editor bridge | Existing patterns can be inspected and selected without claiming writer support |
-| P1 | next | Typed append-only feedback records: `record_pattern_example`, `accept_pattern_suggestion`, `reject_pattern_suggestion` | Accepted/rejected decisions persist with immutable IDs, document/library SHA, provenance, rationale, candidate list, and train/test split |
-| P2 | planned | Deterministic feature extraction and retrieval over accepted examples | Exact constraints filter invalid candidates; top-1/top-3 metrics run on a held-out set |
-| P3 | planned | Suggestion workflow integrated with capability discovery and transactions | The agent proposes ranked existing patterns, explains evidence, and never writes without an explicit existing-pattern operation |
-| P4 | planned | Controlled human correction capture from DipTrace exports | Before/after XML and optional screenshots are linked; XML plus manifest remain authoritative |
-| P5 | blocked | Native Pattern/Component Library writers and learning from corrected footprints | Items 1-2 below provide redistributable DipTrace 5.3 round-trip evidence and every writer passes open/save/re-export equivalence |
-| P6 | deferred | Optional fine-tuning/export pipeline | Only considered after dataset quality, held-out metrics, privacy controls, and retrieval baselines are established |
+| P0 | complete | Pattern/Component Library read/validation, exact pin-to-pad checks, existing-pattern assignment, read-only Pattern Editor bridge | Existing patterns can be inspected and selected without writer claims |
+| P1 | planned after compatibility closure | typed append-only feedback: `record_pattern_example`, `accept_pattern_suggestion`, `reject_pattern_suggestion` | immutable decision records with document/library SHA, provenance, rationale, candidates, train/test split |
+| P2 | planned | deterministic feature extraction and retrieval | exact constraints remove invalid candidates; top-1/top-3 metrics run on held-out data |
+| P3 | planned | ranked suggestion workflow integrated with capabilities | agent explains ranked existing patterns and never mutates a library implicitly |
+| P4 | planned | controlled human correction capture | before/after XML and optional screenshots are linked; XML + manifest remain authoritative |
+| P5 | blocked by real writer evidence | native Pattern/Component Library writers | every writer passes controlled DipTrace 5.3 import and open/save/re-export equivalence |
+| P6 | deferred | optional fine-tuning/export pipeline | considered only after retrieval baseline, held-out metrics, privacy controls, and dataset quality are established |
 
-The P1 record is append-only and local by default. User projects, datasheets, screenshots,
-and library XML are never committed to this repository automatically. Each record must
-include enough immutable context to reproduce the decision without trusting free-form
-claims: normalized package features, source hashes, selected pattern identity, rejected
-alternatives, decision reason, provenance, and validation result.
+The feedback dataset should be append-only and local by default. User projects, datasheets, screenshots, and library XML must never be committed automatically. Each record should preserve reproducible normalized package features, source hashes, chosen pattern, rejected alternatives, rationale, provenance, and validation outcome.
 
-P2 starts with deterministic retrieval rather than embeddings or fine-tuning: filter by
-pad count/type, pitch, body dimensions, mounting/hole requirements, thermal-pad needs,
-and side constraints; then rank the remaining examples by normalized geometry distance.
-The baseline metrics are top-1 accuracy, top-3 accuracy, rejection precision for invalid
-patterns, and manual-correction rate. The held-out set must never be used for retrieval
-or prompt examples during evaluation.
-
-P3 remains read-only with respect to Pattern Libraries. It may call the existing
-component pattern-assignment operation only when the selected pattern already exists and
-pin-to-pad validation passes. P5 cannot start merely because recommendation metrics are
-good; native writer work remains independently evidence-gated.
+Deterministic retrieval should begin with hard filters such as pad count/type, pitch, package/body dimensions, mounting holes, thermal-pad requirements, and side constraints, followed by normalized geometry-distance ranking. Baseline metrics are top-1 accuracy, top-3 accuracy, invalid-pattern rejection precision, and manual-correction rate.
 
 ## Remaining Evidence-Gated Work
 
-Two tracks remain. The pattern-recommendation track (P1-P4 above) can proceed without
-native library writers. The native-writer track remains evidence-gated: items 1 and 2
-below are deferred until suitable DipTrace 5.3 files can be produced, and item 3 is
-blocked by that evidence. The optional solver adapter in item 4 is implemented at the
-protocol/job layer, with only real-runtime acceptance evidence outstanding.
+### 1. Redistributable DipTrace 5.3 Fixture Pack — highest priority
 
-### Local Corpus and Bridge Audit — 2026-07-22
+Add a small non-proprietary fixture pack exported by the current DipTrace 5.3 branch. Keep files byte-for-byte as exported; do not hand-normalize them before commit.
 
-An anonymous, local-only audit was run against 90 shallow repository checkouts selected
-from a private source index. The index is excluded through `docs/private/`; repository
-names, URLs, files, and derived fixtures are not stored in this project. The temporary
-checkouts are not a source of redistributable test data.
-
-The aggregate inventory contained 348 binary schematics and 452 binary boards. Binary
-magic identified all 51 `.eli` files as DipTrace component libraries and 22 of 78 `.lib`
-files as DipTrace pattern libraries; the other 56 `.lib` files belonged to unrelated
-software formats. Eighty-five XML files were inspected, but none had a native DipTrace
-XML root. Of 33 `.dsn` files, only two were textual
-Specctra PCB designs, neither carried a confirmed DipTrace generator marker, and no
-`.ses` file was present. This corpus is therefore useful for local compatibility and
-future export sampling, but it does not satisfy the XML, controlled before/after, or
-DSN/SES evidence gates below.
-
-The installed DipTrace 5.3.0.2 bridge was also exercised against vendor-installed local
-examples without retaining the exported XML. A complex four-layer PCB and a seven-sheet
-schematic both parsed without warnings. This confirms the general 5.3 reader path, but
-does not prove hierarchy, controlled mask/paste/courtyard semantics, copper refill
-before/after behavior, library round trips, or redistribution permission.
-
-The bridge installer now covers Component Editor and Pattern Editor as explicit read-only
-profiles using whole-library export with imports disabled. Both profiles were exercised
-against small vendor-installed 5.3.0.2 libraries: a 187-component export and a
-181-pattern export parsed without warnings. The pattern sample contained top-courtyard
-geometry, but no explicit mask/paste attributes or bottom-courtyard evidence. This
-removes the tooling gap for collecting local library evidence; it does not unblock
-writers until controlled, redistributable round-trip fixtures exist.
-
-### Synthetic Power Multilayer Pre-Fixture — 2026-07-22
-
-A wholly synthetic 70 × 50 mm four-layer source board now lives under
-`tests/fixtures/diptrace_5_3/power_multilayer/`. It was created through guarded MCP
-schematic-authoring, schematic-to-PCB synchronization, placement, trace and via
-operations. It covers Top/Inner 1/Inner 2/Bottom stackup parsing, mirrored and rotated
-Bottom components, seven named nets, five accessible testpoints/test pads, wide power
-routes, an Inner 1 GND route, a Top-only signal route, and a Top/Bottom signal route with
-two explicit through-via spans. Offline component clearance is clean; `SENSE` is the one
-intentional no-trace DRC finding and is reserved for real Freerouting.
-Trace commits now reconcile the exported ratline spanning forest, and trace deletion
-restores the affected pad-to-pad ratline before pruning cycles. Native-import testing exposed
-a second invariant from the official PCB XML specification: every component pad must carry
-the reciprocal `NetId` and `InternalConnection` attributes matching `Net/Pads/Item`. The
-compiler now writes those attributes during schematic-to-PCB synchronization, including
-explicit `NetId=-1` for unconnected pads. The pre-fixture was restored to the last revision
-confirmed to open in DipTrace, augmented only with reciprocal pad membership; ratline
-pruning is deferred until DipTrace 5.3 opens and re-exports this corrected source.
-
-This is preparation, not closure of the evidence gate. The source XML is MCP-generated
-format 4.3.0.3, and the directory deliberately contains only pending-manual instructions
-for the authoritative DipTrace 5.3.0.2 copper-pour before/after pair and real DSN/SES
-pair. Capability discovery reported DSN export unavailable and no configured Freerouting
-adapter, while authoritative copper refill remains outside confirmed write semantics.
-The fixture pack remains incomplete until those four real artifacts are captured, hashed,
-re-imported and recorded in a schema-conforming final manifest.
-
-### 1. Redistributable DipTrace 5.3 Fixture Pack — Deferred
-
-Add a small synthetic, non-proprietary fixture pack exported by the current DipTrace
-5.3 branch. Keep the files exactly as exported; do not hand-normalize XML before it is
-committed. The target layout is:
+Target layout:
 
 ```text
 tests/fixtures/diptrace_5_3/
@@ -227,6 +206,8 @@ tests/fixtures/diptrace_5_3/
   libraries/patterns.xml
   schematic_roundtrip/<case>/before.xml
   schematic_roundtrip/<case>/after.xml
+  pcb_roundtrip/<case>/before.xml
+  pcb_roundtrip/<case>/after.xml
   specctra/source_board.xml
   specctra/input.dsn
   specctra/output.ses
@@ -234,132 +215,70 @@ tests/fixtures/diptrace_5_3/
 
 Required coverage:
 
-- a main schematic sheet, a nested hierarchy block, hierarchy connectors, and a global
-  net;
-- the same PCB immediately before and after a copper-pour refill, including at least one
-  cutout/island or thermal case when the GUI permits it;
-- a component library with a simple component, a multi-part component, custom fields,
-  and attached patterns;
-- a pattern library with SMD and through-hole pads, non-trivial graphics, and pin-to-pad
-  mapping evidence;
-- controlled schematic before/after pairs where each pair changes one feature only:
-  part placement, wire/connectivity, net label, property/value, or attached pattern;
-- a real DSN/SES pair generated from the included PCB without editing the design between
-  DSN export and SES import; include a routed trace and a via/multi-layer case.
+- hierarchical multi-sheet schematic with hierarchy connectors and a global net;
+- controlled schematic writer pairs for placement, wire/connectivity, net label, property/value, and attached pattern;
+- controlled PCB writer pairs for representative component/property/rule/trace/via operations;
+- copper-pour before/after refill, including cutout/island or thermal behavior where possible;
+- Component Library with simple and multi-part components, custom fields, attached patterns;
+- Pattern Library with SMD/THT pads, non-trivial graphics, pin-to-pad mapping, courtyard, and mask/paste evidence;
+- real DSN/SES pair produced from the same board with at least one routed trace and multilayer/via case;
+- authored schematic wire and generated ratline open/save/re-export acceptance.
 
-The official examples installed under the user's DipTrace `Examples` directory should be
-used to bootstrap local 5.3 validation instead of recreating large designs. In particular,
-the `PCB_2`/`PCB_4`/`PCB_6`, `Differential_Pairs`, routed/unrouted, Banana Pi, CNC, and
-SPICE examples provide useful real schematic and PCB coverage. They are shipped as binary
-`.dch`/`.dip` files, so relevant cases must first be opened and exported/saved as native
-5.3 XML. This installed set does not contain component/pattern library fixtures, controlled
-single-setting before/after pairs, or DSN/SES files, and therefore cannot satisfy the
-evidence gate by itself. Treat exported derivatives as local validation data unless their
-redistribution terms are explicitly confirmed; committed fixtures must have clear
-redistribution permission.
+`manifest.json` must record exact DipTrace version/build, OS, export workflow, source type, units, SHA-256 for every file, intended before/after difference, and redistribution permission.
 
-Local bridge acceptance has now confirmed that representative installed PCB and
-multi-sheet Schematic examples export as XML `Version="5.3.0.2"` and parse without
-warnings. Those exports were not retained or committed, so the CI fixture requirement is
-unchanged.
+This item is complete when all four native source types parse, fixture-specific assertions pass, guarded SES import is exercised, writer cases survive DipTrace open/save/re-export, and CI can run the pack without DipTrace installed.
 
-`manifest.json` must record the exact DipTrace version/build, operating system, export
-workflow, source type, units, SHA-256 of every fixture, the intended semantic difference
-for each before/after pair, and confirmation that the files may be redistributed in the
-repository.
+### 2. Mask, Paste, Courtyard, and `Common` Verification
 
-This item is complete when all four native source types parse, fixture-specific semantic
-assertions pass, the real SES imports through the guarded preview path, and CI exercises
-the pack without requiring DipTrace to be installed.
+Capture focused 5.3 pattern-library and placed-PCB exports covering:
 
-### 2. Mask, Paste, Courtyard, and `Common` Verification — Deferred
-
-Add a focused 5.3 pattern-library export and a PCB export containing placed instances of
-the patterns. The evidence matrix must cover, where the DipTrace UI supports it:
-
-- top and bottom mask and paste settings;
-- `Common`, explicit zero, positive expansion, and negative reduction;
+- top/bottom mask and paste;
+- `Common`, explicit zero, positive expansion, negative reduction;
 - SMD and through-hole pads;
 - custom mask/paste shapes;
-- top and bottom courtyard geometry using lines, arcs, and polygons;
-- rotated, bottom-side, and mirrored placed components.
+- top/bottom courtyard lines, arcs, and polygons;
+- rotated, bottom-side, and mirrored components.
 
-For every ambiguous setting, capture two exports that differ by exactly one GUI value and
-record that value in the fixture manifest. Screenshots may be kept as supporting evidence,
-but machine-readable before/after exports and the manifest are authoritative.
+For ambiguous values, capture two exports differing by exactly one GUI setting. Machine-readable before/after XML plus manifest are authoritative; screenshots are supporting evidence only.
 
-This item is complete when the XML fields are mapped to typed model fields, transforms
-are verified on placed instances, unknown fields survive a guarded round trip, and tests
-prove the normalization behavior. The global `Common` policy must not be changed from
-inference alone; normalize it only after the 5.3 exports identify its exact semantics.
+### 3. Evidence-Gated Library Writers
 
-### 3. Evidence-Gated Library Writers — Blocked by Items 1-2
+After items 1-2:
 
-After items 1 and 2 supply round-trip evidence, implement native-XML mutation for:
+- create/update patterns;
+- create/update components, parts, pins, graphics, and custom fields;
+- attach patterns and maintain explicit pin-to-pad mapping;
+- preserve unknown/unsupported XML structures;
+- require explicit collision/replacement behavior;
+- use existing SHA/preview/commit/rollback transaction boundaries.
 
-- creating and updating patterns;
-- creating and updating components, parts, pins, graphics, and custom fields;
-- attaching a pattern to a component and maintaining explicit pin-to-pad mapping;
-- preserving unsupported and unknown XML structures instead of regenerating the whole
-  library from the reduced domain model.
+A writer is complete only when the result imports into DipTrace 5.3 without warnings, survives open/save/re-export semantically, repeated identical operation is idempotent, and `get_capabilities` registers it truthfully.
 
-Library writes must use the existing transaction boundary: confined workspace paths,
-expected source SHA, preview, commit/rollback, atomic replacement, reparsing, and
-post-write validation. Name collisions and replacement must be explicit; a writer must
-not silently overwrite an unrelated library item.
+### 4. Optional Real openEMS Acceptance
 
-This item is complete when every supported mutation has before/after fixture tests, the
-result imports into DipTrace 5.3 without warnings, a DipTrace open/save/re-export cycle is
-semantically equivalent, a second identical MCP operation produces no change, and
-capability discovery truthfully registers the new tools.
+The typed openEMS runner protocol, parsing, bounded jobs, failure handling, timeout handling, and synthetic CI backend are implemented. Remaining evidence is a captured real solver result and one configured integration run. Absence of the solver must continue to produce explicit unavailability rather than fallback/fabricated output.
 
-### 4. Optional Frequency-Dependent Field-Solver Adapter — Implemented v1
+## Existing 5.3 Evidence
 
-The openEMS runner adapter is implemented with a fixed typed JSON protocol. The MCP tool
-is registered, but runtime capability is available only when
-`DIPTRACE_MCP_OPENEMS_RUNNER` points to a compatible backend.
+A live DipTrace 5.3.0.2 schematic acceptance test has already verified source-SHA protection, backup equality, atomic write, 41 scoped `RefDesMarking` edits, bridge apply, independent DipTrace re-export, coordinate persistence, stable normalized object counts, and no new offline ERC errors.
 
-The typed request must include conductor geometry, stackup/material properties, trace
-offset, frequency sweep, and solver/mesh controls. The typed result must include the
-frequency vector, complex characteristic impedance, propagation constant, available loss
-terms, solver version, convergence/mesh metadata, logs, and generated artifacts.
+Representative installed 5.3 PCB and multi-sheet schematic examples have also parsed without warnings, as have small Component/Pattern Library exports through read-only bridge profiles. Those local exports were not retained as redistributable fixtures, so they improve confidence but do not close CI evidence gates.
 
-Implemented validation cases are:
+A synthetic four-layer `power_multilayer` pre-fixture exists for parser/operation regression. It must not be treated as proof of DipTrace 5.3 compatibility until the corresponding native-import/re-export artifacts are captured.
 
-- centered symmetric stripline checked against the existing analytical implementation;
-- off-center stripline that is explicitly unsupported by the closed-form implementation;
-- a multi-frequency sweep with a stored synthetic protocol fixture that is never presented
-  as real solver output;
-- unavailable executable, timeout, malformed output, and non-converged solver outcomes.
+## Closure Definition
 
-Execution uses an isolated job workspace, sanitized environment, fixed command arguments,
-explicit time/result/log limits, and the existing asynchronous job/error contracts. CI
-parses the synthetic protocol fixture and runs deterministic fake backends by default.
+The near-term roadmap closes in this order:
 
-Typed parsing, failure handling, portability, timeout, frequency binding, and centered
-analytical sanity tests are complete. A captured real-openEMS result and one configured
-integration run remain an acceptance-evidence task; they do not cause fallback or
-fabricated output when the solver is absent.
+1. eliminate the explicit write-path trust-invalidation gaps;
+2. commit the redistributable DipTrace 5.3 fixture pack;
+3. verify mask/paste/courtyard/`Common`, authored wires, ratlines, and real DSN/SES paths;
+4. implement and round-trip native library writers;
+5. implement P1-P3 pattern feedback/retrieval/recommendation and evaluate held-out metrics;
+6. add P4 correction capture;
+7. consider P6 fine-tuning only if deterministic retrieval has measurable limitations;
+8. capture optional real-openEMS acceptance evidence.
 
-## Roadmap Closure Definition
+Phase 12 remains partial until evidence-gated library writers exist. Phase 21 remains planned until the feedback/retrieval/recommendation workflow is implemented and measured.
 
-The committed implementation order is:
-
-1. implement P1 append-only feedback contracts and persistence;
-2. implement P2 deterministic retrieval plus held-out metrics;
-3. expose P3 ranked existing-pattern suggestions with truthful capabilities;
-4. collect P4 controlled corrections and native evidence;
-5. obtain the deferred fixture pack and verify mask/paste/courtyard policy;
-6. only then implement P5 native library writers and round-trip them through DipTrace.
-
-Phase 12 remains partial until the evidence-gated writer items pass. Phase 21 remains
-planned until P1-P3 are implemented and evaluated. A recommendation system is not allowed
-to claim footprint creation, native library mutation, or high-trust validation.
-
-The openEMS adapter is complete v1 at the protocol/job layer and gains solver-verified
-status only after a real captured integration run.
-
-Completion does not mean full DipTrace GUI equivalence. A native manufacturing adapter is
-excluded without a verified DipTrace API; generic manifests are not Gerber or NC Drill
-output. Full push-and-shove/global autorouting, GUI automation, and always-on online
-sourcing remain explicit product boundaries rather than unfinished roadmap items.
+Completion does not mean full DipTrace GUI equivalence. Full push-and-shove/global autorouting, GUI automation, native manufacturing generation without a verified DipTrace API, and always-on online sourcing remain explicit product boundaries rather than unfinished core milestones.

--- a/docs/SECURITY_AND_POLICY.md
+++ b/docs/SECURITY_AND_POLICY.md
@@ -5,18 +5,17 @@
 - paths resolve only within the workspace or explicitly allowed roots;
 - document, artifact, and log sizes are bounded;
 - `DOCTYPE` and `ENTITY` declarations are rejected;
-- UTF-8 handling is explicit, writes are atomic, backups are created, and results are reparsed;
+- UTF-8 handling is explicit, writes are atomic, backups are created, and modified XML is reparsed;
 - commits and rollbacks use SHA-256 optimistic concurrency;
-- locked objects are preserved by default;
-- only one live session may be active;
-- external processes use a fixed typed argument vector, `shell=false`, an isolated job
-  directory, bounded logs, a timeout, and cancellation; cancellation is terminal even if
-  process exit races with the worker state update;
-- the core does not use the network or execute arbitrary shell commands supplied by an LLM.
+- locked objects are preserved by default unless an operation explicitly allows otherwise;
+- only one live DipTrace bridge session may be active;
+- external processes use fixed typed argument vectors, `shell=false`, isolated job directories, bounded logs/results, timeouts, and terminal cancellation;
+- the core does not expose arbitrary shell execution supplied by an LLM;
+- high-level write tools default to preview/dry-run behavior and must not silently convert unavailable capabilities into success.
 
 ## Policy Profiles
 
-Set the profile with `DIPTRACE_MCP_POLICY`:
+Set the active profile with `DIPTRACE_MCP_POLICY`:
 
 | Profile | Preview/plan | Commit | External execution | Native manufacturing |
 | --- | --- | --- | --- | --- |
@@ -24,21 +23,64 @@ Set the profile with `DIPTRACE_MCP_POLICY`:
 | `review` | yes | no | no | no |
 | `interactive_edit` | yes | yes | explicit typed tools | no |
 | `automation` | yes | yes | yes | no |
-| `manufacturing` | yes | yes | yes | yes |
+| `manufacturing` | yes | yes | yes | policy permits requests, but unsupported native outputs still fail |
 
-Generic BOM and release manifests are analysis artifacts, not native manufacturing
-outputs. A policy violation returns `policy_denied` with profile, operation, and dry-run
-details. Rollback is not blocked by policy because it restores a previously safe state.
+A policy profile grants permission; it does not create an implementation. Generic BOM/fabrication/assembly manifests are analysis artifacts, not native Gerber/NC Drill/ODB++/IPC-2581 outputs. Unsupported native requests return explicit capability errors.
+
+A policy violation returns `policy_denied` with profile, operation, and dry-run context. Rollback is not blocked by ordinary write policy because it restores a previously captured state.
+
+## Local Security Boundary
+
+The server is designed as a trusted local single-user engineering tool.
+
+Streamable HTTP listens on loopback by default. There is no built-in OAuth, multi-user isolation, or remote authentication. Exposing the HTTP endpoint outside the local machine requires a separate authenticated reverse proxy and is outside the core security model.
+
+Filesystem restrictions reduce accidental reach but do not make an LLM an engineering authority. A model can still request a structurally valid but electrically incorrect change. Visual review, ERC/DRC, and engineering judgment remain mandatory for consequential edits.
 
 ## Trust Boundary
 
-The server is a local single-user tool. Streamable HTTP listens on loopback by default;
-there is no built-in remote authentication. Exposing the port externally requires a
-separate reverse proxy and authentication layer and is outside the core security model.
+The trust model separates provenance from authority.
 
-Clients are not trust authorities. Runtime sidecars, user-supplied evidence, fixture
-manifests, matching hashes, and workspace-controlled JSON cannot self-mint high-trust
-validation. Evidence is bound to exact file roles/paths, source type, SHA-256, and a
-complete semantic comparison. Rollback revalidates restored provenance and evidence.
-High-trust promotion remains unavailable until an authenticated server-owned registry,
-signature verifier, or committed allowlist exists.
+Clients are not trust authorities. Runtime sidecars, user-supplied evidence, fixture manifests, matching hashes, and workspace-controlled JSON cannot self-mint `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified`.
+
+Evidence is bound to exact file roles/paths, source type, before/after SHA-256 values, and required semantic-comparison categories. Rollback reparses and revalidates restored provenance/evidence rather than trusting stale metadata.
+
+High-trust promotion remains unavailable until the project has an authenticated server-owned registry, signature verifier, or committed allowlist.
+
+## Write-Path Trust Invalidation
+
+Documentation must not claim that every possible write path has already proven identical trust-invalidation behavior.
+
+At the current baseline, `get_capabilities` explicitly reports that complete all-write-path invalidation coverage is not yet established. The remaining named paths are:
+
+- `plan_apply`;
+- `ses_import`;
+- `schematic_to_pcb_sync`;
+- `live_session_apply`.
+
+The security requirement for each path is fail-closed behavior: a mutation must not allow stale higher-trust evidence to remain effective, and rollback must not restore authority unless the restored document/evidence pair is revalidated successfully.
+
+Closing these paths is a compatibility/security priority in [ROADMAP.md](ROADMAP.md).
+
+## External Process Boundary
+
+Freerouting, ngspice, and openEMS integrations are explicit typed adapters rather than generic command execution.
+
+Required properties include:
+
+- executable/configuration selected by server settings rather than model-supplied shell fragments;
+- `shell=false`;
+- isolated job workspace;
+- sanitized/bounded environment and arguments;
+- explicit timeout, result-size, and log-size limits;
+- structured status/result parsing;
+- terminal cancellation semantics;
+- explicit `external_tool_unavailable`, timeout, malformed-output, or non-convergence failures instead of fabricated fallback output.
+
+A configured external adapter may still be unavailable for the active document if required geometry, stackup data, or source artifacts are missing.
+
+## Manufacturing Boundary
+
+The `manufacturing` policy profile is not evidence that native manufacturing generation exists. The current core can prepare/review bounded generic manifests and artifacts, but native Gerber/NC Drill/ODB++/IPC-2581 generation is outside the verified capability set.
+
+The project must continue to fail explicitly rather than produce a file that merely looks like a manufacturing artifact without a verified writer/API.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,7 @@
 # Testing
 
+The test strategy intentionally separates implementation correctness from real-DipTrace compatibility evidence. A green unit/CI matrix proves the maintained contracts and fixtures; it does not automatically promote every writer to DipTrace 5.3 round-trip verified status.
+
 ## Gates
 
 ```bash
@@ -10,94 +12,135 @@ mypy --no-incremental src/diptrace_mcp
 python benchmarks/benchmark_core.py --repeat 5 --patch-count 1000
 ```
 
-CI runs full pytest on Linux with Python 3.10, 3.12, and 3.13. Ruff, strict Mypy,
-and generated-skill checks run once on Linux/Python 3.12. macOS and Windows run full
-pytest plus CLI smoke tests on Python 3.12, and a separate Windows job builds and
-verifies a non-empty `diptrace_mcp_bridge.exe`. Core tests do not require DipTrace,
-Java, Freerouting, openEMS, or network access.
+CI responsibilities:
+
+- full pytest on Linux with Python 3.10, 3.12, and 3.13;
+- Ruff, strict Mypy, and generated-skill checks on Linux/Python 3.12;
+- full pytest plus CLI smoke tests on macOS/Python 3.12;
+- full pytest plus CLI smoke tests on Windows/Python 3.12;
+- native Windows build and non-empty verification of `diptrace_mcp_bridge.exe`.
+
+Core CI does not require DipTrace, Java/Freerouting, ngspice, openEMS, or network access.
 
 ## Coverage
 
-- secure parsing, units, stable IDs, transforms/mirroring/arcs/bounding boxes/spatial index;
+The maintained suite covers:
+
+- secure XML parsing, units, stable IDs, transforms, mirroring, arcs, bounding boxes, and spatial indexing;
 - normalized PCB, schematic, Component Library, and Pattern Library models;
-- preservation of unknown XML and semantic round-trips;
-- required-category PCB comparison of trace coordinates/order, widths, segment layers,
-  endpoints, via styles/spans, locks, and differential-pair membership;
-- required-category schematic comparison of sheets/hierarchy, parts, pins, pin-to-net
-  connectivity, wire geometry, labels, and buses;
-- byte-exact preservation of BOM, XML declaration, CRLF, empty tags, and unknown sections
-  outside low-level and semantic patch targets;
-- transaction state, SHA, preview, commit, rollback, and policy;
-- fail-closed trust authority tests: self-minted manifests, path/hardlink/symlink roles,
-  source-type/SHA binding, incomplete comparisons, and rollback with corrupt evidence;
-- component, text, rule, test-point, pattern, and group operations;
-- review registry and findings, silkscreen plans, and placement plans;
-- trace/via compiler, multi-layer 45-degree A*, explicit blind/full via spans, rejection
-  of unknown four-layer spans, and coupled-pair plus symmetric-via round-trips;
-- resolve_copper_layer / require_routing_layer / require_via_layer with synthetic 4-layer
-  PCB (Signal + Plane layers); plane-layer routing rejection, through-via spanning;
-- pattern validation with embedded pattern library (style/name/unique-name lookup,
-  pad mapping, external pattern rejection);
-- unknown format-version feature detection and preservation of optional or unknown XML;
-- exact GEOS DRC for rotated pads, DSN/SES, and mocked Freerouting jobs;
-- external-job cancellation behavior, including a deterministic Python 3.10 regression
-  for the process-exit race;
-- stackup, length/skew/differential-pair analysis, and single/coupled impedance golden cases;
-- typed openEMS runner protocol, synthetic result parsing, centered analytical sanity,
-  malformed/non-converged output, unavailable backend, and timeout handling;
-- return path and pour boundaries, BOM, and schematic/PCB comparison;
-- generic exports, CSV-injection protection, and MCP tool/resource/prompt contracts.
-- all 57 English PCB skill packages, strict result schemas and examples, actual MCP tool
-  mappings, dependency contracts, write-order guards, and false-success rejection.
+- preservation of unknown XML and raw bytes outside targeted semantic/raw patch regions;
+- byte-exact BOM/XML declaration/CRLF/empty-tag preservation where required;
+- transaction state, SHA preview/commit/rollback, policy, backups, and atomic writes;
+- fail-closed authority tests for self-minted manifests, path/hardlink/symlink aliases, source-type/SHA binding, incomplete semantic comparisons, and rollback with corrupt evidence;
+- PCB semantic comparison of components, pads, nets, trace coordinates/order, widths, segment layers, endpoints, via styles/spans, locks, and differential-pair membership;
+- schematic semantic comparison of sheets/hierarchy, parts, values/patterns, pins, pin-to-net connectivity, wire geometry, labels, and buses;
+- component, text, rule, test-point, existing-pattern assignment, and group operations;
+- review registry/findings, silkscreen plans, local placement plans, scoring, and legalization;
+- trace/via compiler, bounded multi-layer 45-degree A*, explicit via spans, unknown-span rejection, and coupled-pair routing;
+- plane-layer routing rejection and through-via spanning across plane layers;
+- congestion-aware multi-net ordering and bounded batch-local rip-up/retry;
+- pattern validation, embedded pattern lookup, pad mapping, and external-pattern rejection;
+- unknown format-version feature detection and unknown/optional XML preservation;
+- exact optional GEOS DRC for rotated pads;
+- DSN/SES bounded parsing/import logic and mocked Freerouting jobs;
+- external-job state, timeout, log bounds, malformed output, and terminal cancellation behavior;
+- stackup, length/skew/differential-pair analysis, and analytical impedance golden cases;
+- typed openEMS runner protocol, synthetic result parsing, centered analytical sanity checks, unavailable backend, malformed/non-converged output, and timeout handling;
+- return-path/pour-boundary heuristics, BOM review, schematic/PCB comparison, and generic exports;
+- CSV-injection protection;
+- MCP tool/resource/prompt contracts;
+- generated PCB skill packages, strict schemas/examples, dependency contracts, write-order guards, and false-success rejection.
 
-`tests/test_skill_packages.py` is the only executable skill test suite. The
-`skills/*/evals/scenarios.json` and `skills/*/evals/assertions.json` files are generated
-behavioral fixtures consumed by that suite. `scripts/generate_pcb_skills.py --check`
-separately rejects package drift from the catalog and capability maps.
+## MCP Protocol Coverage
 
-## Benchmarks
+The test suite establishes an in-memory MCP client/server session and verifies that representative tools, resources, and prompts are actually registered and callable rather than only documented. This includes read/query, transactions, placement, routing, differential-pair, export, external-job, and capability surfaces.
 
-`benchmarks/benchmark_core.py` emits JSON timings for parsing/model creation, indexing,
-bounding-box queries, clearance review, placement candidates, one-net routing, SVG
-rendering, and semantic patches. Unit tests do not enforce timing thresholds. The
-benchmark is intended for revision comparisons and large-fixture runs, not unstable CI
-pass/fail decisions based on wall-clock time.
+`get_capabilities` remains the runtime source of truth; tests must reject documentation-style false success for unavailable capabilities.
 
-## Remaining Fixture Gaps
+## Real DipTrace Acceptance Already Completed
 
-- a redistributable real-world hierarchical multi-sheet schematic;
-- a dense multilayer PCB with exact mask, paste, courtyard, and refill polygons;
-- multiple native XML versions and real DSN/SES pairs;
-- an optional real Freerouting test matrix;
-- a captured real-openEMS SI golden result (the committed protocol fixture is explicitly
-  synthetic).
+A live acceptance test with DipTrace 5.3.0.2 separately verified:
 
-A live acceptance test with DipTrace 5.3 separately verifies the source SHA guard, 41
-bounded schematic-marking patches, backup equality, atomic write, bridge apply, and an
-independent DipTrace re-export. All 41 coordinates survived the application round-trip;
-normalized design counts and offline ERC severity counts remained unchanged. The
-rebuilt Windows bridge also passes an isolated cross-process headless finish-request
-test that verifies metadata/control publication, cleanup, and exchange-file integrity.
+- source-SHA conflict protection;
+- backup equality;
+- atomic write behavior;
+- 41 bounded schematic `RefDesMarking` edits on the Power sheet;
+- bridge apply followed by an independent DipTrace re-export;
+- persistence of all 41 coordinates;
+- unchanged normalized sheet/part/pin/net/bus/differential-pair counts;
+- no new offline ERC errors after the round trip.
 
-User projects are not added to repository fixtures without explicit permission. A
-permitted 5.3 fixture is still required to automate this acceptance path in CI.
+The rebuilt Windows bridge also passes isolated cross-process finish-request tests covering metadata/control publication, cleanup, and exchange-file integrity.
+
+This acceptance evidence is valuable but intentionally scoped. The user project used for the live test is not redistributed, so the same path is not yet automated in public CI.
+
+## Highest-Priority Remaining Test Gaps
+
+### 1. All-write-path trust invalidation
+
+The capability report currently does not claim complete coverage. Explicitly listed paths still needing closure are:
+
+- `plan_apply`;
+- `ses_import`;
+- `schematic_to_pcb_sync`;
+- `live_session_apply`.
+
+The exit criterion is not merely a unit test for a helper. Each write path must prove that stale higher-trust evidence cannot survive a mutation or rollback transition incorrectly.
+
+### 2. Redistributable DipTrace 5.3 fixture pack
+
+CI still needs controlled, redistributable real-DipTrace fixtures for:
+
+- hierarchical multi-sheet schematic;
+- representative PCB 5.3 exports and writer before/after pairs;
+- Component Library and Pattern Library exports;
+- authored schematic wire before/after cases;
+- generated ratline before/after cases;
+- copper-pour before/after refill;
+- mask/paste/courtyard/`Common` one-setting-at-a-time evidence;
+- real paired DSN/SES artifacts.
+
+The fixture pack should be usable in CI without DipTrace installed and must include exact version/build, source role, SHA-256, intended semantic differences, and redistribution permission.
+
+### 3. Native library writer acceptance
+
+This remains blocked until the fixture/evidence items above exist. Every future Component/Pattern Library writer must prove:
+
+- controlled before/after semantics;
+- DipTrace 5.3 import without warnings;
+- open/save/re-export semantic equivalence;
+- preservation of unsupported/unknown XML;
+- idempotence on a second identical operation;
+- truthful capability registration.
+
+### 4. External-tool real-runtime evidence
+
+Optional remaining integration evidence includes:
+
+- a captured real-openEMS golden result and configured run;
+- a broader real Freerouting matrix where useful.
+
+Synthetic/fake backends remain the default deterministic CI mechanism and must never be presented as real solver output.
 
 ## Fixture Trust Model
 
-Test fixtures are classified by `validation_level`:
+Fixtures and evidence are classified by what they actually prove:
 
-- `synthetic_parser_only` — MCP-generated XML, tested only by the MCP parser.
-- `synthetic_operation_fixture` — MCP-generated XML, tested by parser + operations.
-- `diptrace_exported` — XML exported by DipTrace.
-- `diptrace_open_save_verified` — XML that DipTrace opened and saved.
-- `diptrace_roundtrip_verified` — XML that DipTrace opened, saved, and re-exported.
-- `external_tool_roundtrip_verified` — Same plus external tool round-trip.
+- `synthetic_parser_only` — MCP-generated XML tested by the MCP parser;
+- `synthetic_operation_fixture` — MCP-generated XML exercised by operations;
+- `diptrace_exported` — XML exported by DipTrace;
+- `diptrace_open_save_verified` — opened and saved by DipTrace;
+- `diptrace_roundtrip_verified` — opened, saved, re-exported, and semantically compared;
+- `external_tool_roundtrip_verified` — equivalent evidence including an external tool.
 
-User-controlled manifests and sidecars cannot grant `diptrace_roundtrip_verified` or
-higher at all. CI rejects self-minted high trust, missing required comparison categories,
-path/source-type/SHA mismatches, and semantic differences. Future high-trust promotion
-requires an authenticated server-owned registry, signature verifier, or committed
-allowlist in addition to exact DipTrace version and round-trip evidence.
+User-controlled manifests/sidecars cannot grant high trust. Future high-trust promotion requires an authenticated server-owned registry, signature verifier, or committed allowlist in addition to exact version and semantic evidence.
 
-The `power_multilayer` fixture is classified as `synthetic_operation_fixture` and must
-not be used as evidence of DipTrace 5.3 compatibility.
+The synthetic `power_multilayer` fixture is an operation fixture, not proof of DipTrace 5.3 compatibility.
+
+## Benchmarks
+
+`benchmarks/benchmark_core.py` reports timings for parsing/model creation, indexing, bounding-box queries, clearance review, placement candidates, one-net routing, SVG rendering, and semantic patches.
+
+Wall-clock thresholds are deliberately not CI pass/fail gates. The benchmark is intended for regression comparison and large-fixture analysis, where deterministic functional correctness remains the primary gate.
+
+See [ROADMAP.md](ROADMAP.md) for the acceptance order and [XML_COMPATIBILITY.md](XML_COMPATIBILITY.md) for the compatibility matrix.

--- a/docs/XML_COMPATIBILITY.md
+++ b/docs/XML_COMPATIBILITY.md
@@ -1,128 +1,132 @@
 # XML Compatibility
 
+DipTrace MCP uses feature detection, raw-preserving patches, and explicit evidence levels rather than assuming compatibility from a file extension or application version alone.
+
+The runtime source of truth is `get_capabilities`. This document describes the maintained compatibility baseline, not a promise that every XML object in every DipTrace build has been round-trip verified.
+
 ## Supported Source Types
 
-- `DipTrace-PCB`
-- `DipTrace-Schematic`
-- `DipTrace-ComponentLibrary` — normalized reading and validation for the tested 4.3 fixture.
-- `DipTrace-PatternLibrary` — normalized reading and validation for the tested 4.3 fixture.
+- `DipTrace-PCB`;
+- `DipTrace-Schematic`;
+- `DipTrace-ComponentLibrary`;
+- `DipTrace-PatternLibrary`.
+
+Standalone Component/Pattern Libraries are currently supported for normalized reading and validation. Native library mutation remains evidence-gated and is not registered as a normal capability.
 
 ## Official Format Evidence
 
-- [PCB XML specification](https://www.diptrace.com/books/DipTraceXML_Pcb_En.pdf)
-- [Schematic XML specification](https://diptrace.com/books/DipTraceXML_Schematic_En.pdf)
-- [Component Editor XML specification](https://www.diptrace.com/books/DipTraceXML_CompEdit_En.pdf)
-- [Pattern Editor XML specification](https://www.diptrace.com/books/DipTraceXML_PattEdit_En.pdf)
-- [DipTrace plug-ins specification](https://diptrace.com/books/DipTrace_Plugins.pdf)
+The implementation is constrained by the official DipTrace XML and plug-in specifications plus controlled observed exports. The maintained references include PCB, Schematic, Component Editor, Pattern Editor, and executable plug-in XML documentation.
 
-`Version` is preserved in document identity and the compatibility report, but it is not
-the only gate. The reader uses feature detection, tolerates omitted optional/default
-parameters, and preserves unknown sections. Each write operation separately verifies
-the fields it requires.
+`Version` is preserved in document identity and compatibility reports, but it is not the sole compatibility gate. Readers use feature detection, tolerate documented optional/default fields, preserve unknown sections, and require each writer to validate the structures it needs.
 
-A live import/re-export acceptance run with DipTrace 5.3 confirms that real Schematic
-XML may use `Version="5.3.0.2"`, while the publicly available specifications and some
-examples still use `4.3.0.3`. Component and Pattern Library documents have been observed
-with `5.3.0.0` and embedded legacy versions. The application version and the XML
-`Version` value are not treated as interchangeable.
+A live import/re-export acceptance run with DipTrace 5.3 has confirmed real Schematic XML using `Version="5.3.0.2"`. Component and Pattern Library exports have also been observed from DipTrace 5.3, while some public specification examples remain 4.3-era. Application version and XML `Version` are therefore treated as related but non-equivalent evidence.
 
 ## Implemented Readers
 
-- XML root validation for `<Source>` and official standalone `<Library>` roots.
-- Rejection of `DOCTYPE` and `ENTITY` declarations.
-- PCB outline, components, pads, holes, nets, ratlines, copper layers, physical stackup, and rules.
-- Trace arcs, segment width and layer, vias, pour boundaries, text, keepouts, and differential pairs.
-- Schematic sheets, parts, pins, nets, fixture-covered wires, buses, and ERC blobs.
-- Component Library parts, pins, fields, attached patterns, and pin-to-pad mapping.
-- Pattern pad styles, pads, holes, shapes, mask/paste metadata, and 3D references.
+- `<Source>` and official standalone `<Library>` root validation;
+- rejection of `DOCTYPE` and `ENTITY` declarations;
+- PCB outline, components, pads, holes, nets, ratlines, copper layers, physical stackup, and rules;
+- trace arcs, segment width/layer, vias, pour boundaries, text, keepouts, and differential pairs;
+- schematic sheets, parts, pins, nets, fixture-covered wires, labels, buses, hierarchy records, and ERC data;
+- Component Library parts, pins, fields, attached patterns, and pin-to-pad mapping;
+- Pattern Library pad styles, pads, holes, shapes, mask/paste metadata, courtyard-related geometry where present, and 3D references;
+- unknown/unsupported XML remains accessible through raw XML inspection and is preserved outside targeted patches.
 
 ## Implemented Writers
 
-- New document scaffolding: `create_schematic_document` and `create_pcb_document`
-  generate official-structure XML (sheets, outline, layers, stackup, via styles, net
-  classes, DRC) and validate it by parsing before writing.
-- Low-level XML edits through `apply_xml_edits`.
-- Semantic component, part, pattern, group, text, schematic no-connect/net, NetClass, and
-  test-point edits.
-- Schematic authoring: sheets, part placement, pin/net connectivity, official
-  `<Net>/<Wires>/<Wire>/<Points>` wires, and net-bound text labels.
-- Additive schematic-to-PCB authoring: PCB components, embedded pattern/pad-style subtrees,
-  net pad endpoints, and ratlines. Pattern-library units must match PCB units; multi-part
-  pin-to-pad mapping must be explicit when it cannot be proven from XML.
-- Official PCB `<Panel>` panelization parameters (V-Scoring / Tab Routing).
-- Official PCB `<Net>/<Traces>/<Trace>/<Points>/<Point>` patches for trace and via primitives.
-- Atomic coupled-pair patches: two traces plus `DifferentialPairs/Segments/Segment`.
-- Atomic write, backup, and reparse after writing.
+- synthetic document scaffolding through `create_schematic_document` and `create_pcb_document`;
+- seed-based copies through `create_document_from_seed`;
+- low-level guarded XML edits through `apply_xml_edits`;
+- semantic component, part, pattern-assignment, group, board-text, schematic property/no-connect/net, NetClass, and test-point edits;
+- schematic authoring: sheets, part placement, logical pin/net connectivity, official `<Net>/<Wires>/<Wire>/<Points>` wires, and net-bound labels;
+- additive and guarded exact schematic-to-PCB synchronization, including PCB components, embedded pattern/pad-style subtrees, pad membership, nets, ratlines, and explicit multi-part pin mapping where inference is insufficient;
+- official PCB `<Panel>` parameters for V-Scoring / Tab Routing;
+- official PCB trace/via structures and coupled differential-pair segment metadata;
+- atomic writes, backups, SHA conflict protection, and reparsing after modification.
 
-## Layer Resolution
+## Compatibility and Evidence Levels
 
-Copper layers are resolved by case-insensitive name or exact id match via
-`resolve_copper_layer()`. The resolved layer includes `layer_id`, `layer_name`,
-and `layer_type` (Signal, Plane, or Unknown). Routing operations use
-`require_routing_layer()` to reject active trace segments on Plane layers;
-through-via spans across Plane layers are permitted. Via transitions use
-`require_via_layer()` which rejects Plane layers but allows Unknown types.
+A parser success is not equivalent to a real DipTrace writer round trip. The project distinguishes:
+
+- `synthetic_parser_only` — MCP-generated XML accepted by the MCP parser;
+- `synthetic_operation_fixture` — MCP-generated XML exercised by semantic operations;
+- `diptrace_exported` — XML exported by DipTrace;
+- `diptrace_open_save_verified` — file opened and saved by DipTrace;
+- `diptrace_roundtrip_verified` — controlled open/save/re-export evidence with semantic comparison;
+- `external_tool_roundtrip_verified` — equivalent evidence including an external tool path.
+
+User-controlled manifests, sidecars, labels, or hashes cannot mint high-trust levels by themselves.
 
 ## Compatibility Matrix
 
-| Source | Read | Write | Round-trip |
+| Source | Read | Write | Evidence status |
 | --- | --- | --- | --- |
-| PCB XML 4.3.0.3 synthetic fixture | yes | partial semantic writes | tested objects plus preservation of unknown XML |
-| PCB XML 5.3.0.2 installed example | yes; local bridge acceptance | not mutated | complex four-layer design parsed without warnings; redistributable fixture pending |
-| Other DipTrace 5.x XML | feature-detected | per-operation evidence gate | preserve unknown XML; a matching fixture is preferred |
-| Schematic XML 4.3.0.3 synthetic fixture | yes | partial semantic writes | tested objects plus preservation of unknown XML |
-| Schematic XML 5.3.0.2 live project | yes | bounded raw/semantic writes | manual bridge apply and independent DipTrace re-export verified |
-| Schematic XML 5.3.0.2 installed example | yes; local bridge acceptance | not mutated | seven-sheet design parsed without warnings; hierarchy not proven |
-| Component Library XML 4.3 fixture | yes | expert XML only | read/validate plus preservation of unknown XML |
-| Pattern Library XML 4.3 fixture | yes | expert XML only | read/validate plus preservation of unknown XML |
-| Component Library XML 5.3.0.2 installed example | yes; local bridge acceptance | unavailable | 187-component library parsed without warnings; redistributable fixture pending |
-| Pattern Library XML 5.3.0.2 installed example | yes; local bridge acceptance | unavailable | 181-pattern library parsed without warnings; redistributable fixture pending |
-| Other Component/Pattern Library XML 5.3.x | feature-detected | unavailable | preserve unknown XML; matching fixtures preferred |
-| DSN/SES fixtures | bounded subset | semantic SES import | tested bounded subset |
+| PCB XML 4.3.0.3 synthetic fixtures | yes | partial semantic writes | parser/operation regression coverage; unknown XML preserved |
+| PCB XML 5.3.0.2 installed examples | yes | not broadly mutation-verified | complex multilayer examples parsed locally; redistributable round-trip fixtures still needed |
+| Other DipTrace 5.x PCB XML | feature-detected | per-operation | preserve unknown XML; matching fixture preferred |
+| Schematic XML 4.3.0.3 synthetic fixtures | yes | partial semantic writes | parser/operation regression coverage |
+| Schematic XML 5.3.0.2 live project | yes | bounded raw/semantic writes | real bridge apply + independent DipTrace re-export verified for scoped marking edits |
+| Schematic XML 5.3.0.2 installed examples | yes | not broadly mutation-verified | multi-sheet examples parsed locally; hierarchy/writer fixture coverage still incomplete |
+| Component Library XML 4.3 fixture | yes | expert raw XML only | normalized read/validate + unknown preservation |
+| Pattern Library XML 4.3 fixture | yes | expert raw XML only | normalized read/validate + unknown preservation |
+| Component Library XML 5.3 local export | yes | unavailable as native writer | local read-only bridge acceptance; redistributable fixture pending |
+| Pattern Library XML 5.3 local export | yes | unavailable as native writer | local read-only bridge acceptance; redistributable fixture pending |
+| Other 5.3.x libraries | feature-detected | unavailable | preserve unknown XML; matching fixtures preferred |
+| DSN/SES bounded subset | yes | guarded SES import | synthetic/mocked regression coverage; real paired DipTrace fixture still required |
 
-## Notes
+## Known Writer Evidence Gaps
 
-- Unknown XML sections and original bytes outside targeted nodes are preserved by the
-  raw-patch compiler. Structural additions serialize only the new subtree. After reparse,
-  the semantic tree must match the compiled model.
-- Native binary `.dip` and `.dch` files are not parsed directly. Export them to DipTrace
-  XML first, unless the specific file is already stored as XML and begins with an
-  official DipTrace XML root.
-- PCB and Schematic golden fixtures are synthetic 4.3.0.3 fixtures derived from the
-  public official specifications. A real 5.3.0.2 schematic acceptance run preserved all
-  41 scoped marking coordinates and the normalized sheet/part/pin/net/bus/differential-
-  pair counts after DipTrace import and re-export. The user project is not redistributed,
-  so a permitted fixture is still required for automated 5.3 round-trip CI.
-- DipTrace canonicalized numeric values and derived fields during that re-export and
-  removed two unreferenced embedded Pattern records. Neither PatternStyle was referenced
-  by a part before or after import. Byte equality is therefore required across MCP
-  patching outside targets, but not across a subsequent DipTrace import/export cycle.
-- Segment parameters are written on the second point, as required by the official PCB XML specification.
-- Via-style geometry reads documented `Size`/`HoleSize` and observed
-  `Diameter`/`Hole` aliases. Explicit `Lay1`/`Lay2` values are normalized to an inclusive
-  physical layer span. An omitted span is accepted only on a two-layer board. On larger
-  stackups, automatic via routing is disabled until the span is known.
-- A copper-pour boundary is not interpreted as final refilled copper.
-- Schematic wire authoring follows the official specification structure; a live DipTrace
-  import/re-export acceptance run for authored wires is still pending, so the writer is
-  covered by synthetic round-trip tests only.
-- Library mutation remains unavailable until writer round-trip fixtures exist.
-- The installer includes read-only Component and Pattern Editor bridge profiles. They use
-  the official whole-library export mode with imports disabled, allowing local 5.3
-  inspection without implying writer or round-trip support.
-- **Synthetic MCP-generated XML** (from `create_schematic_document` or
-  `create_pcb_document`) has the correct XML structure but has not been verified by
-  DipTrace open/save. Use `create_document_from_seed` with a real DipTrace export when
-  compatibility is required.
-- **Plane layer routing** is not supported. Only Signal layers accept active trace
-  segments. Through-via spans across Plane layers are allowed.
-- **Ratline generation** follows the DipTrace XML structure but has not been verified
-  by DipTrace open/save/re-export. Synthetic scaffolding ratlines are experimental.
+The following are implemented but still need stronger real-DipTrace evidence before they should be described as broadly round-trip verified:
 
-## Version Baseline
+- authored schematic wires;
+- generated ratlines;
+- representative PCB semantic writes on DipTrace 5.3;
+- schematic-to-PCB synchronization across controlled 5.3 before/after fixtures;
+- SES import through a real DipTrace-produced DSN/SES pair;
+- Component/Pattern Library writers, which remain blocked and unregistered.
 
-The documentation and live acceptance path were reviewed against an installed DipTrace
-5.3 build exporting XML `Version="5.3.0.2"`. The official XML specification PDFs used
-by this project still show 4.3-era examples, so compatibility claims remain
-feature-based and fixture-based rather than inferred solely from the application
-version number.
+The trust layer also currently reports incomplete all-path invalidation coverage for `plan_apply`, `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`. This is a trust/evidence gap, not permission to silently claim higher compatibility.
+
+## Mask, Paste, Courtyard, and `Common`
+
+The parser already models significant mask/paste and pattern geometry, but some DipTrace 5.3 semantics remain evidence-gated. Controlled exports are still required for:
+
+- top/bottom mask and paste;
+- `Common` versus explicit values;
+- zero, positive expansion, and negative reduction;
+- custom mask/paste shapes;
+- SMD and through-hole pads;
+- top/bottom courtyard lines, arcs, and polygons;
+- mirrored/rotated/bottom-side placed instances.
+
+The global `Common` policy must not be normalized from inference alone. One-setting-at-a-time DipTrace exports are the acceptance source.
+
+## Layer Resolution
+
+Copper layers are resolved by case-insensitive name or exact ID. The normalized result includes layer identity and type (`Signal`, `Plane`, or unknown).
+
+Routing requires active trace segments on routable signal layers. Plane layers are not accepted as active trace-routing layers, although through-via spans may cross plane layers. On multilayer boards, automatic via routing requires a confirmed span; an omitted span is accepted only in the explicitly supported two-layer case.
+
+## Preservation Rules
+
+- raw patches preserve original bytes outside targeted regions where the patch model permits;
+- structural additions serialize only the new subtree instead of regenerating the whole document;
+- unknown XML is preserved whenever the operation does not need to own that structure;
+- semantic post-parse checks compare the resulting model against the intended operation;
+- DipTrace itself may canonicalize numeric fields or derived structures on import/export, so byte equality is required for untouched MCP regions but not across an independent DipTrace round trip.
+
+A prior live schematic acceptance run observed DipTrace canonicalization and removal of unreferenced embedded pattern records. That behavior is treated as application canonicalization rather than proof that arbitrary reserialization is safe.
+
+## Binary and Native-XML Files
+
+Legacy binary `.dip`/`.dch` files are not parsed as binary project formats. Export them through DipTrace XML first.
+
+Some current `.dip`, `.dch`, `.eli`, or `.lib` files may already contain XML. Direct analysis is allowed only when the content passes official DipTrace XML root validation; the extension alone is not trusted.
+
+## Current 5.3 Baseline
+
+The maintained code and documentation were reviewed against an installed DipTrace 5.3.0.2 environment. A live schematic round trip preserved all 41 scoped marking-coordinate changes, stable normalized object counts, and offline ERC severity counts.
+
+Representative installed PCB, multi-sheet schematic, Component Library, and Pattern Library exports have also parsed without warnings through local bridge acceptance. Because those files are not committed as redistributable fixtures, they increase confidence but do not close automated CI evidence gates.
+
+See [ROADMAP.md](ROADMAP.md) for the fixture pack and writer-verification exit criteria.


### PR DESCRIPTION
## What changed

- rewrote `README_RU.md` against the current implementation and English baseline;
- refreshed `README.md` so public capability/trust claims match `get_capabilities`;
- reprioritized `docs/ROADMAP.md` around real DipTrace 5.3 compatibility evidence before new recommendation features;
- aligned `docs/MCP_TOOLS.md`, `docs/XML_COMPATIBILITY.md`, `docs/TESTING.md`, and `docs/SECURITY_AND_POLICY.md` with the current capability boundary;
- documented the explicit trust-invalidation coverage gaps for `plan_apply`, `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`;
- clarified that native library writers and native manufacturing outputs remain evidence-gated/unavailable;
- made authored schematic wires, generated ratlines, real DSN/SES, mask/paste/courtyard semantics, and redistributable DipTrace 5.3 fixtures first-class acceptance work.

## Why

The implementation has advanced faster than the public status documentation, especially the Russian README. Some docs also used stronger trust wording than the current capability layer actually claims. The revised documentation separates implemented code, runtime availability, and real DipTrace round-trip verification.

## Roadmap change

The near-term order is now:

1. close all-write-path trust invalidation gaps;
2. commit a redistributable DipTrace 5.3 fixture pack;
3. verify mask/paste/courtyard/Common, authored wires, ratlines, and real DSN/SES;
4. implement and round-trip native library writers;
5. then build the pattern feedback/retrieval/recommendation workflow;
6. treat fine-tuning and real-openEMS acceptance as later/optional work.

## Validation

Documentation-only change. The branch is based directly on current `main`; no production code or generated skill files were modified.