### PR TITLE
safety: preserve XML guard error contracts

### DIFF
--- a/src/diptrace_mcp/operations.py
+++ b/src/diptrace_mcp/operations.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import Field, field_validator, model_validator
 
 from .domain import QuerySelector, StrictModel
+from .xml_document import reject_forbidden_xml_declarations
 
 
 class SemanticOperation(StrictModel):
@@ -462,11 +463,12 @@ class SyncSchematicToPcbOperation(SemanticOperation):
         definitions = [*self.pattern_xml, *self.pad_style_xml]
         if sum(len(item) for item in definitions) > 64 * 1024 * 1024:
             raise ValueError("embedded pattern definitions exceed 64 MiB")
-        if any(
-            "<!doctype" in item.casefold() or "<!entity" in item.casefold()
-            for item in definitions
-        ):
-            raise ValueError("DTD and ENTITY declarations are forbidden in pattern definitions")
+        for definition in definitions:
+            reject_forbidden_xml_declarations(
+                definition,
+                error_type=ValueError,
+                context="pattern_definition",
+            )
         return self
 
 

--- a/src/diptrace_mcp/semantic_compiler.py
+++ b/src/diptrace_mcp/semantic_compiler.py
@@ -61,7 +61,12 @@ from .routing_compiler import (
     ROUTING_OPERATION_TYPES,
     apply_routing_operation,
 )
-from .xml_document import DipTraceDocument, RawTreeSnapshot, sha256_bytes
+from .xml_document import (
+    DipTraceDocument,
+    RawTreeSnapshot,
+    parse_xml_definition,
+    sha256_bytes,
+)
 
 
 @dataclass(slots=True)
@@ -1508,7 +1513,7 @@ def _apply_sync_schematic_to_pcb(
         (item.get("Name") or "").casefold() for item in pad_styles.findall("./PadStyle")
     }
     for raw in operation.pad_style_xml:
-        element = ET.fromstring(raw)
+        element = parse_xml_definition(raw)
         if element.tag != "PadStyle" or not element.get("Name"):
             raise EditError("Schematic sync contains an invalid PadStyle definition")
         key = str(element.get("Name")).casefold()
@@ -1517,7 +1522,7 @@ def _apply_sync_schematic_to_pcb(
             existing_pad_styles.add(key)
             patch_count += 1
     for raw in operation.pattern_xml:
-        element = ET.fromstring(raw)
+        element = parse_xml_definition(raw)
         style = element.get("PatternStyle") or element.get("Style")
         if element.tag != "Pattern" or not style:
             raise EditError("Schematic sync contains an invalid Pattern definition")

--- a/src/diptrace_mcp/xml_document.py
+++ b/src/diptrace_mcp/xml_document.py
@@ -44,7 +44,12 @@ _ALLOWED_XML_ENCODINGS = frozenset(
         "iso-8859-1",
     }
 )
-_FORBIDDEN_XML_MESSAGE = "DTD and ENTITY declarations are not allowed"
+ForbiddenXmlContext = Literal["document", "fragment", "pattern_definition"]
+_FORBIDDEN_XML_MESSAGES: dict[ForbiddenXmlContext, str] = {
+    "document": "DTD and ENTITY declarations are not allowed",
+    "fragment": "DTD and ENTITY declarations are not allowed in XML fragments",
+    "pattern_definition": "DTD and ENTITY declarations are forbidden in pattern definitions",
+}
 _XML_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]*$")
 
 
@@ -92,12 +97,29 @@ def _encoding_candidates(data: bytes) -> tuple[tuple[str, int], ...]:
     return ((encoding, 0),)
 
 
-def _detect_encoding_and_check(data: bytes) -> None:
-    """Reject DTD/entity declarations through byte and allowlisted text scans."""
+class _ForbiddenXmlDeclaration(Exception):
+    """Internal signal raised from Expat declaration callbacks."""
+
+
+def reject_forbidden_xml_declarations(
+    data: bytes | str,
+    *,
+    error_type: type[Exception],
+    context: ForbiddenXmlContext = "document",
+) -> None:
+    """Reject DTD/entity declarations with the caller's public error contract."""
+    message = _FORBIDDEN_XML_MESSAGES[context]
+    if isinstance(data, str):
+        # Python text has already been decoded, so it has no UTF-16 byte-layout
+        # hole. This is the guard used by the operation-model validation layer.
+        if _FORBIDDEN_XML_TEXT.search(data):
+            raise error_type(message)
+        return
+
     # This unconditional whole-document pass covers every single-byte encoding.
     # Decoding below is an additional pass for NUL-interleaved UTF-16/32 input.
     if _FORBIDDEN_XML.search(data):
-        raise DocumentError(_FORBIDDEN_XML_MESSAGE)
+        raise error_type(message)
 
     for encoding, bom_len in _encoding_candidates(data):
         try:
@@ -105,15 +127,10 @@ def _detect_encoding_and_check(data: bytes) -> None:
         except (LookupError, UnicodeError, ValueError):
             continue
         if _FORBIDDEN_XML_TEXT.search(text):
-            raise DocumentError(_FORBIDDEN_XML_MESSAGE)
+            raise error_type(message)
 
