### PR TITLE
metrics: measure XML coverage from parser calls

### DIFF
--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -5,89 +5,34 @@
 | Metric | Value |
 | --- | --- |
 | Total elements in spec | 294 |
-| Normalized (reader produces typed field) | 48 |
-| Written (writer can create/modify) | 66 |
-| Passthrough (unknown XML, kept byte-for-byte) | 180 |
-| **Coverage** | **38.8%** |
+| Normalized (reader produces typed field) | 61 |
+| Written only (writer can create/modify) | 22 |
+| Mentioned only (literal, not an XML call) | 20 |
+| Passthrough (unknown XML, kept byte-for-byte) | 191 |
+| **Coverage** | **28.2%** |
 
 ## Normalized Elements
 
-- `Assy`
-- `BoardClearance`
-- `BotSegments`
-- `Courtyard`
-- `DatasheetMarking`
-- `GNDTemplate`
-- `Id`
-- `Item`
-- `Lay`
-- `LayerName`
-- `LayerStackItems`
-- `LayerStackName`
-- `Library`
-- `LineWidth`
-- `ManufacturerMarking`
-- `Name`
-- `NameMarking`
-- `NegTrace`
-- `NetClass`
-- `Pad`
-- `PadId`
-- `Pads`
-- `Part`
-- `PartName`
-- `PartRefDes`
-- `PatternMarking`
-- `Pin`
-- `Pins`
-- `Point`
-- `Polygon`
-- `PosTrace`
-- `RefDes`
-- `RefDesMarking`
-- `Segments`
-- `Shape`
-- `Sheet`
-- `Silk`
-- `Size`
-- `Text`
-- `TopSegments`
-- `TraceWidth`
-- `Type`
-- `VCCTemplate`
-- `Value`
-- `ValueMarking`
-- `ViaStyle`
-- `X`
-- `Y`
-
-## Written Elements
-
-- `ActiveSheet`
 - `AddField`
 - `AddFields`
-- `Board`
 - `BoardOutline`
 - `Bus`
 - `Buses`
 - `CenterPoint`
 - `CenterPoints`
-- `Columns`
+- `ClearanceDetails`
 - `Component`
 - `Components`
 - `ConnectivityCheck`
 - `CopperLayers`
+- `CopperPour`
 - `CopperPours`
 - `DRC`
+- `DifferentialPair`
 - `DifferentialPairs`
 - `ERC`
-- `FontScale`
-- `FontSize`
-- `FontVector`
-- `FontWidth`
-- `Group`
-- `Groups`
-- `HorzTabsX`
+- `Item`
+- `Lay`
 - `LayClearance`
 - `LayClearances`
 - `LayProperties`
@@ -95,40 +40,88 @@
 - `LaySize`
 - `LaySizes`
 - `LayerStackItem`
+- `LayerStackItems`
+- `Library`
+- `MaskPaste`
 - `Material`
-- `NegPoint`
-- `NegPoints`
 - `Net`
+- `NetClass`
 - `NetClasses`
 - `Nets`
-- `Origin`
-- `Panel`
+- `Pad`
+- `PadPoint`
+- `PadPoints`
+- `Pads`
+- `Part`
+- `Pin`
+- `Pins`
+- `Point`
 - `Points`
-- `PosPoint`
-- `PosPoints`
 - `Ratline`
 - `Ratlines`
 - `Routing`
-- `Schematic`
 - `Segment`
+- `Segments`
 - `Settings`
+- `Shape`
 - `Shapes`
+- `Sheet`
 - `SheetSettings`
 - `Sheets`
-- `Show`
-- `Signal`
-- `Source`
-- `TextLine`
-- `TextLines`
 - `Trace`
-- `TraceClearance`
 - `Traces`
-- `VertTabsY`
-- `ViaHole`
-- `ViaSize`
+- `ViaStyle`
 - `ViaStyles`
 - `Wire`
 - `Wires`
