### PR TITLE
tests: remove misleading skill and trust gates

### DIFF
--- a/scripts/generate_pcb_skills.py
+++ b/scripts/generate_pcb_skills.py
@@ -1749,11 +1749,11 @@ def initialize_skill(entry: dict[str, Any], init_script: Path) -> None:
 
 
 def validate_catalog(catalog: list[dict[str, Any]]) -> None:
-    if len(catalog) != 57:
-        raise ValueError(f"Expected 57 skills, got {len(catalog)}")
+    if not catalog:
+        raise ValueError("Skill catalog must not be empty")
     ids = [entry["id"] for entry in catalog]
-    if ids != list(range(1, 58)):
-        raise ValueError("Skill IDs must be contiguous from 1 through 57")
+    if ids != list(range(1, len(catalog) + 1)):
+        raise ValueError("Skill IDs must be contiguous from 1 through the catalog size")
     slugs = [entry["slug"] for entry in catalog]
     if len(slugs) != len(set(slugs)):
         raise ValueError("Skill slugs must be unique")

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # PCB Skills for DipTrace MCP
 
-This catalog contains 57 permanent skill packages spanning a PCB project from requirements intake and architecture through engineering reviews, release artifacts, bring-up, and regression control. [catalog.json](catalog.json) is the source of truth for the package inventory and workflow-specific content.
+This catalog contains the skill packages selected by [catalog.json](catalog.json), which is the source of truth for package inventory and workflow-specific content.
 
 ## Package Structure
 
