### PR TITLE
engineering: sweep coupled microstrip physical invariants

### DIFF
--- a/docs/IMPEDANCE_AND_SI.md
+++ b/docs/IMPEDANCE_AND_SI.md
@@ -13,9 +13,17 @@ Reference equations: Qucs Technical Papers, transmission-line chapter, equations
 `structure="differential_microstrip"` uses the Hammerstad-Jensen parallel-coupled
 microstrip model: even and odd modes, `Zdiff=2*Zodd`, validity range
 `0.1<=W/h<=10`, and `gap/h>=0.01`. Modal impedances and effective permittivity are
-returned in `validity`. The golden case is checked against Qucs-core
-`mscoupled::analysQuasiStatic`:
-<https://qucs.sourceforge.net/doxygen/0.0.18/qucs-core/mscoupled_8cpp_source.html>.
+returned in `validity`. The equations and all three bounds come from the
+[Qucs Hammerstad-Jensen coupled-microstrip section](https://qucs.sourceforge.net/tech/node77.html).
+The `0.1<=gap/h<=10` range shown earlier on that page belongs to the different
+Kirschning-Jansen model and is not presented as a bound for this implementation.
+
+The [swept physical-invariant suite](../tests/test_impedance_invariants.py) checks
+3,360 combinations of width, gap, height, dielectric constant, and the three requested
+test thicknesses. It checks modal-permittivity ordering only inside the published band,
+checks width/height/gap monotonicity, and checks the far-separation permittivity and
+`Zdiff -> 2*Z0` limits. The last impedance limit is intentionally restricted to zero
+thickness because the coupled branch does not implement a thickness correction.
 
 The coupled implementation is a zero-thickness quasi-static model. Non-zero copper
 thickness is not silently ignored: the tool returns a warning and `confidence="low"`.

--- a/src/diptrace_mcp/impedance.py
+++ b/src/diptrace_mcp/impedance.py
@@ -7,10 +7,36 @@ from .domain import ImpedanceInput, ImpedanceResult, StackupModel
 from .errors import CapabilityUnavailableError, InsufficientStackupDataError
 
 _FREE_SPACE_IMPEDANCE_OHM = 376.730313668
+_COUPLED_MICROSTRIP_VALIDITY_REFERENCE = (
+    "https://qucs.sourceforge.net/tech/node77.html"
+)
+_COUPLED_MIN_WIDTH_OVER_HEIGHT = 0.1
+_COUPLED_MAX_WIDTH_OVER_HEIGHT = 10.0
+_COUPLED_MIN_GAP_OVER_HEIGHT = 0.01
 
 
 def _sech(value: float) -> float:
     return 1.0 / math.cosh(value)
+
+
+def _inside_coupled_published_range(width_ratio: float, gap_ratio: float) -> bool:
+    width_at_or_above_minimum = (
+        width_ratio >= _COUPLED_MIN_WIDTH_OVER_HEIGHT
+        or math.isclose(width_ratio, _COUPLED_MIN_WIDTH_OVER_HEIGHT, rel_tol=1e-12)
+    )
+    width_at_or_below_maximum = (
+        width_ratio <= _COUPLED_MAX_WIDTH_OVER_HEIGHT
+        or math.isclose(width_ratio, _COUPLED_MAX_WIDTH_OVER_HEIGHT, rel_tol=1e-12)
+    )
+    gap_at_or_above_minimum = (
+        gap_ratio >= _COUPLED_MIN_GAP_OVER_HEIGHT
+        or math.isclose(gap_ratio, _COUPLED_MIN_GAP_OVER_HEIGHT, rel_tol=1e-12)
+    )
+    return (
+        width_at_or_above_minimum
+        and width_at_or_below_maximum
+        and gap_at_or_above_minimum
+    )
 
 
 def _air_impedance(normalized_width: float) -> float:
@@ -252,7 +278,10 @@ def calculate_impedance(values: ImpedanceInput) -> ImpedanceResult:
     elif values.structure == "differential_microstrip":
         assert values.gap_mm is not None
         normalized_gap = values.gap_mm / values.dielectric_height_mm
-        within_validity = 0.1 <= normalized_width <= 10.0 and normalized_gap >= 0.01
+        within_validity = _inside_coupled_published_range(
+            normalized_width,
+            normalized_gap,
+        )
         if not within_validity:
             warnings.append(
                 "Width/height or gap/height is outside the published coupled-model range."
@@ -268,9 +297,23 @@ def calculate_impedance(values: ImpedanceInput) -> ImpedanceResult:
             "normalized_width": normalized_width,
             "normalized_gap": normalized_gap,
             "published_range": {
-                "min_width_over_height": 0.1,
-                "max_width_over_height": 10.0,
-                "min_gap_over_height": 0.01,
+                "min_width_over_height": _COUPLED_MIN_WIDTH_OVER_HEIGHT,
+                "max_width_over_height": _COUPLED_MAX_WIDTH_OVER_HEIGHT,
+                "min_gap_over_height": _COUPLED_MIN_GAP_OVER_HEIGHT,
+            },
+            "published_range_citations": {
+                "min_width_over_height": (
+                    f"{_COUPLED_MICROSTRIP_VALIDITY_REFERENCE} — Hammerstad and Jensen "
+                    "validation range before equation 11.156"
+                ),
+                "max_width_over_height": (
+                    f"{_COUPLED_MICROSTRIP_VALIDITY_REFERENCE} — Hammerstad and Jensen "
+                    "validation range before equation 11.156"
+                ),
+                "min_gap_over_height": (
+                    f"{_COUPLED_MICROSTRIP_VALIDITY_REFERENCE} — Hammerstad and Jensen "
+                    "validation range before equation 11.156"
+                ),
             },
             "inside_published_range": within_validity,
             **modal,

--- a/tests/test_impedance_invariants.py
+++ b/tests/test_impedance_invariants.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from itertools import pairwise, product
+
+import pytest
+
+from diptrace_mcp.domain import ImpedanceInput, ImpedanceResult
+from diptrace_mcp.impedance import calculate_impedance
+
+ER_VALUES = (2.2, 3.5, 4.1, 4.4, 10.2)
+HEIGHTS_MM = (0.1, 0.18, 0.5, 1.0)
+WIDTH_RATIOS = (0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0)
+IN_BAND_WIDTH_RATIOS = WIDTH_RATIOS[:-1]
+GAP_RATIOS = (0.01, 0.1, 0.2, 0.5, 1.0, 2.0, 10.0)
+COPPER_THICKNESSES_MM = (0.0, 0.035, 0.070)
+
+
+def _coupled_result(
+    *,
+    er: float,
+    height_mm: float,
+    width_ratio: float,
+    gap_ratio: float,
+    thickness_mm: float,
+) -> ImpedanceResult:
+    return calculate_impedance(
+        ImpedanceInput(
+            structure="differential_microstrip",
+            width_mm=width_ratio * height_mm,
+            gap_mm=gap_ratio * height_mm,
+            copper_thickness_mm=thickness_mm,
+            dielectric_height_mm=height_mm,
+            dielectric_constant=er,
+        )
+    )
+
+
+def _zero_thickness_single_result(
+    *,
+    er: float,
+    height_mm: float,
+    width_ratio: float,
+) -> ImpedanceResult:
+    return calculate_impedance(
+        ImpedanceInput(
+            structure="microstrip",
+            width_mm=width_ratio * height_mm,
+            copper_thickness_mm=0.0,
+            dielectric_height_mm=height_mm,
+            dielectric_constant=er,
+        )
+    )
+
+
+def test_coupled_published_bounds_are_cited_and_inclusive() -> None:
+    result = _coupled_result(
+        er=4.1,
+        height_mm=0.18,
+        width_ratio=0.1,
+        gap_ratio=0.01,
+        thickness_mm=0.0,
+    )
+
+    assert result.validity["inside_published_range"] is True
+    published_range = result.validity["published_range"]
+    citations = result.validity["published_range_citations"]
+    assert published_range == {
+        "min_width_over_height": 0.1,
+        "max_width_over_height": 10.0,
+        "min_gap_over_height": 0.01,
+    }
+    assert citations.keys() == published_range.keys()
+    assert all(
+        "https://qucs.sourceforge.net/tech/node77.html" in citation
+        for citation in citations.values()
+    )
+
+
+def test_coupled_microstrip_swept_physical_invariants() -> None:
+    evaluated = 0
+    for er, height_mm, thickness_mm in product(
+        ER_VALUES,
+        HEIGHTS_MM,
+        COPPER_THICKNESSES_MM,
+    ):
+        results_by_gap: dict[float, dict[float, ImpedanceResult]] = {}
+        for gap_ratio in GAP_RATIOS:
+            results_by_width: dict[float, ImpedanceResult] = {}
+            for width_ratio in WIDTH_RATIOS:
+                result = _coupled_result(
+                    er=er,
+                    height_mm=height_mm,
+                    width_ratio=width_ratio,
+                    gap_ratio=gap_ratio,
+                    thickness_mm=thickness_mm,
+                )
+                results_by_width[width_ratio] = result
+                evaluated += 1
+
+                if width_ratio <= 10.0:
+                    single = _zero_thickness_single_result(
+                        er=er,
+                        height_mm=height_mm,
+                        width_ratio=width_ratio,
+                    )
+                    single_er = single.effective_dielectric_constant
+                    assert single_er is not None
+                    odd_er = float(
+                        result.validity["odd_mode_effective_dielectric_constant"]
+                    )
+                    even_er = float(
+                        result.validity["even_mode_effective_dielectric_constant"]
+                    )
+                    # The coupled branch is explicitly zero-thickness. Compare its
+                    # modal permittivities with the zero-thickness single line even
+                    # when the caller supplied finite copper thickness.
+                    assert odd_er < single_er < even_er
+                    assert 1.0 < odd_er < er
+                    assert 1.0 < single_er < er
+                    assert 1.0 < even_er < er
+                    assert result.validity["inside_published_range"] is True
+                else:
+                    # Do not assert model physics outside the published W/h band.
+                    assert result.validity["inside_published_range"] is False
+                    assert result.confidence == "low"
+                    assert any("outside" in warning.lower() for warning in result.warnings)
+
+            in_band_by_width = [
+                results_by_width[ratio].estimated_impedance_ohm
+                for ratio in IN_BAND_WIDTH_RATIOS
+            ]
+            assert all(
+                left > right
+                for left, right in pairwise(in_band_by_width)
+            )
+            results_by_gap[gap_ratio] = results_by_width
+
+        for width_ratio in IN_BAND_WIDTH_RATIOS:
+            in_band_by_gap = [
+                results_by_gap[ratio][width_ratio].estimated_impedance_ohm
+                for ratio in GAP_RATIOS
+            ]
+            assert all(
+                left < right
+                for left, right in pairwise(in_band_by_gap)
+            )
+
+    assert evaluated == 3_360
+
+
+def test_coupled_microstrip_impedance_increases_with_dielectric_height() -> None:
+    for er, thickness_mm in product(ER_VALUES, COPPER_THICKNESSES_MM):
+        impedances = [
+            calculate_impedance(
+                ImpedanceInput(
+                    structure="differential_microstrip",
+                    width_mm=0.2,
+                    gap_mm=0.15,
+                    copper_thickness_mm=thickness_mm,
+                    dielectric_height_mm=height_mm,
+                    dielectric_constant=er,
+                )
+            ).estimated_impedance_ohm
+            for height_mm in HEIGHTS_MM
+        ]
+        assert all(
+            left < right
+            for left, right in pairwise(impedances)
+        )
+
+
+def test_coupled_microstrip_decoupling_asymptote() -> None:
+    for er, height_mm, width_ratio, thickness_mm in product(
+        ER_VALUES,
+        HEIGHTS_MM,
+        IN_BAND_WIDTH_RATIOS,
+        COPPER_THICKNESSES_MM,
+    ):
+        coupled = _coupled_result(
+            er=er,
+            height_mm=height_mm,
+            width_ratio=width_ratio,
+            gap_ratio=1_000.0,
+            thickness_mm=thickness_mm,
+        )
+        single = _zero_thickness_single_result(
+            er=er,
+            height_mm=height_mm,
+            width_ratio=width_ratio,
+        )
+        single_er = single.effective_dielectric_constant
+        assert single_er is not None
+        odd_er = float(coupled.validity["odd_mode_effective_dielectric_constant"])
+        even_er = float(coupled.validity["even_mode_effective_dielectric_constant"])
+
+        assert odd_er == pytest.approx(single_er, rel=0.01)
+        assert even_er == pytest.approx(single_er, rel=0.01)
+        if thickness_mm == 0.0:
+            assert coupled.estimated_impedance_ohm == pytest.approx(
+                2.0 * single.estimated_impedance_ohm,
+                rel=0.05,
+            )
+        else:
+            # The coupled model does not implement the finite-thickness
+            # correction, so comparing it with a thickness-corrected Z0 would
+            # turn this physical asymptote into a known false assertion.
+            assert coupled.confidence == "low"
+            assert any(
+                "Finite copper thickness" in warning for warning in coupled.warnings
+            )

--- a/tests/test_signal_integrity.py
+++ b/tests/test_signal_integrity.py
@@ -179,6 +179,18 @@ def test_coupled_microstrip_physical_invariants() -> None:
         dielectric_constant=4.1,
     )
     result = calculate_impedance(v)
+    tolerance_result = calculate_impedance(
+        v.model_copy(
+            update={
+                "target_ohm": result.estimated_impedance_ohm,
+                "tolerance_ohm": 0.0,
+            }
+        )
+    )
+
+    assert tolerance_result.within_tolerance is True
+    assert result.validity["inside_published_range"] is True
+    assert result.sensitivity_ohm_per_percent["gap_mm"] > 0.0
 
     # INVARIANT 1: eps_eff ordering — odd < single < even
     # The odd mode has MORE field in air, so its eps_eff must be the LOWEST.


### PR DESCRIPTION
WO-7 replaces the stale Qucs golden-case claim with physical invariants swept across 3,360 geometries and all requested copper thicknesses. Assertions are band-aware, include modal-permittivity ordering, width/height/gap monotonicity, decoupling and Zdiff asymptotes, and preserve the explicit finite-thickness limitation. The implemented equations are the Qucs Hammerstad-Jensen section, whose stated validation range is 0.1 <= W/h <= 10 and gap/h >= 0.01; the stricter 0.1 <= gap/h <= 10 range on the same page belongs to the different Kirschning-Jansen model and is not attributed to this implementation.