+
+## Written-Only Elements
+
+- `ActiveSheet`
+- `Board`
+- `GNDTemplate`
+- `Group`
+- `Groups`
+- `Id`
+- `LayerName`
+- `LayerStackName`
+- `Name`
+- `Origin`
+- `Panel`
+- `PartName`
+- `PartRefDes`
+- `RefDes`
+- `Schematic`
+- `Source`
+- `Text`
+- `TextLine`
+- `TextLines`
+- `Type`
+- `VCCTemplate`
+- `Value`
+
+## Mentioned-Only Elements
+
+- `Assy`
+- `BotSegments`
+- `Columns`
+- `Courtyard`
+- `DatasheetMarking`
+- `HorzTabsX`
+- `ManufacturerMarking`
+- `NameMarking`
+- `NegPoint`
+- `NegPoints`
+- `PatternMarking`
+- `Polygon`
+- `PosPoint`
+- `PosPoints`
+- `RefDesMarking`
+- `Signal`
+- `Silk`
+- `TopSegments`
+- `ValueMarking`
+- `VertTabsY`
 
 ## Passthrough Elements
 
@@ -144,6 +137,7 @@
 - `AxisColor`
 - `BlindLay`
 - `BlockId`
+- `BoardClearance`
 - `Border`
 - `BorderZones`
 - `BottomComponentLock`
@@ -160,7 +154,6 @@
 - `Cell`
 - `Cells`
 - `ClassToClass`
-- `ClearanceDetails`
 - `ColWidths`
 - `Column`
 - `ColumnWidths`
@@ -168,7 +161,6 @@
 - `CompOutline`
 - `CompRotate`
 - `ConnectedTeardrops`
-- `CopperPour`
 - `CustomSpoke`
 - `CustomSpokes`
 - `DCTransferFunc`
@@ -177,7 +169,6 @@
 - `DesignCache`
 - `DesignError`
 - `DesignErrors`
-- `DifferentialPair`
 - `Dimension`
 - `Dimensions`
 - `DisplayName`
@@ -195,6 +186,10 @@
 - `FontColor`
 - `FontLineWidth`
 - `FontName`
+- `FontScale`
+- `FontSize`
+- `FontVector`
+- `FontWidth`
 - `GndNetName`
 - `Grid`
 - `HSheet`
@@ -218,21 +213,21 @@
 - `Lib`
 - `LibPath`
 - `Libs`
+- `LineWidth`
 - `LockNetStructure`
 - `MainLengthRule`
 - `ManufacturerGlobal`
 - `Markings`
-- `MaskPaste`
 - `NameGlobal`
 - `NegSeparateTraces`
+- `NegTrace`
 - `NodeSize`
 - `Noise`
 - `NonSignal`
 - `NonSignals`
 - `NumberOfPoints`
 - `OutputNet`
-- `PadPoint`
-- `PadPoints`
+- `PadId`
 - `PasteMaskShrink`
 - `Path`
 - `PatternGlobal`
@@ -243,6 +238,7 @@
 - `PointsPerSummary`
 - `Polygons`
 - `PosSeparateTraces`
+- `PosTrace`
 - `Position`
 - `ProjectDir`
 - `ProjectLibs`
@@ -267,11 +263,13 @@
 - `Separator`
 - `SheetHeight`
 - `SheetWidth`
+- `Show`
 - `ShowCompFiducials`
 - `ShowList`
 - `SignalDelayLength`
 - `Signals`
 - `Simulator`
+- `Size`
 - `SmallSignalAC`
 - `Snap`
 - `SolderMaskSwell`
@@ -298,6 +296,8 @@
 - `TopLeftBlock`
 - `TopMargin`
 - `TopRightBlock`
+- `TraceClearance`
+- `TraceWidth`
 - `Transient`
 - `UId`
 - `UpdateIds`
@@ -307,23 +307,34 @@
 - `Variation`
 - `VertBorderSize`
 - `VertZones`
+- `ViaHole`
+- `ViaSize`
 - `Visible`
+- `X`
 - `XPos`
+- `Y`
 - `YIdentical`
 - `YPos`
 - `YSize`
 
 ## What Passthrough Means
 
-Passthrough elements survive byte-for-byte **only** while no operation regenerates
-their parent subtree. The following operations regenerate whole subtrees and will
-destroy any passthrough data within them:
+Passthrough elements survive byte-for-byte **only** while no operation removes or
+regenerates their parent subtree. The list below is derived from writer call sites
+that iterate existing children and remove them. A value of `none` means no child
+currently classified as passthrough was named by the inventory or removal path; it
+does not make undocumented children safe.
 