@@ -40,7 +40,7 @@ From the repository root:
 .venv/bin/python -m pytest -q tests/test_skill_packages.py
 ```
 
-`--check` verifies that all 57 packages are reproducible from their sources and contain no hand-edited drift. Pytest is the only executable skill test suite; it validates structure, schemas, examples, capability mappings, scenarios, and eval assertions. Files under each package's `evals/` directory are test data consumed by that central suite, not a second test runner.
+`--check` verifies that every catalog-selected package is reproducible from its sources and contains no hand-edited drift. Pytest is the only executable skill test suite; it validates structure, schemas, examples, capability mappings, scenarios, and eval assertions. Files under each package's `evals/` directory are test data consumed by that central suite, not a second test runner.
 
 For an additional frontmatter and naming check, run `quick_validate.py` from an installed `skill-creator` package:
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -90,29 +90,25 @@ def test_session_state_read_retries_transient_os_errors(
     assert attempts == 2
 
 
-def test_stale_active_json_is_ignored_when_session_not_active(
+def test_new_session_allowed_after_clean_finalize(
     tmp_path: Path,
 ) -> None:
-    """If the process crashed leaving active.json, a new session should work."""
+    """A cleanly finalized session does not block the next session."""
     exchange = tmp_path / "plugin_exchange.xml"
     exchange.write_bytes((FIXTURES / "pcb.xml").read_bytes())
     store = SessionStore(tmp_path / "state", 10_000_000)
     metadata = store.create(exchange)
     session_id = metadata["session_id"]
 
-    # Simulate crash: finalize without cleaning active.json
     store.finalize(session_id, "cancel")
 
-    # active.json still references the old (now cancelled) session.
-    # New session creation should succeed because active_metadata()
-    # checks status == "active" and finds "cancelled".
+    # TODO(WO-15): exercise active.json left behind by an abrupt bridge crash.
     metadata2 = store.create(exchange)
     assert metadata2["session_id"] != session_id
     assert metadata2["status"] == "active"
 
 
-def test_double_finish_is_idempotent(tmp_path: Path) -> None:
-    """Calling finalize twice on the same session raises on the second call."""
+def test_second_finalize_is_rejected(tmp_path: Path) -> None:
     exchange = tmp_path / "plugin_exchange.xml"
     exchange.write_bytes((FIXTURES / "pcb.xml").read_bytes())
     store = SessionStore(tmp_path / "state", 10_000_000)

--- a/tests/test_skill_packages.py
+++ b/tests/test_skill_packages.py
@@ -315,8 +315,8 @@ def schema_annotation(schema: dict[str, Any], path: str) -> Any:
 
 def test_skill_catalog_and_packages_are_discoverable() -> None:
     entries = catalog()
-    assert len(entries) == 57
-    assert [entry["id"] for entry in entries] == list(range(1, 58))
+    assert entries
+    assert [entry["id"] for entry in entries] == list(range(1, len(entries) + 1))
     slugs = [entry["slug"] for entry in entries]
     assert len(slugs) == len(set(slugs))
     assert set(slugs) == {
@@ -927,4 +927,4 @@ def test_generated_skill_packages_are_current() -> None:
         text=True,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert completed.stdout.strip() == "verified 57 PCB skill packages"
+    assert completed.stdout.strip() == f"verified {len(catalog())} PCB skill packages"

--- a/tests/test_skills_integrity.py
+++ b/tests/test_skills_integrity.py
@@ -1,10 +1,4 @@
-"""Skill-package integrity gates.
-
-Every PCB skill must have a SKILL.md, a result schema, an example, and evals.
-The generate_pcb_skills.py --check script already validates these, but this test
-provides an explicit pytest-level gate so the CI matrix catches regressions
-even if the script step is skipped.
-"""
+"""Content-neutral JSON checks for the optional skill-package artifacts."""
 
 from __future__ import annotations
 
@@ -18,50 +12,19 @@ def _skill_dirs() -> list[Path]:
     return sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir() and (d / "SKILL.md").exists())
 
 
-def test_all_skills_have_required_artifacts() -> None:
-    """Every skill directory must contain SKILL.md, schema, example, and evals."""
+def test_optional_skill_json_artifacts_are_valid() -> None:
+    """Every JSON artifact that a skill chooses to ship must parse."""
     errors: list[str] = []
     for skill_dir in _skill_dirs():
-        name = skill_dir.name
-        for relpath in (
-            "SKILL.md",
-            "schemas/result.schema.json",
-            "examples/result.example.json",
-            "evals/scenarios.json",
-            "evals/assertions.json",
-        ):
-            if not (skill_dir / relpath).exists():
-                errors.append(f"{name}: missing {relpath}")
-    assert not errors, "Skills missing required artifacts:\n" + "\n".join(errors)
-
-
-def test_schemas_are_valid_json() -> None:
-    """All skill schemas and examples must be valid JSON."""
-    errors: list[str] = []
-    for skill_dir in _skill_dirs():
-        for relpath in ("schemas/result.schema.json", "examples/result.example.json"):
-            path = skill_dir / relpath
-            if path.exists():
-                try:
-                    json.loads(path.read_text(encoding="utf-8"))
-                except json.JSONDecodeError as exc:
-                    errors.append(f"{skill_dir.name}/{relpath}: {exc}")
+        for path in skill_dir.rglob("*.json"):
+            try:
+                json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path.relative_to(SKILLS_DIR)}: {exc}")
     assert not errors, "Invalid JSON in skill artifacts:\n" + "\n".join(errors)
 
 
-def test_capability_map_references_existing_skills() -> None:
-    """The capability-map.json missing entries should reference known skill names."""
+def test_capability_map_is_valid_json() -> None:
     cap_map_path = SKILLS_DIR / "capability-map.json"
-    if not cap_map_path.exists():
-        return
-    cap_map = json.loads(cap_map_path.read_text(encoding="utf-8"))
-    # Missing entries reference contract names, not skill names directly — just
-    # verify the file is valid JSON and has the expected top-level keys.
-    assert "aliases" in cap_map
-    assert "missing" in cap_map
-
-
-def test_skill_count_matches_generate_check() -> None:
-    """The number of skills with SKILL.md must be stable (57 as of Phase 8)."""
-    count = len(_skill_dirs())
-    assert count >= 57, f"Expected at least 57 skills, found {count}"
+    assert cap_map_path.exists()
+    assert isinstance(json.loads(cap_map_path.read_text(encoding="utf-8")), dict)

--- a/tests/test_trust_model.py
+++ b/tests/test_trust_model.py
@@ -510,14 +510,13 @@ class TestSemanticComparisonRegression:
         assert "parse_warnings" in result
 
 
-# ── All write paths invalidate trust ─────────────────────────────────────────
+# ── Trust capability disclosures ─────────────────────────────────────────────
 
 
-class TestAllWritePathsInvalidate:
-    """Every MCP write path must invalidate trust."""
+class TestTrustCapabilityDisclosures:
+    """Trust metadata and dry-run behavior remain fail-closed and explicit."""
 
-    def test_apply_edits_noop_preserves_trust(self, tmp_path: Path) -> None:
-        """apply_edits with a no-op edit does not change the document."""
+    def test_apply_edits_dry_run_preserves_trust(self, tmp_path: Path) -> None:
         service = _service(tmp_path)
         service.create_document("pcb", "board.dip")
         board_path = tmp_path / "board.dip"
@@ -549,8 +548,10 @@ class TestAllWritePathsInvalidate:
         assert loaded is not None
         assert loaded.validation_level == FixtureValidationLevel.synthetic_operation_fixture
 
-    def test_create_document_from_seed_invalidation(self, tmp_path: Path) -> None:
-        """create_document_from_seed writes trust sidecar with correct authority."""
+    def test_create_document_from_seed_writes_runtime_low_trust_sidecar(
+        self,
+        tmp_path: Path,
+    ) -> None:
         service = _service(tmp_path)
         raw = build_pcb_document(PcbScaffold(width_mm=50.0, height_mm=30.0))
         (tmp_path / "seed.dip").write_bytes(raw)
@@ -564,8 +565,7 @@ class TestAllWritePathsInvalidate:
         assert loaded.authority == ProvenanceAuthority.runtime
         assert loaded.validation_level == FixtureValidationLevel.synthetic_parser_only
 
-    def test_all_claimed_write_paths_have_public_e2e_tests(self) -> None:
-        """§17: Verify the capability report honestly marks untested paths."""
+    def test_capability_report_discloses_unverified_write_families(self) -> None:
         from diptrace_mcp.capabilities import get_capabilities
 
         report = get_capabilities(None)
@@ -574,33 +574,6 @@ class TestAllWritePathsInvalidate:
         assert "plan_apply" in trust["untested_write_paths"]
         assert "ses_import" in trust["untested_write_paths"]
         assert "schematic_to_pcb_sync" in trust["untested_write_paths"]
-
-    def test_untested_write_paths_are_exhaustively_listed(self) -> None:
-        """§17b: Every write path the code claims is untested must appear in
-        the untested_write_paths list, and the list must not contain paths
-        that don't exist in the codebase."""
-        from diptrace_mcp.capabilities import get_capabilities
-
-        report = get_capabilities(None)
-        trust = report.trust_model
-        listed = set(trust["untested_write_paths"])
-
-        # These paths are verified untested because they require a real DipTrace
-        # installation to exercise the write-back through the bridge.
-        # When a path is tested, remove it from this set and from the
-        # capability_model._BASE_TRUST_MODEL untested_write_paths list.
-        expected_untested = {
-            "plan_apply",
-            "ses_import",
-            "schematic_to_pcb_sync",
-            "live_session_apply",
-        }
-        assert listed == expected_untested, (
-            f"untested_write_paths mismatch: "
-            f"listed={listed}, expected={expected_untested}. "
-            f"Update capability_model._BASE_TRUST_MODEL if paths were tested "
-            f"or new untested paths were added."
-        )
 
 
 # ── §7 Attack regression tests ─────────────────────────────────────────────


### PR DESCRIPTION
WO-4 removes anti-goal skill-count/eval gates, replaces misleading or tautological tests, and makes session test names match their assertions.

Accurate mapping for the original mimo history:
- 0a26496 (Phase 5) contains XML parser hardening; it does not satisfy Phase 5 CI/test-infrastructure acceptance.
- 6d4f861 (Phase 6) adds tests of existing session behavior with no live-session robustness implementation; it does not satisfy Phase 6.
- e4c3829 (Phase 7) adds a self-comparing trust test; it does not deliver the Phase 7 evidence harness.
- 0b1b924 (Phase 8) pins the skill count at 57; it does not deliver and actively blocked Phase 8 consolidation.