### PR TITLE
docs: remove stale serializer reference claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ See [the roadmap](docs/ROADMAP.md) for the current priority order and exit crite
 - component/part move, rotate, side, lock, property, pattern, alignment, distribution, and grouping operations;
 - board-text edits, documented NetClass rules, and standalone-pad test points;
 - Component/Pattern Library reading, validation, and pin-to-pad checks;
-- a machine-readable serializer reference for exact XML enums, defaults, aliases, and import semantics derived from supplied documentation archives; it is reference-only and cannot grant DipTrace round-trip trust;
 - registry-based offline DRC/ERC reviews with persistent structured findings;
 - deterministic silkscreen and bounded local placement planners;
 - explicit trace/via operations, bounded multi-layer 45-degree A*, and symmetric via insertion;
@@ -70,7 +69,7 @@ Synthetic 4.3 fixtures cover PCB, schematic, Component Library, Pattern Library,
 - persistence of all 41 coordinates and unchanged normalized sheet/part/pin/net/bus/differential-pair counts;
 - no new offline ERC errors after the round trip.
 
-This is strong evidence for the tested paths, not a claim of complete compatibility with every DipTrace version or XML object. The bundled serializer reference constrains parser behavior but does not replace real DipTrace open/save/re-export evidence.
+This is strong evidence for the tested paths, not a claim of complete compatibility with every DipTrace version or XML object.
 
 ## Architecture
 
@@ -195,7 +194,6 @@ The server distinguishes provenance from authority. A client may submit evidence
 - **Synthetic MCP-generated**: XML created by `create_schematic_document` or `create_pcb_document` is classified as `synthetic_parser_only` until stronger independently verified evidence exists.
 - **Seed-based**: XML copied by `create_document_from_seed` from a real DipTrace export preserves seed provenance but does not create round-trip authority.
 - **Recorded evidence**: `record_roundtrip_evidence` binds before/after files, exact paths, source type, SHA-256 values, and semantic comparison. User-supplied evidence is useful for audit/regression but is not a trusted root.
-- **Serializer reference**: the bundled rule set fingerprints and distills XML documentation. It constrains parser/writer implementation and tests but has no trust effect.
 - **High trust**: promotion to `diptrace_roundtrip_verified` or `external_tool_roundtrip_verified` is intentionally unavailable until the project has an authenticated server-owned registry, signature verifier, or committed allowlist.
 
 Trust invalidation is implemented for the main verified mutation paths, but the capability layer intentionally does **not** claim complete coverage for every write path yet. Current explicitly reported gaps are `plan_apply`, `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`. Closing these fail-closed trust paths is a near-term roadmap priority.

--- a/README_RU.md
+++ b/README_RU.md
@@ -32,7 +32,6 @@ DipTrace MCP — локальный Model Context Protocol сервер для �
 - move/rotate/side/lock/property/pattern/alignment/distribution/group operations для компонентов и частей;
 - board-text edits, документированные NetClass rules и standalone-pad test points;
 - чтение и validation Component/Pattern Libraries, включая pin-to-pad checks;
-- machine-readable serializer reference с XML enums, defaults, aliases и import semantics, извлечёнными из документации; reference ограничивает parser/writer поведение, но сам по себе не создаёт DipTrace round-trip trust;
 - registry-based offline DRC/ERC review с persistent structured findings;
 - deterministic silkscreen planner и bounded local placement planner;
 - explicit trace/via operations, bounded multi-layer 45-degree A* и symmetric via insertion;
@@ -68,7 +67,7 @@ Synthetic 4.3 fixtures покрывают PCB, schematic, Component Library, Pat
 - сохранение всех 41 координат и неизменность нормализованных количеств sheet/part/pin/net/bus/differential-pair;
 - отсутствие новых offline ERC errors после round trip.
 
-Это сильное доказательство для проверенных путей, но не обещание полной совместимости со всеми версиями DipTrace и всеми XML objects. Serializer reference дополнительно ограничивает parser behavior, но не заменяет реальные DipTrace open/save/re-export fixtures.
+Это сильное доказательство для проверенных путей, но не обещание полной совместимости со всеми версиями DipTrace и всеми XML objects.
 
 ## Архитектура
 