-- `routing_compiler.py` `_write_points` — regenerates trace point lists
-- Ratlines rewrite — regenerates the entire `<Ratlines>` section
-- Copper pour refill (if implemented) — regenerates `<CopperPour>` content
+- `routing_compiler.py::_prune_satisfied_ratlines` may remove `<Ratline>` from `<Ratlines>`; known passthrough children: none.
+- `routing_compiler.py::_write_points` clears all children of `<Points>` (inventory children: `<Item>`, `<Point>`); known passthrough children: none.
+- `semantic_compiler.py::_apply_remove_testpoints` may remove `<PadStyle>` from `<PadStyles>`; known passthrough children: none.
+- `semantic_compiler.py::_apply_remove_testpoints` may remove `<Item>` from `<Pads>`; known passthrough children: none.
+- `semantic_compiler.py::_apply_remove_testpoints` may remove `<Pattern>` from `<Patterns>`; known passthrough children: none.
+- `semantic_compiler.py::_apply_sync_schematic_to_pcb` may remove `<Item>` from `<Pads>`; known passthrough children: none.
+- `semantic_compiler.py::_apply_sync_schematic_to_pcb` may remove `<Ratline>` from `<Ratlines>`; known passthrough children: none.
+- `semantic_compiler.py::_apply_ungroup_components` may remove `<Group>` from `<Groups>`; known passthrough children: none.
 
-Any edit to a passthrough element's parent container that triggers a full rewrite
-will silently lose the passthrough data. This is the expected behaviour: the tool
-only preserves what it understands.
+Any operation listed above can discard matching passthrough children rather than
+preserve their original bytes. Unlisted dynamic removal sites remain unavailable
+to this static detector and must not be assumed safe.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,10 +23,11 @@ The official DipTrace XML specifications (PCB and Schematic, v4.3.0.3, 2023) def
 | Metric | Value |
 | --- | --- |
 | Total elements in spec | 294 |
-| Normalized (reader produces typed field) | 48 |
-| Written (writer can create/modify) | 66 |
-| Passthrough (unknown XML, kept byte-for-byte) | 180 |
-| **Coverage** | **38.8%** |
+| Normalized (reader produces typed field) | 61 |
+| Written only (writer can create/modify) | 22 |
+| Mentioned only (literal, not an XML call) | 20 |
+| Passthrough (unknown XML, kept byte-for-byte) | 191 |
+| **Coverage** | **28.2%** |
 
 See [FORMAT_COVERAGE.md](FORMAT_COVERAGE.md) for the full element-by-element inventory, and [OPEN_QUESTIONS.md](OPEN_QUESTIONS.md) for facts the specification does not settle.
 

--- a/scripts/report_format_coverage.py
+++ b/scripts/report_format_coverage.py
@@ -11,10 +11,31 @@ from __future__ import annotations
 
 import argparse
 import ast
+import difflib
 import json
+import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+_READER_MODULES = frozenset(
+    {
+        "adapters.py",
+        "advanced_review.py",
+        "library_adapters.py",
+        "synchronization.py",
+    }
+)
+_WRITER_MODULES = frozenset(
+    {"routing_compiler.py", "scaffolding.py", "semantic_compiler.py"}
+)
+_READER_ELEMENT_METHODS = frozenset(
+    {"find", "findall", "findtext", "iter", "iterfind"}
+)
+_WRITER_ELEMENT_HELPERS = frozenset({"_named"})
+_XML_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]*$")
+_PATH_PREDICATE = re.compile(r"\[[^\]]*\]")
 
 
 def _load_inventory(inventory_path: Path) -> dict[str, Any]:
@@ -28,70 +49,265 @@ def _find_source_files(src_dir: Path) -> list[Path]:
     return sorted(src_dir.rglob("*.py"))
 
 