-
-class _ForbiddenXmlDeclaration(Exception):
-    """Internal signal raised from Expat declaration callbacks."""
-
-
-def _reject_forbidden_xml_at_parser_level(data: bytes) -> None:
-    """Use Expat callbacks so DTD rejection is independent of byte position."""
+    # Expat callbacks make the final rejection independent of byte position and
+    # encoding whenever the input is otherwise parseable by the XML parser.
     parser = expat.ParserCreate()
 
     def reject_doctype(
@@ -149,7 +166,7 @@ def _reject_forbidden_xml_at_parser_level(data: bytes) -> None:
     try:
         parser.Parse(data, True)
     except _ForbiddenXmlDeclaration:
-        raise DocumentError(_FORBIDDEN_XML_MESSAGE) from None
+        raise error_type(message) from None
     except expat.ExpatError:
         # ElementTree below preserves the public Invalid XML error contract for
         # ordinary syntax and unsupported-encoding failures.
@@ -175,13 +192,25 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
 
 
 def _parse_root(data: bytes) -> ET.Element:
-    _detect_encoding_and_check(data)
-    _reject_forbidden_xml_at_parser_level(data)
+    reject_forbidden_xml_declarations(data, error_type=DocumentError)
     try:
         parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
         return ET.fromstring(data, parser=parser)
     except ET.ParseError as exc:
         raise DocumentError(f"Invalid XML: {exc}") from exc
+
+
+def parse_xml_definition(data: str) -> ET.Element:
+    """Parse an embedded pattern definition through the shared write guard."""
+    reject_forbidden_xml_declarations(
+        data,
+        error_type=EditError,
+        context="pattern_definition",
+    )
+    try:
+        return ET.fromstring(data)
+    except (ET.ParseError, ValueError) as exc:
+        raise EditError(f"Invalid embedded XML definition: {exc}") from exc
 
 
 @dataclass(frozen=True)
@@ -601,7 +630,7 @@ def _scan_start_tag_end(data: bytes, start: int) -> int:
 
 
 def _raw_element_spans(data: bytes) -> list[_RawElementSpan]:
-    _detect_encoding_and_check(data)
+    reject_forbidden_xml_declarations(data, error_type=EditError)
     spans: list[_RawElementSpan] = []
     stack: list[int] = []
     parser = expat.ParserCreate()
@@ -872,7 +901,11 @@ def _parse_fragment(index: int, value: str | None) -> ET.Element:
 
 
 def _parse_root_fragment(data: bytes) -> ET.Element:
-    _detect_encoding_and_check(data)
+    reject_forbidden_xml_declarations(
+        data,
+        error_type=EditError,
+        context="fragment",
+    )
     try:
         return ET.fromstring(b"<McpFragment>" + data + b"</McpFragment>")
     except ET.ParseError as exc:

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -8,6 +8,7 @@ import pytest
 
 from diptrace_mcp.config import Settings
 from diptrace_mcp.errors import EditError, LockedObjectError
+from diptrace_mcp.operations import SyncSchematicToPcbOperation
 from diptrace_mcp.scaffolding import build_pcb_document
 from diptrace_mcp.semantic_compiler import apply_semantic_operations
 from diptrace_mcp.service import DipTraceService
@@ -34,6 +35,24 @@ def _mapping() -> list[ComponentSyncMapping]:
             ],
         ),
     ]
+
+
+def test_sync_compiler_rejects_entity_in_pattern_xml_even_if_model_is_bypassed() -> None:
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    operation = SyncSchematicToPcbOperation.model_construct(
+        schematic_sha256="0" * 64,
+        components=[],
+        pattern_xml=[
+            '<!DOCTYPE Pattern [<!ENTITY x "boom">]>'
+            '<Pattern PatternStyle="unsafe">&x;</Pattern>'
+        ],
+    )
+
+    with pytest.raises(
+        EditError,
+        match="DTD and ENTITY declarations are forbidden in pattern definitions",
+    ):
+        apply_semantic_operations(pcb, [operation])
 
 
 def test_sync_populates_empty_pcb_and_copies_patterns() -> None:

--- a/tests/test_xml_document.py
+++ b/tests/test_xml_document.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from diptrace_mcp.errors import DocumentError, EditError
-from diptrace_mcp.xml_document import DipTraceDocument, XmlEdit
+from diptrace_mcp.xml_document import DipTraceDocument, RawTreeSnapshot, XmlEdit
 
 FIXTURES = Path(__file__).parent / "fixtures"
 ENTITY_BOMB = (
@@ -147,7 +147,10 @@ def test_clean_utf16_fixture_loads(bom: bytes, encoding: str) -> None:
 def test_apply_edits_rejects_entity_declaration_in_fragment() -> None:
     document = DipTraceDocument.load(FIXTURES / "pcb.xml", 10_000_000)
 
-    with pytest.raises((DocumentError, EditError), match="DTD and ENTITY"):
+    with pytest.raises(
+        EditError,
+        match="DTD and ENTITY declarations are not allowed in XML fragments",
+    ):
         document.apply_edits(
             [
                 XmlEdit(
@@ -160,6 +163,20 @@ def test_apply_edits_rejects_entity_declaration_in_fragment() -> None:
                 )
             ]
         )
+
+
+def test_raw_span_guard_preserves_write_error_contract() -> None:
+    document = DipTraceDocument.load(FIXTURES / "pcb.xml", 10_000_000)
+    document.raw_bytes = (
+        b'<!DOCTYPE Source [<!ENTITY x "boom">]>'
+        b'<Source Type="DipTrace-PCB"><Board>&x;</Board></Source>'
+    )
+
+    with pytest.raises(
+        EditError,
+        match=r"^DTD and ENTITY declarations are not allowed$",
+    ):
+        RawTreeSnapshot.capture(document)
 
 
 def test_raw_patch_preserves_bom_declaration_empty_tags_and_unknown_sections() -> None:


### PR DESCRIPTION
WO-6 routes client-supplied pattern and pad-style fragments through the shared hardened XML guard while preserving the established wire contract: document parsing raises DocumentError, write spans/fragments raise EditError with their path-specific messages. Regression tests cover hostile pattern XML, apply_xml_edits, and fragment parsing.