### PR TITLE
safety: enforce transaction capacity and caller SHA

### DIFF
--- a/src/diptrace_mcp/adapters.py
+++ b/src/diptrace_mcp/adapters.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from typing import Any, Literal
 
-from .capability_model import get_trust_model
+from .capability_model import MAX_TRANSACTION_OPERATIONS, get_trust_model
 from .domain import (
     BoardModel,
     CapabilityReport,
@@ -2588,7 +2588,7 @@ def capability_report(
         limits={
             "max_document_bytes": None,
             "max_query_results": 500,
-            "max_transaction_operations": 100,
+            "max_transaction_operations": MAX_TRANSACTION_OPERATIONS,
         },
         policy={
             "default_write_mode": "dry_run",

--- a/src/diptrace_mcp/capabilities.py
+++ b/src/diptrace_mcp/capabilities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from . import __version__
 from .adapters import capability_report
-from .capability_model import get_trust_model
+from .capability_model import MAX_TRANSACTION_OPERATIONS, get_trust_model
 from .domain import CapabilityReport
 from .geometry_backend import backend_report
 from .xml_document import DipTraceDocument
@@ -143,7 +143,10 @@ def get_capabilities(
             },
             geometry_backend=backend_report(),
             preview_formats=["svg", "json", "diff"],
-            limits={"max_transaction_operations": 100, "max_query_results": 500},
+            limits={
+                "max_transaction_operations": MAX_TRANSACTION_OPERATIONS,
+                "max_query_results": 500,
+            },
             policy={
                 "active_profile": "interactive_edit",
                 "default_write_mode": "dry_run",

--- a/src/diptrace_mcp/capability_model.py
+++ b/src/diptrace_mcp/capability_model.py
@@ -6,7 +6,9 @@ the single source of truth in this module.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
+
+MAX_TRANSACTION_OPERATIONS: Final = 100
 
 # The trust model is a single dict that both entry points produce.
 # When a document is present, additional document-specific keys are merged in.

--- a/src/diptrace_mcp/domain.py
+++ b/src/diptrace_mcp/domain.py
@@ -8,6 +8,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from .capability_model import MAX_TRANSACTION_OPERATIONS
+
 StableId = str
 SourceType = Literal[
     "DipTrace-PCB",
@@ -1170,7 +1172,10 @@ class TransactionRecord(StrictModel):
     status: TransactionStatus
     source_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
     target_path: str
-    operations: list[dict[str, Any]] = Field(default_factory=list, max_length=10_000)
+    operations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        max_length=MAX_TRANSACTION_OPERATIONS,
+    )
     created_at: str
     updated_at: str
     expected_sha256: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")

--- a/src/diptrace_mcp/service.py
+++ b/src/diptrace_mcp/service.py
@@ -20,6 +20,7 @@ from .adapters import (
 )
 from .bom import compare_bom_records, extract_bom, group_bom, review_bom
 from .capabilities import get_capabilities as build_capabilities
+from .capability_model import MAX_TRANSACTION_OPERATIONS
 from .config import Settings
 from .connectivity import build_connectivity_graph
 from .design_compare import compare_schematic_to_pcb as compare_design_snapshots
@@ -217,6 +218,14 @@ def same_file_role(path_a: Path, path_b: Path) -> bool:
         left = os.path.normcase(os.path.abspath(path_a))
         right = os.path.normcase(os.path.abspath(path_b))
     return left == right
+
+
+def _require_transaction_capacity(operation_count: int) -> None:
+    if operation_count > MAX_TRANSACTION_OPERATIONS:
+        raise EditError(
+            "Transaction would exceed "
+            f"{MAX_TRANSACTION_OPERATIONS} operations limit ({operation_count} staged)"
+        )
 
 
 # ── Effective trust resolution ───────────────────────────────────────────
@@ -2071,10 +2080,7 @@ class DipTraceService:
         if not parsed:
             raise EditError("At least one semantic operation is required")
         staged = [*record.operations, *(operation.model_dump() for operation in parsed)]
-        if len(staged) > 100:
-            raise EditError(
-                f"Transaction would exceed 100 operations limit ({len(staged)} staged)"
-            )
+        _require_transaction_capacity(len(staged))
         updated = self.transactions.update(
             txid,
             status="staged",
@@ -2869,7 +2875,7 @@ class DipTraceService:
             operations,
             path,
             dry_run,
-            expected_sha256 or snapshot.info.sha256,
+            expected_sha256,
             txid,
         )
 
@@ -2962,7 +2968,7 @@ class DipTraceService:
             operations,
             path,
             dry_run,
-            expected_sha256 or snapshot.info.sha256,
+            expected_sha256,
             txid,
         )
 
@@ -5501,7 +5507,7 @@ class DipTraceService:
             operations,
             str(target_path),
             dry_run,
-            expected_sha256 or plan.source_sha256,
+            expected_sha256,
             txid,
         )
         transaction = response.get("transaction") or {}
@@ -5776,6 +5782,13 @@ class DipTraceService:
             dry_run=dry_run,
             operation=operations[0].kind if len(operations) == 1 else "semantic_operations",
         )
+        if not dry_run and expected_sha256 is None:
+            raise ConfirmationRequiredError(
+                "expected_sha256 is required for semantic writes",
+                txid=txid,
+            )
+        incoming_operations = [operation.model_dump() for operation in operations]
+        _require_transaction_capacity(len(incoming_operations))
         if txid is None:
             document, target = self.load(path)
             snapshot = build_snapshot(document, live_session=target.is_live)
@@ -5799,7 +5812,7 @@ class DipTraceService:
             self.transactions.update(
                 txid,
                 status="staged",
-                operations=[operation.model_dump() for operation in operations],
+                operations=incoming_operations,
                 compiled_patch_count=len(operations),
                 snapshot_path=str(self.transactions.snapshot_path(txid)),
             )
@@ -5821,9 +5834,9 @@ class DipTraceService:
                         },
                         txid=txid,
                     )