@@ -193,7 +192,6 @@ XML с `DOCTYPE` или `ENTITY` отклоняется. Доступ к фай�
 - **Synthetic MCP-generated**: XML из `create_schematic_document`/`create_pcb_document` имеет `synthetic_parser_only`, пока нет более сильного независимо проверенного evidence.
 - **Seed-based**: `create_document_from_seed` копирует реальный DipTrace export и сохраняет provenance, но копирование само по себе не создаёт round-trip authority.
 - **Recorded evidence**: `record_roundtrip_evidence` связывает before/after files, точные paths, source type, SHA-256 и semantic comparison. User-supplied evidence полезен для audit/regression, но не является trusted root.
-- **Serializer reference**: bundled rule set фиксирует и нормализует правила из XML documentation. Он ограничивает parser/writer implementation и tests, но не влияет на trust level.
 - **High trust**: повышение до `diptrace_roundtrip_verified`/`external_tool_roundtrip_verified` недоступно до появления authenticated server-owned registry, signature verifier или committed allowlist.
 
 Trust invalidation после MCP write реализован для основных проверенных путей, но capability layer намеренно **не заявляет полное покрытие всех write paths**. Отдельно остаются неполностью закрытыми `plan_apply`, `ses_import`, `schematic_to_pcb_sync` и `live_session_apply`; их полное fail-closed trust invalidation входит в ближайший roadmap. Поэтому `get_capabilities` имеет приоритет над более общими описаниями документации.

--- a/reference/diptrace-xml/REFERENCE.md
+++ b/reference/diptrace-xml/REFERENCE.md
@@ -1,7 +1,9 @@
 # DipTrace XML Implementation Reference
 
-This is the coding-agent summary of the machine-readable rules in
-`../../src/diptrace_mcp/data/serializer_reference.json`.
+This is a coding-agent guide to the extracted public
+[specification inventory](spec_inventory.json) and measured
+[format coverage](../../docs/FORMAT_COVERAGE.md). Missing or unknown entries remain unknown; this
+guide does not supply facts that the cited specifications do not state.
 
 ## Exchange lifecycle
 
@@ -19,7 +21,9 @@ when present. `Enabled="N"` is an import delete flag on objects that support it.
 
 - Root `Units`: `mm`, `inch`, `mil`.
 - Canonical decimal separator: dot.