-def _extract_string_literals_from_file(filepath: Path) -> set[str]:
-    """Extract all string literals from a Python file using AST."""
-    try:
-        source = filepath.read_text(encoding="utf-8")
-        tree = ast.parse(source)
-    except (SyntaxError, UnicodeDecodeError):
+def _literal_string(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _qualified_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _qualified_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _xml_path_names(value: str) -> list[str]:
+    clean = _PATH_PREDICATE.sub("", value)
+    result: list[str] = []
+    for part in clean.split("/"):
+        name = part.strip()
+        if name in {"", ".", "..", "*"} or name.startswith("@"):
+            continue
+        if _XML_NAME.fullmatch(name):
+            result.append(name)
+    return result
+
+
+def _split_xml_path(value: str) -> set[str]:
+    """Return literal XML element names addressed by an ElementTree path."""
+    return set(_xml_path_names(value))
+
+
+def _dict_string_keys(node: ast.AST) -> set[str]:
+    if not isinstance(node, ast.Dict):
         return set()
-
-    strings: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            strings.add(node.value)
-    return strings
-
-
-def _check_element_in_source(
-    element_name: str,
-    all_strings: dict[str, set[str]],
-) -> tuple[bool, bool]:
-    """Check if an element name appears as a string literal in reader or writer code.
-
-    Returns (is_normalized, is_written).
-    """
-    # Reader modules (normalize/parse XML into domain objects)
-    reader_modules = {"adapters.py", "library_adapters.py", "synchronization.py"}
-    # Writer modules (produce XML from domain objects)
-    writer_modules = {"semantic_compiler.py", "routing_compiler.py", "scaffolding.py"}
-
-    is_normalized = False
-    is_written = False
-
-    for filename, strings in all_strings.items():
-        basename = filename.split("/")[-1]
-        if basename in reader_modules and element_name in strings:
-            is_normalized = True
-        if basename in writer_modules and element_name in strings:
-            is_written = True
-
-    return is_normalized, is_written
+    return {
+        value
+        for key in node.keys
+        if (value := _literal_string(key)) is not None
+    }
 
 
-def _check_attribute_in_source(
-    element_name: str,
-    attr_name: str,
-    all_strings: dict[str, set[str]],
-) -> tuple[bool, bool]:
-    """Check if an attribute name appears as a string literal in reader or writer code.
+@dataclass
+class UsageFacts:
+    read_elements: set[str] = field(default_factory=set)
+    read_attributes: set[str] = field(default_factory=set)
+    written_elements: set[str] = field(default_factory=set)
+    written_attributes: set[str] = field(default_factory=set)
+    all_literals: set[str] = field(default_factory=set)
+    call_argument_literals: set[str] = field(default_factory=set)
 
-    Returns (is_normalized, is_written).
-    """
-    reader_modules = {"adapters.py", "library_adapters.py", "synchronization.py"}
-    writer_modules = {"semantic_compiler.py", "routing_compiler.py", "scaffolding.py"}
+    @property
+    def bare_literals(self) -> set[str]:
+        return self.all_literals - self.call_argument_literals
 
-    is_normalized = False
-    is_written = False
 
-    for filename, strings in all_strings.items():
-        basename = filename.split("/")[-1]
-        if basename in reader_modules and attr_name in strings:
-            is_normalized = True
-        if basename in writer_modules and attr_name in strings:
-            is_written = True
+class XmlUsageVisitor(ast.NodeVisitor):
+    """Collect literal XML names from calls, keeping prose/literals separate."""
 
-    return is_normalized, is_written
+    def __init__(self) -> None:
+        self.facts = UsageFacts()
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            self.facts.all_literals.add(node.value)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        for argument in [*node.args, *(item.value for item in node.keywords)]:
+            for child in ast.walk(argument):
+                value = _literal_string(child)
+                if value is not None:
+                    self.facts.call_argument_literals.add(value)
+
+        qualified = _qualified_name(node.func)
+        method = node.func.attr if isinstance(node.func, ast.Attribute) else ""
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and method in _READER_ELEMENT_METHODS
+            and node.args
+        ):
+            path = _literal_string(node.args[0])
+            if path is not None:
+                self.facts.read_elements.update(_split_xml_path(path))
+        elif isinstance(node.func, ast.Attribute) and method == "get" and node.args:
+            attribute = _literal_string(node.args[0])
+            if attribute is not None and _XML_NAME.fullmatch(attribute):
+                self.facts.read_attributes.add(attribute)
+
+        tag_argument: ast.AST | None = None
+        attribute_arguments: list[ast.AST] = []
+        if qualified in {"ET.Element", "Element"} and node.args:
+            tag_argument = node.args[0]
+            attribute_arguments = list(node.args[1:])
+        elif qualified in {"ET.SubElement", "SubElement"} and len(node.args) >= 2:
+            tag_argument = node.args[1]
+            attribute_arguments = list(node.args[2:])
+        elif qualified in _WRITER_ELEMENT_HELPERS and node.args:
+            tag_argument = node.args[0]
+
+        tag = _literal_string(tag_argument)
+        if tag is not None and _XML_NAME.fullmatch(tag):
+            self.facts.written_elements.add(tag)
+        for argument in attribute_arguments:
+            self.facts.written_attributes.update(_dict_string_keys(argument))
+        for keyword in node.keywords:
+            if keyword.arg == "attrib":
+                self.facts.written_attributes.update(_dict_string_keys(keyword.value))
+
+        if isinstance(node.func, ast.Attribute) and method == "set" and node.args:
+            attribute = _literal_string(node.args[0])
+            if attribute is not None and _XML_NAME.fullmatch(attribute):
+                self.facts.written_attributes.add(attribute)
+
+        self.generic_visit(node)
+
+
+def _scan_source(source: str, *, filename: str = "<memory>") -> UsageFacts:
+    tree = ast.parse(source, filename=filename)
+    visitor = XmlUsageVisitor()
+    visitor.visit(tree)
+    return visitor.facts
+
+
+def _scan_file(path: Path) -> UsageFacts:
+    return _scan_source(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _partition_names(
+    names: set[str],
+    read: set[str],
+    written: set[str],
+    mentioned: set[str],
+) -> dict[str, list[str]]:
+    normalized = names & read
+    written_only = (names & written) - normalized
+    mentioned_only = (names & mentioned) - normalized - written_only
+    passthrough = names - normalized - written_only - mentioned_only
+    classes = {
+        "normalized": sorted(normalized),
+        "written": sorted(written_only),
+        "mentioned_only": sorted(mentioned_only),
+        "passthrough": sorted(passthrough),
+    }
+    class_sets = [set(values) for values in classes.values()]
+    assert set().union(*class_sets) == names
+    assert sum(len(values) for values in class_sets) == len(names)
+    return classes
+
+
+@dataclass(frozen=True, order=True)
+class ContainerRewrite:
+    module: str
+    function: str
+    container: str
+    removed_children: tuple[str, ...] | None
+
+
+def _assignment_container_tags(function: ast.FunctionDef) -> dict[str, str]:
+    tags: dict[str, str] = {}
+    for node in ast.walk(function):
+        target: ast.AST | None = None
+        value: ast.AST | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+            value = node.value
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
+            continue
+        qualified = _qualified_name(value.func)
+        method = value.func.attr if isinstance(value.func, ast.Attribute) else ""
+        tag: str | None = None
+        if method in {"find", "findall"} and value.args:
+            path = _literal_string(value.args[0])
+            names = _xml_path_names(path) if path is not None else []
+            if names:
+                tag = names[-1]
+        elif qualified in {"ET.Element", "Element"} and value.args:
+            tag = _literal_string(value.args[0])
+        elif qualified in {"ET.SubElement", "SubElement"} and len(value.args) >= 2:
+            tag = _literal_string(value.args[1])
+        if tag is not None and _XML_NAME.fullmatch(tag):
+            tags[target.id] = tag
+    return tags
+
+
+def _loop_removal(
+    function: ast.FunctionDef,
+    loop: ast.For,
+) -> tuple[str, tuple[str, ...] | None] | None:
+    if not isinstance(loop.target, ast.Name) or not isinstance(loop.iter, ast.Call):
+        return None
+    if _qualified_name(loop.iter.func) != "list" or len(loop.iter.args) != 1:
+        return None
+    selected = loop.iter.args[0]
+    container_variable: str | None = None
+    removed_children: tuple[str, ...] | None = None
+    if isinstance(selected, ast.Name):
+        container_variable = selected.id
+    elif (
+        isinstance(selected, ast.Call)
+        and isinstance(selected.func, ast.Attribute)
+        and selected.func.attr == "findall"
+        and isinstance(selected.func.value, ast.Name)
+        and selected.args
+    ):
+        container_variable = selected.func.value.id
+        path = _literal_string(selected.args[0])
+        if path is None:
+            return None
+        removed_children = tuple(sorted(_split_xml_path(path)))
+    if container_variable is None:
+        return None
+
+    removes_target = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "remove"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == container_variable
+        and bool(node.args)
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == loop.target.id
+        for node in ast.walk(loop)
+    )
+    if not removes_target:
+        return None
+    tags = _assignment_container_tags(function)
+    container = tags.get(container_variable)
+    if container is None:
+        return None
+    return container, removed_children
+
+
+def _container_rewrites(src_dir: Path) -> list[ContainerRewrite]:
+    rewrites: set[ContainerRewrite] = set()
+    for path in _find_source_files(src_dir):
+        if path.name not in _WRITER_MODULES:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for function in [
+            node for node in tree.body if isinstance(node, ast.FunctionDef)
+        ]:
+            for loop in [node for node in ast.walk(function) if isinstance(node, ast.For)]:
+                removal = _loop_removal(function, loop)
+                if removal is None:
+                    continue
+                container, children = removal
+                rewrites.add(
+                    ContainerRewrite(
+                        module=path.name,
+                        function=function.name,
+                        container=container,
+                        removed_children=children,
+                    )
+                )
+    return sorted(rewrites)
 
 
 def compute_coverage(
@@ -99,68 +315,68 @@ def compute_coverage(
     src_dir: Path,
 ) -> dict[str, Any]:
     """Compute format coverage by comparing spec inventory against source code."""
-    source_files = _find_source_files(src_dir)
-
-    # Extract all string literals from each file
-    all_strings: dict[str, set[str]] = {}
-    for filepath in source_files:
-        strings = _extract_string_literals_from_file(filepath)
-        all_strings[str(filepath)] = strings
-
     elements = inventory.get("elements", {})
+    read_elements: set[str] = set()
+    read_attributes: set[str] = set()
+    written_elements: set[str] = set()
+    written_attributes: set[str] = set()
+    mentioned: set[str] = set()
 
-    # Classify each element
-    normalized_elements: list[str] = []
-    written_elements: list[str] = []
-    passthrough_elements: list[str] = []
+    for path in _find_source_files(src_dir):
+        if path.name not in _READER_MODULES | _WRITER_MODULES:
+            continue
+        facts = _scan_file(path)
+        mentioned.update(facts.bare_literals)
+        if path.name in _READER_MODULES:
+            read_elements.update(facts.read_elements)
+            read_attributes.update(facts.read_attributes)
+        if path.name in _WRITER_MODULES:
+            written_elements.update(facts.written_elements)
+            written_attributes.update(facts.written_attributes)
 
-    # Also track attribute-level coverage
+    classes = _partition_names(
+        set(elements),
+        read_elements,
+        written_elements,
+        mentioned,
+    )
     element_attr_coverage: dict[str, dict[str, str]] = {}
-
     for elem_name, elem_data in sorted(elements.items()):
-        is_norm, is_written = _check_element_in_source(elem_name, all_strings)
-
-        if is_norm:
-            normalized_elements.append(elem_name)
-        elif is_written:
-            written_elements.append(elem_name)
-        else:
-            passthrough_elements.append(elem_name)
-
-        # Check attributes
+        attribute_names = set(elem_data.get("attributes", {}))
+        attribute_classes = _partition_names(
+            attribute_names,
+            read_attributes,
+            written_attributes,
+            mentioned,
+        )
         attr_coverage: dict[str, str] = {}
-        for attr_name in elem_data.get("attributes", {}):
-            a_norm, a_written = _check_attribute_in_source(elem_name, attr_name, all_strings)
-            if a_norm:
-                attr_coverage[attr_name] = "normalized"
-            elif a_written:
-                attr_coverage[attr_name] = "written"
-            else:
-                attr_coverage[attr_name] = "passthrough"
+        for status, values in attribute_classes.items():
+            attr_coverage.update(dict.fromkeys(values, status))
         element_attr_coverage[elem_name] = attr_coverage
 
     total = len(elements)
-    norm_count = len(normalized_elements)
-    written_count = len(written_elements)
-    pass_count = len(passthrough_elements)
-
+    norm_count = len(classes["normalized"])
+    written_count = len(classes["written"])
+    mentioned_count = len(classes["mentioned_only"])
+    pass_count = len(classes["passthrough"])
     coverage_pct = ((norm_count + written_count) / total * 100) if total > 0 else 0
 
-    result = {
+    return {
         "summary": {
             "total_elements": total,
             "normalized": norm_count,
             "written": written_count,
+            "mentioned_only": mentioned_count,
             "passthrough": pass_count,
             "coverage_percent": round(coverage_pct, 1),
         },
-        "normalized_elements": normalized_elements,
-        "written_elements": written_elements,
-        "passthrough_elements": passthrough_elements,
+        "normalized_elements": classes["normalized"],
+        "written_elements": classes["written"],
+        "mentioned_only_elements": classes["mentioned_only"],
+        "passthrough_elements": classes["passthrough"],
         "attribute_coverage": element_attr_coverage,
+        "container_rewrites": _container_rewrites(src_dir),
     }
-
-    return result
 
 
 def _format_coverage_markdown(
@@ -178,7 +394,8 @@ def _format_coverage_markdown(
         "| --- | --- |",
         f"| Total elements in spec | {summary['total_elements']} |",
         f"| Normalized (reader produces typed field) | {summary['normalized']} |",
-        f"| Written (writer can create/modify) | {summary['written']} |",
+        f"| Written only (writer can create/modify) | {summary['written']} |",
+        f"| Mentioned only (literal, not an XML call) | {summary['mentioned_only']} |",
         f"| Passthrough (unknown XML, kept byte-for-byte) | {summary['passthrough']} |",
         f"| **Coverage** | **{summary['coverage_percent']}%** |",
         "",
@@ -191,11 +408,20 @@ def _format_coverage_markdown(
 
     lines.extend([
         "",
-        "## Written Elements",
+        "## Written-Only Elements",
         "",
     ])
 
     for elem in coverage["written_elements"]:
+        lines.append(f"- `{elem}`")
+
+    lines.extend([
+        "",
+        "## Mentioned-Only Elements",
+        "",
+    ])
+
+    for elem in coverage["mentioned_only_elements"]:
         lines.append(f"- `{elem}`")
 
     lines.extend([
@@ -211,19 +437,46 @@ def _format_coverage_markdown(
         "",
         "## What Passthrough Means",
         "",
-        "Passthrough elements survive byte-for-byte **only** while no operation regenerates",
-        "their parent subtree. The following operations regenerate whole subtrees and will",
-        "destroy any passthrough data within them:",
-        "",
-        "- `routing_compiler.py` `_write_points` — regenerates trace point lists",
-        "- Ratlines rewrite — regenerates the entire `<Ratlines>` section",
-        "- Copper pour refill (if implemented) — regenerates `<CopperPour>` content",
-        "",
-        "Any edit to a passthrough element's parent container that triggers a full rewrite",
-        "will silently lose the passthrough data. This is the expected behaviour: the tool",
-        "only preserves what it understands.",
+        "Passthrough elements survive byte-for-byte **only** while no operation removes or",
+        "regenerates their parent subtree. The list below is derived from writer call sites",
+        "that iterate existing children and remove them. A value of `none` means no child",
+        "currently classified as passthrough was named by the inventory or removal path; it",
+        "does not make undocumented children safe.",
         "",
     ])
+
+    passthrough = set(coverage["passthrough_elements"])
+    elements = inventory.get("elements", {})
+    for rewrite in coverage["container_rewrites"]:
+        if rewrite.removed_children is None:
+            known_children = tuple(
+                sorted(elements.get(rewrite.container, {}).get("children", []))
+            )
+            rendered = ", ".join(f"`<{name}>`" for name in known_children) or "unavailable"
+            action = (
+                f"clears all children of `<{rewrite.container}>` "
+                f"(inventory children: {rendered})"
+            )
+        else:
+            known_children = rewrite.removed_children
+            rendered = ", ".join(f"`<{name}>`" for name in known_children) or "unknown"
+            action = f"may remove {rendered} from `<{rewrite.container}>`"
+        at_risk = sorted(set(known_children) & passthrough)
+        rendered_risk = ", ".join(f"`{name}`" for name in at_risk) or "none"
+        lines.append(
+            f"- `{rewrite.module}::{rewrite.function}` {action}; "
+            f"known passthrough children: {rendered_risk}."
+        )
+
+    lines.extend(
+        [
+            "",
+            "Any operation listed above can discard matching passthrough children rather than",
+            "preserve their original bytes. Unlisted dynamic removal sites remain unavailable",
+            "to this static detector and must not be assumed safe.",
+            "",
+        ]
+    )
 
     return "\n".join(lines) + "\n"
 
@@ -260,8 +513,6 @@ def main() -> int:
         existing = out_path.read_text(encoding="utf-8")
         if existing != report_md:
             print(f"FAIL: {out_path} differs from fresh computation", file=sys.stderr)
-            # Show summary diff
-            import difflib
             diff = list(difflib.unified_diff(
                 existing.splitlines(), report_md.splitlines(),
                 fromfile=str(out_path), tofile="fresh computation",
@@ -277,8 +528,11 @@ def main() -> int:
     out_path.write_text(report_md, encoding="utf-8")
 
     s = coverage["summary"]
-    print(f"Coverage: {s['coverage_percent']}% ({s['normalized']} normalized + "
-          f"{s['written']} written / {s['total_elements']} total)")
+    print(
+        f"Coverage: {s['coverage_percent']}% ({s['normalized']} normalized + "
+        f"{s['written']} written / {s['total_elements']} total; "
+        f"{s['mentioned_only']} mentioned only)"
+    )
     print(f"Written to {out_path}")
     return 0
 

--- a/tests/test_format_coverage.py
+++ b/tests/test_format_coverage.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.report_format_coverage import (
+    ContainerRewrite,
+    _container_rewrites,
+    _partition_names,
+    _scan_source,
+    compute_coverage,
+)
+
+ROOT = Path(__file__).parents[1]
+INVENTORY = ROOT / "reference" / "diptrace-xml" / "spec_inventory.json"
+SOURCE = ROOT / "src" / "diptrace_mcp"
+
+
+def test_call_detector_separates_reads_writes_and_mentions() -> None:
+    facts = _scan_source(
+        '''
+"""D"""
+element.findall("./A/B")
+ET.SubElement(element, "C")
+'''
+    )
+
+    classes = _partition_names(
+        {"A", "B", "C", "D"},
+        facts.read_elements,
+        facts.written_elements,
+        facts.bare_literals,
+    )
+
+    assert classes == {
+        "normalized": ["A", "B"],
+        "written": ["C"],
+        "mentioned_only": ["D"],
+        "passthrough": [],
+    }
+
+
+def test_reader_call_changes_classification() -> None:
+    before = _scan_source('"""AddFieldsGlobal"""')
+    after = _scan_source('element.findall("./AddFieldsGlobal")')
+
+    before_classes = _partition_names(
+        {"AddFieldsGlobal"},
+        before.read_elements,
+        before.written_elements,
+        before.bare_literals,
+    )
+    after_classes = _partition_names(
+        {"AddFieldsGlobal"},
+        after.read_elements,
+        after.written_elements,
+        after.bare_literals,
+    )
+
+    assert before_classes["mentioned_only"] == ["AddFieldsGlobal"]
+    assert after_classes["normalized"] == ["AddFieldsGlobal"]
+
+
+def test_real_coverage_spot_checks_and_partitions_inventory() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    coverage = compute_coverage(inventory, SOURCE)
+    normalized = set(coverage["normalized_elements"])
+
+    assert {
+        "CopperPour",
+        "DifferentialPair",
+        "MaskPaste",
+        "PadPoint",
+        "PadPoints",
+        "AddField",
+        "AddFields",
+        "ClearanceDetails",
+    } <= normalized
+    assert {"Id", "RefDes", "LineWidth"}.isdisjoint(normalized)
+
+    classes = [
+        set(coverage["normalized_elements"]),
+        set(coverage["written_elements"]),
+        set(coverage["mentioned_only_elements"]),
+        set(coverage["passthrough_elements"]),
+    ]
+    assert set().union(*classes) == set(inventory["elements"])
+    assert sum(len(items) for items in classes) == len(inventory["elements"])
+
+
+def test_container_rewrite_detector_finds_wholesale_removal(tmp_path: Path) -> None:
+    source = tmp_path / "routing_compiler.py"
+    source.write_text(
+        """
+def _write_points(trace):
+    container = trace.find("./Points")
+    for child in list(container):
+        container.remove(child)
+""",
+        encoding="utf-8",
+    )
+
+    assert _container_rewrites(tmp_path) == [
+        ContainerRewrite(
+            module="routing_compiler.py",
+            function="_write_points",
+            container="Points",
+            removed_children=None,
+        )
+    ]

--- a/tests/test_spec_inventory.py
+++ b/tests/test_spec_inventory.py
@@ -106,6 +106,7 @@ class TestFormatCoverage:
         assert "Total elements in spec" in content
         assert "Normalized" in content
         assert "Written" in content
+        assert "Mentioned only" in content
         assert "Passthrough" in content
         assert "Coverage" in content
 


### PR DESCRIPTION
WO-3 replaces literal-name collisions with AST call-site measurement, splits XML paths, reports mentioned-only names separately, derives destructive-container passthrough disclosures from writer code, and regenerates the coverage artifacts. Unit tests prove a newly added reader changes the measured result and fails the check gate.