-            incoming_operations = [operation.model_dump() for operation in operations]
             if existing.operations != incoming_operations:
                 combined_operations = [*existing.operations, *incoming_operations]
+                _require_transaction_capacity(len(combined_operations))
                 self.transactions.update(
                     txid,
                     status="staged",
@@ -5835,10 +5848,9 @@ class DipTraceService:
         preview = self.preview_transaction(txid)
         if dry_run:
             return preview
-        record = self.transactions.read(txid)
         return self.commit_transaction(
             txid,
-            expected_sha256=expected_sha256 or record.source_sha256,
+            expected_sha256=expected_sha256,
         )
 
     def _preview_semantic_operations(

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -6,9 +6,15 @@ import pytest
 from pydantic import ValidationError
 
 from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.capability_model import MAX_TRANSACTION_OPERATIONS
 from diptrace_mcp.config import Settings
 from diptrace_mcp.domain import ObjectRecord, QueryRequest, QuerySelector
-from diptrace_mcp.errors import Sha256MismatchError, TransactionConflictError
+from diptrace_mcp.errors import (
+    ConfirmationRequiredError,
+    EditError,
+    Sha256MismatchError,
+    TransactionConflictError,
+)
 from diptrace_mcp.operations import MoveComponentsOperation, SetComponentValueOperation
 from diptrace_mcp.semantic_compiler import apply_semantic_operations
 from diptrace_mcp.service import DipTraceService
@@ -214,6 +220,114 @@ def test_transaction_append_validation_and_conflict_safe_rollback(tmp_path: Path
     with pytest.raises(Sha256MismatchError):
         service.rollback_transaction(txid, commit_sha)
     assert sha256_bytes(path.read_bytes()) != commit_sha
+
+
+def test_transaction_limit_is_enforced_by_stage_operations(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "board.dip").write_bytes((FIXTURES / "pcb.xml").read_bytes())
+    service = service_for(project, tmp_path / "state")
+    txid = service.begin_transaction("board.dip")["transaction"]["txid"]
+    operations = [
+        {
+            "kind": "set_component_value",
+            "selector": {"refdes": ["R1"]},
+            "value": f"value-{index}",
+        }
+        for index in range(MAX_TRANSACTION_OPERATIONS)
+    ]
+
+    staged = service.stage_operations(txid, operations)
+
+    assert staged["result"]["staged_count"] == MAX_TRANSACTION_OPERATIONS
+    with pytest.raises(EditError, match=rf"{MAX_TRANSACTION_OPERATIONS + 1} staged"):
+        service.stage_operations(
+            txid,
+            [
+                {
+                    "kind": "set_component_value",
+                    "selector": {"refdes": ["R1"]},
+                    "value": "one-too-many",
+                }
+            ],
+        )
+    assert len(service.transactions.read(txid).operations) == MAX_TRANSACTION_OPERATIONS
+
+
+def test_transaction_limit_is_enforced_by_semantic_write_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "board.dip").write_bytes((FIXTURES / "pcb.xml").read_bytes())
+    service = service_for(project, tmp_path / "state")
+    txid = service.begin_transaction("board.dip")["transaction"]["txid"]
+    monkeypatch.setattr(
+        service,
+        "preview_transaction",
+        lambda current_txid: {"ok": True, "transaction": {"txid": current_txid}},
+    )
+
+    for index in range(MAX_TRANSACTION_OPERATIONS):
+        service.set_component_value(
+            {"refdes": ["R1"]},
+            f"value-{index}",
+            txid=txid,
+            dry_run=True,
+        )
+
+    assert len(service.transactions.read(txid).operations) == MAX_TRANSACTION_OPERATIONS
+    with pytest.raises(EditError, match=rf"{MAX_TRANSACTION_OPERATIONS + 1} staged"):
+        service.set_component_value(
+            {"refdes": ["R1"]},
+            "one-too-many",
+            txid=txid,
+            dry_run=True,
+        )
+    assert len(service.transactions.read(txid).operations) == MAX_TRANSACTION_OPERATIONS
+
+
+def test_oversized_semantic_batch_does_not_create_transaction(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "board.dip").write_bytes((FIXTURES / "pcb.xml").read_bytes())
+    service = service_for(project, tmp_path / "state")
+    testpoints = [
+        {
+            "net": "VCC",
+            "x": float(index),
+            "y": 0.0,
+            "pad_diameter": 1.0,
+            "refdes": f"TP{index}",
+        }
+        for index in range(MAX_TRANSACTION_OPERATIONS + 1)
+    ]
+
+    with pytest.raises(EditError, match=rf"{MAX_TRANSACTION_OPERATIONS + 1} staged"):
+        service.add_testpoints(testpoints, path="board.dip", dry_run=True)
+
+    assert service.transactions.list() == []
+
+
+def test_semantic_write_requires_caller_sha(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    board = project / "board.dip"
+    original = (FIXTURES / "pcb.xml").read_bytes()
+    board.write_bytes(original)
+    service = service_for(project, tmp_path / "state")
+
+    with pytest.raises(ConfirmationRequiredError, match="expected_sha256"):
+        service.set_component_value(
+            {"refdes": ["R1"]},
+            "47k",
+            path="board.dip",
+            dry_run=False,
+        )
+
+    assert service.transactions.list() == []
+    assert board.read_bytes() == original
 
 
 def test_rolling_back_uncommitted_plan_does_not_touch_document(tmp_path: Path) -> None:

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -125,7 +125,11 @@ def test_placement_plan_commit_and_rollback(tmp_path: Path) -> None:
         "no_new_placement_errors": True,
     }
 
-    committed = service.apply_component_placement_plan(plan["plan_id"], dry_run=False)
+    committed = service.apply_component_placement_plan(
+        plan["plan_id"],
+        dry_run=False,
+        expected_sha256=plan["source_sha256"],
+    )
     assert committed["transaction"]["status"] == "committed"
     root = ET.fromstring(board.read_bytes())
     component = root.find("./Board/Components/Component[@Id='1']")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -393,7 +393,11 @@ def test_route_plan_commit_review_details_and_rollback(tmp_path: Path) -> None:
     assert plan["metrics"]["total_length_mm"] == 10
     assert len(planned["resources"]) == 4
 
-    committed = service.apply_route_plan(plan["plan_id"], dry_run=False)
+    committed = service.apply_route_plan(
+        plan["plan_id"],
+        dry_run=False,
+        expected_sha256=plan["source_sha256"],
+    )
     assert committed["transaction"]["status"] == "committed"
     details = service.get_route_details(net="VCC", path=str(board))
     assert details["result"]["trace_count"] == 1
@@ -434,7 +438,11 @@ def test_diff_pair_plan_commit_and_rollback(tmp_path: Path) -> None:
     assert plan["metrics"]["symmetric_via_count"] == 4
     assert len(planned["resources"]) == 4
 
-    committed = service.apply_route_plan(plan["plan_id"], dry_run=False)
+    committed = service.apply_route_plan(
+        plan["plan_id"],
+        dry_run=False,
+        expected_sha256=plan["source_sha256"],
+    )
     assert committed["transaction"]["status"] == "committed"
     root = ET.fromstring(board.read_bytes())
     assert len(root.findall("./Board/DifferentialPairs/DifferentialPair/Segments/Segment")) == 1

--- a/tests/test_silkscreen.py
+++ b/tests/test_silkscreen.py
@@ -93,7 +93,11 @@ def test_silkscreen_plan_preview_commit_and_rollback(tmp_path: Path) -> None:
     )
     assert '"candidates"' in service.plan_resource(plan_id, "preview.json")
 
-    committed = service.apply_silkscreen_plan(plan_id, dry_run=False)
+    committed = service.apply_silkscreen_plan(
+        plan_id,
+        dry_run=False,
+        expected_sha256=plan["source_sha256"],
+    )
     assert committed["transaction"]["status"] == "committed"
     assert committed["plan"]["status"] == "committed"
     committed_sha = committed["transaction"]["committed_sha256"]


### PR DESCRIPTION
WO-5 defines the 100-operation limit once and enforces it on both staging and one-shot semantic paths with 100/101 boundary tests. It also closes the sibling hash-gate bypass: committed one-shot writes require the caller expected_sha256; source-hash convenience remains explicit for dry-run/transaction staging rather than silently authorizing a write.