-- Ordinary `Angle`: radians CCW.
+- `Shape/@Angle` for text and pictures: radians CCW.
+- `Component/@Angle`: assumed to be radians by the current code, but unverified; see
+  [OPEN_QUESTIONS.md Q1](../../docs/OPEN_QUESTIONS.md#q1-is-componentangle-in-radians-or-degrees).
 - Discrete `Orientation`: `0`, `90`, `180`, `270` where documented.
 - `Model3D/Rotate`: degrees.
 - Preserve unknown XML and existing IDs.
@@ -42,7 +46,7 @@ A fiducial is special:
 `MainStack/Height` is omitted; `Width` is copper diameter. `PadStyle/Hole` means fiducial keepout
 diameter rather than drill geometry.
 
-MainStack shapes documented by the supplied serializer reference are `Ellipse`, `Obround`,
+The public specification inventory records these MainStack shapes: `Ellipse`, `Obround`,
 `Rectangle`, `Polygon`, `D-shape`, and `Fiducial`.
 
 Mask modes: `Common`, `Open`, `Tented`, `By Paste`. Paste modes: `Common`, `Solder`, `No Solder`,

--- a/reference/diptrace-xml/SKILL.md
+++ b/reference/diptrace-xml/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diptrace-xml-reference
-description: "Reference skill for implementing, reviewing, or debugging DipTrace XML parsers, writers, plug-in exchange, and bridge behavior. Use it to resolve exact XML enums/defaults/import semantics before changing MCP code. It is reference-only and never grants DipTrace compatibility or round-trip trust."
+description: "Reference skill for implementing, reviewing, or debugging DipTrace XML parsers, writers, plug-in exchange, and bridge behavior. Consult the extracted public-spec inventory and measured coverage before changing MCP code, and preserve unknowns where the sources are silent."
 ---
 
 # DipTrace XML Reference
@@ -8,24 +8,28 @@ description: "Reference skill for implementing, reviewing, or debugging DipTrace
 ## Purpose
 
 Use this skill when changing the MCP's DipTrace XML parser/compiler, library adapters, bridge,
-fixture generator, semantic transactions, or any code that emits XML. The canonical machine rules
-are in `../../src/diptrace_mcp/data/serializer_reference.json`; read `REFERENCE.md` for a compact
-human-oriented map.
+fixture generator, semantic transactions, or any code that emits XML. Consult the extracted
+[specification inventory](spec_inventory.json), its measured
+[format coverage](../../docs/FORMAT_COVERAGE.md), and [REFERENCE.md](REFERENCE.md). These artifacts
+describe the public sources and current implementation coverage; they do not turn undocumented
+behavior into a fact.
 
 ## Trust boundary
 
-The supplied documents state that they were generated/verified against a DipTrace serializer
-repository revision 7276. This repository does not independently authenticate that claim. Treat
-them as `user_supplied_reference` with `trust_effect=none`.
+The inventory records source URLs, hashes, and page provenance from the public DipTrace
+specifications. That provenance does not authenticate behavior in a particular DipTrace build and
+does not replace open/save/re-export evidence.
 
-They may constrain parser/writer behavior and regression tests. They may not promote a document to
-`diptrace_exported`, `diptrace_open_save_verified`, or `diptrace_roundtrip_verified`, and they may
-not unblock native Pattern/Component Library writers without independent DipTrace 5.3 fixtures.
+The specifications may constrain parser/writer behavior and regression tests. They may not promote
+a document to `diptrace_exported`, `diptrace_open_save_verified`, or
+`diptrace_roundtrip_verified`, and they may not unblock native Pattern/Component Library writers
+without independent DipTrace 5.3 fixtures.
 
 ## Mandatory workflow
 
 1. Identify the exact XML dialect and element/attribute being changed.
-2. Look up the stable machine rule ID before implementing an enum/default/write condition.
+2. Look up the inventory entry and its cited source page before implementing an
+   enum/default/write condition; if the source is silent, record the gap as an open question.
 3. Check cross-cutting behaviors before touching import, deletion, IDs, or nested lists.
 4. Preserve unknown attributes/elements and existing IDs unless the semantic operation explicitly
    requires a change.
@@ -36,8 +40,10 @@ not unblock native Pattern/Component Library writers without independent DipTrac
 
 ## High-risk rules
 
-- Ordinary `Angle` values are radians counter-clockwise. Pin and Pattern `Orientation` are discrete
-  `0/90/180/270`; `Model3D/Rotate` is degrees.
+- `Shape/@Angle` for text and pictures is documented in radians counter-clockwise.
+  `Component/@Angle` is assumed to be radians by the current code but is unverified; see
+  [OPEN_QUESTIONS.md Q1](../../docs/OPEN_QUESTIONS.md#q1-is-componentangle-in-radians-or-degrees).
+  Pin and Pattern `Orientation` are discrete `0/90/180/270`; `Model3D/Rotate` is degrees.
 - `Enabled="N"` is an edit-import delete flag, not visibility.
 - Under `Edit`, keep an existing top-level object's `Id`; omit `Id` for a new object.
 - With a PCB/Schematic `Selected` import filter, unselected incoming objects are skipped entirely.

--- a/src/diptrace_mcp/library_adapters.py
+++ b/src/diptrace_mcp/library_adapters.py
@@ -509,9 +509,8 @@ def get_library_model(document: DipTraceDocument) -> LibraryModel:
         patterns=patterns,
         pad_styles=styles,
         warnings=[
-            "Parser coverage for newer library fields is constrained by the bundled "
-            "serializer-derived reference; unknown fields are preserved and real DipTrace "
-            "round-trip verification is still required."
+            "Parser coverage for newer library fields is incomplete; unknown fields are "
+            "preserved and real DipTrace round-trip verification is still required."
         ]
         if document.version and not document.version.startswith("4.3")
         else [],

--- a/tests/test_documentation_links.py
+++ b/tests/test_documentation_links.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+ROOT = Path(__file__).parents[1]
+_MARKDOWN_LINK = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
+_REFERENCE_LINK = re.compile(r"^\s*\[[^\]\n]+\]:\s*(\S+)", re.MULTILINE)
+_INLINE_CODE = re.compile(r"`([^`\n]+)`")
+_FENCE = re.compile(r"^\s*(```|~~~)")
+_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+_WINDOWS_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_LINE_SUFFIX = re.compile(r":\d+(?:-\d+)?$")
+_ROOT_PATH_PREFIXES = (
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "examples/",
+    "plugin/",
+    "reference/",
+    "scripts/",
+    "skills/",
+    "src/",
+    "tests/",
+)
+
+
+@dataclass(frozen=True)
+class MissingTarget:
+    source: Path
+    line: int
+    target: str
+    resolved: Path
+
+
+def _documentation_files(root: Path) -> list[Path]:
+    files = list(root.glob("*.md"))
+    for directory in ("docs", "reference"):
+        files.extend((root / directory).rglob("*.md"))
+    return sorted(set(files))
+
+
+def _non_fenced_lines(text: str) -> list[tuple[int, str]]:
+    result: list[tuple[int, str]] = []
+    fence: str | None = None
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        match = _FENCE.match(line)
+        if match:
+            marker = match.group(1)
+            if fence is None:
+                fence = marker
+            elif marker == fence:
+                fence = None
+            continue
+        if fence is None:
+            result.append((line_number, line))
+    return result
+
+
+def _markdown_target(raw: str) -> str:
+    value = raw.strip()
+    if value.startswith("<") and ">" in value:
+        return value[1 : value.index(">")]
+    return value.split(maxsplit=1)[0] if value else ""
+
+
+def _inline_repository_path(raw: str) -> str | None:
+    value = raw.strip().strip(".,;")
+    if not value or any(character.isspace() for character in value):
+        return None
+    if value.startswith(("./", "../", *_ROOT_PATH_PREFIXES)):
+        return value
+    return None
+
+
+def _candidate_target(raw: str) -> str | None:
+    value = unquote(raw.strip())
+    if not value or value.startswith(("#", "/", "~", "$", "%")):
+        return None
+    if _WINDOWS_PATH.match(value) or _SCHEME.match(value):
+        return None
+    value = value.split("#", 1)[0].split("?", 1)[0].split("::", 1)[0]
+    value = _LINE_SUFFIX.sub("", value)
+    if not value or any(character in value for character in "*{}[]"):
+        return None
+    return value
+
+
+def _resolve_target(root: Path, source: Path, raw: str, *, inline: bool) -> Path | None:
+    candidate = _candidate_target(raw)
+    if candidate is None:
+        return None
+    if inline and candidate.startswith(_ROOT_PATH_PREFIXES):
+        resolved = (root / candidate).resolve()
+    else:
+        resolved = (source.parent / candidate).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _missing_targets(root: Path, files: list[Path]) -> list[MissingTarget]:
+    missing: list[MissingTarget] = []
+    for source in files:
+        for line_number, line in _non_fenced_lines(source.read_text(encoding="utf-8")):
+            markdown_targets = [
+                _markdown_target(match.group(1))
+                for match in _MARKDOWN_LINK.finditer(line)
+            ]
+            markdown_targets.extend(
+                match.group(1) for match in _REFERENCE_LINK.finditer(line)
+            )
+            inline_targets = [
+                target
+                for match in _INLINE_CODE.finditer(line)
+                if (target := _inline_repository_path(match.group(1))) is not None
+            ]
+            for raw, inline in [
+                *((target, False) for target in markdown_targets),
+                *((target, True) for target in inline_targets),
+            ]:
+                resolved = _resolve_target(root, source, raw, inline=inline)
+                if resolved is not None and not resolved.exists():
+                    missing.append(
+                        MissingTarget(
+                            source=source,
+                            line=line_number,
+                            target=raw,
+                            resolved=resolved,
+                        )
+                    )
+    return missing
+
+
+def test_documentation_relative_targets_exist() -> None:
+    missing = _missing_targets(ROOT, _documentation_files(ROOT))
+
+    assert not missing, "\n".join(
+        f"{item.source.relative_to(ROOT)}:{item.line}: "
+        f"{item.target!r} -> {item.resolved}"
+        for item in missing
+    )
+
+
+def test_broken_relative_markdown_link_is_reported(tmp_path: Path) -> None:
+    document = tmp_path / "README.md"
+    document.write_text("[missing](docs/not-there.md)\n", encoding="utf-8")
+
+    missing = _missing_targets(tmp_path, [document])
+
+    assert [item.target for item in missing] == ["docs/not-there.md"]


### PR DESCRIPTION
WO-2 removes capability claims and runtime/documentation references to the deleted serializer reference, qualifies Component Angle as unverified, and adds a repository-wide relative Markdown link integrity gate. Verified by the full test and static-analysis suite.