### PR TITLE
docs: make open compatibility questions evidence-ready

### DIFF
--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,177 +1,401 @@
 # Open Questions — DipTrace XML Format
 
-This document lists every fact the code depends on but the official specification does not
-settle. Each entry includes the question, why the code depends on it, the file:line that
-assumes it, and the exact experiment that would settle it.
+This document tracks known, high-impact compatibility questions that the public
+specifications and committed evidence do not settle. It is not exhaustive. Each question
+states the production dependency, a stable code-symbol reference, and an experiment that
+requires a real DipTrace installation or other human-controlled evidence.
+
+Do not turn these questions into conventions by round-tripping a writer through this
+project's reader. Where evidence is absent, the implementation must disclose, preserve, or
+refuse rather than guess.
 
 ---
 
 ## Q1: Is `Component/@Angle` in radians or degrees?
 
-**Why the code depends on it:** The reader at `adapters.py:223` reads the raw attribute
-and calls `math.degrees()` on it, assuming it is in radians. The writer at
-`semantic_compiler.py:2175` writes `math.radians(angle_deg)`. Every existing test
-round-trips through the same assumption, so the test passes whether or not the assumption
-is correct.
+**Question:** Does DipTrace interpret an ordinary PCB or schematic
+`Component/@Angle` value as radians or degrees?
 
-**File:line:** `adapters.py:223`, `adapters.py:591`, `semantic_compiler.py:2175`
+**Why the code depends on it:** The reader
+`src/diptrace_mcp/adapters.py::_component_records` applies `math.degrees()`, while the
+primary writer `src/diptrace_mcp/semantic_compiler.py::_set_angle_attribute` applies
+`math.radians()`. Those functions are exact inverses, so a writer-reader round trip cannot
+validate the convention.
 
-**What the spec says:** "Component rotation angle. The parameter is absent if = 0."
-No unit is stated. For text/picture shapes the spec explicitly says "Angle of the text
-and picture in radians." For table orientation it says "digrees." The component angle
-is silent.
+**What is documented:** The public specification says only “Component rotation angle.”
+It explicitly says radians for text and pictures and degrees for table orientation, but
+states no unit for `Component/@Angle`.
 
-**Experiment:** In DipTrace, place one component, set rotation to exactly 90 degrees,
-export XML, read the literal attribute value. If the value is approximately 1.5708
-(pi/2), the unit is radians. If it is exactly 90, the unit is degrees.
+**Experiment:** In DipTrace, place one component, set its rotation to exactly 90 degrees,
+and export XML without passing the file through MCP. Read the literal value. Approximately
+`1.5708` means radians; `90` means degrees.
 
-**Who can perform:** Human with DipTrace license.
-
----
-
-## Q2: Does DipTrace address top-level arrays by `Id` or by position?
-
-**Why the code depends on it:** The code deletes elements out of the middle of arrays
-(Components, Nets, Ratlines, Traces). If DipTrace addresses by position (index), then
-deleting element at index 2 causes element at index 3 to become index 2, and all
-cross-references break. If it addresses by `Id`, deletions are safe.
-
-**File:line:** Various deletion paths in `semantic_compiler.py`, `synchronization.py`
-
-**Experiment:** Export a board with 3 components (Ids 0, 1, 2). Delete the middle
-component (Id 1) by hand in a text editor. Open in DipTrace, save, re-export, compare
-Ids. If the remaining components have Ids 0 and 2, DipTrace uses Id-based addressing.
-If they have Ids 0 and 1, it uses position-based addressing.
-
-**Who can perform:** Human with DipTrace license.
+**Who can perform:** Human with a licensed DipTrace installation.
 
 ---
 
-## Q3: What encoding and line endings does DipTrace write?
+## Q2: Which objects can an `ImpMode=All` apply delete because the exchange export omitted them?
 
-**Why the code depends on it:** The writer emits UTF-8 unconditionally. If DipTrace
-produces UTF-16 with BOM, or uses CRLF line endings, round-tripping will change bytes.
+**Question:** Is an `ExpMode=All` exchange complete enough that returning it under
+`ImpMode=All` cannot delete design objects or embedded records that DipTrace omitted from
+`plugin_exchange.xml`?
 
-**File:line:** `xml_document.py` (write path)
+**Why the code depends on it:** The shipped PCB and schematic profiles use
+`ImpMode=All`, and `src/diptrace_mcp/sessions.py::SessionStore.finalize` copies the complete
+working exchange file back when `src/diptrace_mcp/service.py::DipTraceService.finish_live_session`
+requests apply. There is no per-object survival check before that replacement.
 
-**Experiment:** Export the same board with `Units` = mm, inch, and mil. Examine the
-raw bytes of each file. Check: (a) encoding declaration in the XML prolog, (b) presence
-of BOM, (c) line endings (LF vs CRLF).
+**What is documented:** The public plug-in specification defines `ImpMode=All` as importing
+all regardless of object-specific settings. The repository's
+[exchange reference](../reference/diptrace-xml/REFERENCE.md#exchange-lifecycle) records list
+replacement behavior, and a committed
+[compatibility observation](XML_COMPATIBILITY.md#preservation-rules) records one live
+round trip in which DipTrace removed unreferenced embedded pattern records. The public
+plug-in specification does not enumerate everything that an `ExpMode=All` export may omit.
+The current profiles are
+[`pcb.settings.xml`](../plugin/settings/pcb.settings.xml) and
+[`schematic.settings.xml`](../plugin/settings/schematic.settings.xml).
 
-**Who can perform:** Human with DipTrace license.
+**Experiment:** On a disposable copy, export a board rich in object types: components,
+embedded patterns and pad styles, nets, traces, vias, pours, shapes, tables, dimensions,
+differential pairs, groups, and board outline. Record counts, IDs, and relevant subtree
+hashes by type. Apply one unrelated scalar edit under `ImpMode=All`, save, re-export, and
+compare every type. Repeat with a byte-unchanged apply as a canonicalization control. Any
+loss must become a refusal or an explicit deletion disclosure.
 
----
-
-## Q4: How many significant digits does DipTrace emit for `Real` attributes?
-
-**Why the code depends on it:** The writer can produce scientific notation (e.g.
-`9.6e-09`). If DipTrace does not emit scientific notation, or uses a fixed number of
-significant digits, round-tripping will change the byte representation of every real
-number.
-
-**File:line:** `semantic_compiler.py` (float formatting), `xml_document.py`
-
-**Experiment:** Place a component at a coordinate that requires many significant digits
-(e.g. X="12.345678"). Export XML, examine the literal value. Try values like 0.001,
-0.000001, 1e-6, 1e-9.
-
-**Who can perform:** Human with DipTrace license.
-
----
-
-## Q5: With `ImpMode=All`, does DipTrace re-import the exchange file after Cancel?
-
-**Why the code depends on it:** If Cancel is a no-op (no re-import), then the
-`ImpMode=All` profiles can safely be used for read-only sessions. If Cancel still
-triggers a re-import, the plug-in must not modify the file at all during a read-only
-session.
-
-**File:line:** `sessions.py`, `bridge.py` (session state machine)
-
-**Experiment:** Export XML, run the plug-in with `ImpMode=All`, press Cancel, save in
-DipTrace, export again, compare SHA-256. If hashes differ, Cancel triggers re-import
-and the PCB/Schematic profiles must move to `ImpMode=Edit`.
-
-**Who can perform:** Human with DipTrace license.
+**Who can perform:** Human with DipTrace 5.3 and a disposable representative design.
 
 ---
 
-## Q6: Does DipTrace honour `Selected="Y"` on import for newly added objects?
+## Q3: Does Cancel prevent an `ImpMode=All` exchange from being re-imported?
 
-**Why the code depends on it:** The writer currently emits `Selected="N"` for all
-objects. If DipTrace ignores this attribute on import, it is harmless. If DipTrace
-uses it to determine which objects to highlight or apply operations to, emitting "N"
-silently suppresses a user-visible state.
+**Question:** When the bridge returns Cancel, does DipTrace leave the design untouched, or
+does it still read some or all of the exchange file?
 
-**File:line:** `semantic_compiler.py` (Selected attribute handling)
+**Why the code depends on it:** `src/diptrace_mcp/bridge.py::BridgeController.finish` and
+`src/diptrace_mcp/sessions.py::SessionStore.finalize` distinguish apply from cancel, but
+the repository has no acknowledgement from DipTrace proving what the host application did
+after the process exited.
 
-**Experiment:** Create a board with one component selected. Export XML. Verify that
-the exported component has `Selected="Y"`. Then manually add a new component to the
-XML with `Selected="Y"`, import via the plug-in, and check if DipTrace shows it as
-selected.
+**Experiment:** On a disposable board, make the test plug-in write a recognizable harmless
+change to the exchange XML, then press Cancel. Save and independently re-export the board.
+Check the specific field and object counts, not only whole-file SHA-256, because DipTrace
+may canonicalize an otherwise unchanged file.
 
-**Who can perform:** Human with DipTrace license.
-
----
-
-## Q7: What does DipTrace do if the plug-in exits non-zero, leaves the file unchanged,
-or truncates it?
-
-**Why the code depends on it:** The bridge must handle these error conditions. Today
-the bridge reports success in all cases. If DipTrace ignores non-zero exit codes,
-the bridge must use a different mechanism (file hash comparison) to detect failure.
-
-**File:line:** `bridge.py` (exit handling), `service.py` (finish_live_session)
-
-**Experiment:** (a) Make the plug-in exit with code 1. Does DipTrace show an error?
-(b) Make the plug-in exit with code 0 but leave the file unchanged. Does DipTrace
-import the unchanged file? (c) Make the plug-in truncate the file to 0 bytes. Does
-DipTrace show an error or crash?
-
-**Who can perform:** Human with DipTrace license.
+**Who can perform:** Human with a licensed DipTrace installation.
 
 ---
 
-## Q8: Which XML elements did DipTrace 5.3 add that the 2023 specifications do not cover?
+## Q4: Does DipTrace address top-level list entries by `Id` or by position?
 
-**Why the code depends on it:** The spec PDFs describe format version 4.3.0.3. DipTrace
-5.3 added a native XML project format and may have added new XML elements or attributes.
-Without knowing what was added, the reader may silently drop data from 5.3 files.
+**Question:** Are sparse IDs and removal from the middle of top-level arrays preserved, or
+does DipTrace renumber entries by list position?
 
-**File:line:** `adapters.py` (element parsing), `xml_document.py` (version detection)
+**Why the code depends on it:** Exact synchronization can remove components, nets, traces,
+and ratlines in `src/diptrace_mcp/semantic_compiler.py::_apply_sync_schematic_to_pcb`, and
+direct routing deletion is implemented by
+`src/diptrace_mcp/routing_compiler.py::_delete_traces`. Cross-references are safe only if
+the host preserves the documented IDs or consistently rewrites every dependent reference.
 
-**Experiment:** Open the vendor's public "What's new" page for DipTrace 5.3. Check
-the `Docs` folder inside the DipTrace installation for updated specification PDFs.
-Export a board from DipTrace 5.3 and compare the element set against the 4.3.0.3 spec.
+**Experiment:** Export a design with three mutually referenced objects whose IDs are
+`0`, `1`, and `2`. In a disposable copy, remove the middle object and import it. Save and
+re-export. Compare remaining IDs and every reference. Repeat with deliberately sparse IDs
+such as `2`, `9`, and `40`.
 
-**Who can perform:** Human with DipTrace license and access to the installation directory.
-
----
-
-## Q9: Does DipTrace write `Component/@Angle` when the value is 0?
-
-**Why the code depends on it:** The spec says "The parameter is absent if = 0." The
-code already handles this (omits the attribute when angle is 0). But we need to verify
-DipTrace actually does this.
-
-**File:line:** `semantic_compiler.py` (angle handling)
-
-**Experiment:** Place a component with rotation 0. Export XML. Check whether the `Angle`
-attribute is present or absent.
-
-**Who can perform:** Human with DipTrace license.
+**Who can perform:** Human with DipTrace and a disposable cross-referenced design.
 
 ---
 
-## Q10: What is the maximum number of significant digits DipTrace uses for coordinates?
+## Q5: Which routed `Point` attributes does DipTrace 5.3 require and preserve?
 
-**Why the code depends on it:** If DipTrace uses 6 significant digits but the writer
-uses 9, every coordinate will differ in the least significant digits, breaking
-byte-for-byte round-tripping.
+**Question:** Which optional `Point` attributes does DipTrace 5.3 actually emit, require on
+import, and preserve for straight segments, arcs, jumpers, vias, necks, meanders, and
+differential-pair points?
 
-**File:line:** `semantic_compiler.py` (float formatting)
+**Why the code depends on it:** `src/diptrace_mcp/routing_compiler.py::_write_points`
+deletes every existing child and writes a fixed set, including `Jumper="0"` and `Arc="N"`;
+`src/diptrace_mcp/routing_compiler.py::_replace_trace` relies on that rewrite. Any
+condition-dependent attribute outside that set is lost.
 
-**Experiment:** Place components at various coordinates and export. Examine the number
-of digits after the decimal point. Try coordinates like 0.1, 0.01, 0.001, 123.456789.
+**What is documented:** PCB specification section 4.20.1.6.1.2.1 names 16 trace-point
+attributes: `Id`, `X`, `Y`, `Lay`, `Width`, `Jumper`, `Arc`, `ViaStyle`, `PhaseFwd`,
+`PhaseBack`, `PairPoint`, `PairSubPoint`, `PairNecked`, `Meander`, `MeanderAngle`, and
+`Selected`. What remains unknown is the real 5.3 combination and required semantics for
+each geometry, not the existence of the documented names.
 
-**Who can perform:** Human with DipTrace license.
+**Experiment:** Export one minimal example each of a straight trace, arc, top and bottom
+jumper, via transition, necked segment, meander, and differential pair. Preserve the raw
+files. Compare the per-`Point` attribute sets, then remove one optional-looking attribute
+at a time in disposable imports to distinguish required, derived, and ignored fields.
+
+**Who can perform:** Human with DipTrace 5.3 who can create each routing geometry.
+
+---
+
+## Q6: Under object setting `All`, does `Selected="Y"` become persistent imported selection state?
+
+**Question:** For a newly added PCB or schematic object imported with the object selector
+set to `All`, does `Selected="Y"` control or persist the post-import UI selection state?
+
+**Why the code depends on it:** Every creation path that emits this attribute hard-codes
+`Selected="N"`; no creation writer emits `Selected="Y"`. Representative paths are
+`src/diptrace_mcp/semantic_compiler.py::_apply_add_testpoint`,
+`src/diptrace_mcp/semantic_compiler.py::_apply_place_part`,
+`src/diptrace_mcp/routing_compiler.py::_write_points`, and
+`src/diptrace_mcp/scaffolding.py::build_pcb_document`. If the attribute also represents a
+persistent user-visible state, those writers intentionally clear it.
+
+**What is documented:** The
+[public plug-in specification text](../reference/diptrace-xml/extracted_text/DipTrace_Plugins.pages.json)
+says that a PCB/Schematic object selector set to `Selected` considers incoming
+`Selected="Y"`. That filtering behavior is settled. The shipped profiles use selector
+`All`, and the specification does not state whether selection/highlighting persists after
+import. For Component/Pattern Editor import, the specification says `Selected` is
+equivalent to `All`; that is a separate documented rule.
+
+**Experiment:** Under a temporary PCB or schematic profile whose object selector is `All`,
+import otherwise identical new objects with `Selected="Y"` and `Selected="N"`. Inspect the
+UI selection immediately, then save and re-export both objects. A separate selector
+`Selected` control can confirm the documented filter without treating it as the unknown.
+
+**Who can perform:** Human with a licensed DipTrace installation.
+
+---
+
+## Q7: Which `Real` spellings does DipTrace emit and accept?
+
+**Question:** What precision and lexical forms does DipTrace emit for `Real` values, and
+does its importer accept equivalent scientific notation such as `9.6e-09`?
+
+**Why the code depends on it:** Writers use bounded general formatting in
+`src/diptrace_mcp/semantic_compiler.py::_set_angle_attribute`,
+`src/diptrace_mcp/semantic_compiler.py::_apply_net_class_rules`, and
+`src/diptrace_mcp/routing_compiler.py::_write_points`. The resulting text can differ from
+DipTrace's preferred spelling even when the numeric value is equal.
+
+**Experiment:** First export values spanning large, small, and high-precision magnitudes
+and record their literal spellings. Then hand-edit one valid `Real` in a disposable
+exchange file from decimal notation to the equivalent `9.6e-09`, import it, and re-export.
+Record whether DipTrace rejects, accepts and canonicalizes, or preserves the scientific
+notation.
+
+**Who can perform:** Human with a licensed DipTrace installation.
+
+---
+
+## Q8: Which encoding, BOM, and line endings does DipTrace export?
+
+**Question:** What source encoding, BOM policy, XML declaration spelling, and line endings
+does each DipTrace editor emit?
+
+**Why the code depends on it:** The parser
+`src/diptrace_mcp/xml_document.py::DipTraceDocument.from_bytes` accepts several encodings,
+while full-tree output from
+`src/diptrace_mcp/xml_document.py::DipTraceDocument.serialize` is UTF-8. Exact untouched
+byte preservation and independent DipTrace canonicalization must not be conflated.
+
+**Experiment:** Export minimal PCB, schematic, Component Library, and Pattern Library
+documents directly from DipTrace. Inspect raw bytes for BOM, declaration encoding, and
+LF/CRLF. Include non-ASCII text such as Cyrillic plus `µ`, `Ω`, `°`, and `±`.
+
+**Who can perform:** Human with each relevant DipTrace 5.3 editor.
+
+---
+
+## Q9: Must an MCP edit preserve the source encoding and BOM?
+
+**Question:** Which loaded encodings can be returned after an edit without DipTrace
+rejecting or corrupting the exchange, and must the original BOM/declaration be preserved?
+
+**Why the code depends on it:** Raw replacements in
+`src/diptrace_mcp/xml_document.py::DipTraceDocument.apply_edits` retain surrounding bytes,
+but `src/diptrace_mcp/xml_document.py::_serialize_new_element` emits UTF-8 and the document
+model does not retain an explicit source-encoding field. Structural edits to UTF-16/32
+input can therefore produce an invalid mixed-encoding result.
+
+**Experiment:** For clean UTF-8, UTF-8-with-BOM, UTF-16LE/BE, and any encoding DipTrace
+itself exports, apply one raw attribute edit and one structural insertion. Import each
+result into a disposable design, then save and re-export. Verify non-ASCII text and inspect
+the final declaration/BOM.
+
+**Who can perform:** Human with DipTrace and provenance-preserving encoded fixtures.
+
+---
+
+## Q10: How does DipTrace 5.3 encode authoritative copper-pour fill data?
+
+**Question:** Does DipTrace 5.3 store filled copper regions as plain XML text,
+Deflate-compressed Base64, another encoding, or only derived data outside the public
+exchange format?
+
+**Why the code depends on it:** `src/diptrace_mcp/adapters.py::_board_copper_pour_records`
+models only the boundary polygon and explicitly warns that it is not the final refilled
+region. Clearance, routing, and DFM logic cannot treat that boundary as authoritative
+copper.
+
+**Experiment:** In DipTrace 5.3, create a pour with thermal spokes, a cutout, an island,
+and an obstacle, refill it, and export before and after refill. Inspect every
+`CopperPour` child and payload without assuming a decoder. If an encoded blob changes,
+identify its envelope and compression only from reproducible decode evidence.
+
+**Who can perform:** Human with DipTrace 5.3 and a controlled pour fixture.
+
+---
+
+## Q11: What are the standalone Component and Pattern Editor XML mutation semantics?
+
+**Question:** What complete XML structures, identity rules, and replacement behavior do
+the standalone Component and Pattern Editors require for safe library mutation?
+
+**Why the code depends on it:** `src/diptrace_mcp/library_adapters.py::get_library_model`
+and `src/diptrace_mcp/library_adapters.py::_components` read observed library structures,
+but there is no public Component/Pattern XML format specification and no native library
+writer. Reader success does not prove mutation semantics.
+
+**What is documented:** The public plug-in specification documents editor export/import
+modes such as `Library All`, `Library Add`, `Library Insert`, `Component All`, `Part All`,
+and `Edit`. It does not document the complete library XML schema or identity/canonicalization
+rules.
+
+**Experiment:** Export minimal Component and Pattern libraries, then vary one setting at a
+time: multi-part structure, pin and pad identity, pattern attachment, mask, paste,
+courtyard, additional fields, and embedded graphics. For each, retain export → import →
+save → re-export pairs and compare identity references and object counts.
+
+**Who can perform:** Human with licensed Component and Pattern Editors and permission to
+share sanitized fixtures.
+
+---
+
+## Q12: How does DipTrace acknowledge plug-in failure or output corruption?
+
+**Question:** What does DipTrace do when the plug-in exits non-zero, exits zero without a
+change, produces malformed/truncated XML, or applies successfully?
+
+**Why the code depends on it:** `src/diptrace_mcp/bridge.py::BridgeController.finish` can
+report local finalization, and `src/diptrace_mcp/sessions.py::SessionStore.finalize` can
+reject local copy/parse failures, but neither receives a host acknowledgement that
+DipTrace accepted the import. Local success is not application success.
+
+**Experiment:** On disposable files, run four controlled plug-ins: exit `1`; exit `0`
+unchanged; exit `0` with a zero-byte file; and exit `0` with one valid edit. Record dialogs,
+whether the design changes, and the process/host exit behavior. Re-export after each case.
+
+**Who can perform:** Human with DipTrace and a controlled test plug-in.
+
+---
+
+## Q13: Which DipTrace 5.3 XML elements and attributes are absent from the public specifications?
+
+**Question:** What XML vocabulary or semantics were added after the public 4.3-era PCB and
+schematic specifications?
+
+**Why the code depends on it:** `src/diptrace_mcp/adapters.py::build_snapshot` exposes only
+known normalized structures, while
+`src/diptrace_mcp/adapters.py::_compatibility_for` reports the version boundary. Unknown
+raw XML is generally preserved, but it may remain invisible to analysis or be at risk when
+an owning parent is regenerated.
+
+**Experiment:** Inspect the `Docs` directory from a DipTrace 5.3 installation for newer
+specifications. Export representative 5.3 PCB and schematic designs and compare all element
+paths and attributes with `reference/diptrace-xml/spec_inventory.json`. Record unknowns;
+do not promote them from a synthetic fixture alone.
+
+**Who can perform:** Human with DipTrace 5.3 and access to its installation directory.
+
+---
+
+## Q14: Can DipTrace 5.3 open and save its native XML project format directly?
+
+**Question:** Can a current `.dip`, `.dch`, `.eli`, or `.lib` XML project be opened and
+saved directly without the plug-in exchange lifecycle, and what subset differs from
+exchange XML?
+
+**Why the code depends on it:** `src/diptrace_mcp/xml_document.py::DipTraceDocument.from_bytes`
+accepts supported XML roots regardless of filename extension, while
+`src/diptrace_mcp/service.py::DipTraceService.resolve_target` still treats the live bridge
+as the central write channel. If native XML is directly editable, much of the
+`ImpMode`/session risk may be avoidable.
+
+**Experiment:** Create one native XML project in DipTrace 5.3, close it, copy it, change one
+safe scalar in the copy, and open the copy directly in DipTrace without a plug-in. Save and
+re-export it. Compare roots, object counts, and canonicalization with a plug-in exchange
+from the same design.
+
+**Who can perform:** Human with DipTrace 5.3 using disposable project copies.
+
+---
+
+## Q15: What does DipTrace canonicalize on open, save, and re-export?
+
+**Question:** Which byte and semantic changes does DipTrace itself make to an untouched
+export or native XML project?
+
+**Why the code depends on it:** `src/diptrace_mcp/xml_document.py::RawTreeSnapshot.compile`
+protects untouched MCP regions, while
+`src/diptrace_mcp/service.py::_semantic_roundtrip_check` compares selected normalized
+categories. Neither defines DipTrace's independent ordering, default omission, derived
+records, or numeric canonicalization.
+
+**Experiment:** Export a representative design, open and save it without editing, then
+re-export. Compare byte-level and semantic changes separately: ordering, IDs, omitted
+defaults, number spelling, derived lists, embedded records, and whitespace.
+
+**Who can perform:** Human with DipTrace and a representative disposable design.
+
+---
+
+## Q16: How does the same design scale across root `Units=mm`, `inch`, and `mil`?
+
+**Question:** Does DipTrace rescale every dimension consistently across the three documented
+root units, and are any fields always stored in a fixed unit?
+
+**Why the code depends on it:** Unit normalization is centralized in
+`src/diptrace_mcp/geometry.py::to_mm` and
+`src/diptrace_mcp/geometry.py::from_mm`, and readers such as
+`src/diptrace_mcp/adapters.py::_float_attr_mm` assume dimensional fields follow root
+`Units` unless explicitly documented otherwise.
+
+**Experiment:** Export the same unchanged design three times with root units set to `mm`,
+`inch`, and `mil`. Normalize documented dimensions and compare them field by field. Record
+any attribute that does not scale with root units rather than adding an inferred exception.
+
+**Who can perform:** Human with DipTrace and control of export units.
+
+---
+
+## Q17: What DSN/SES conventions does DipTrace use on a real routed design?
+
+**Question:** Which Specctra quoting, layer, padstack, via, coordinate, and session constructs
+does DipTrace emit and accept in a real DSN/SES round trip?
+
+**Why the code depends on it:** `src/diptrace_mcp/specctra.py::export_dsn`,
+`src/diptrace_mcp/specctra.py::parse_ses`, and
+`src/diptrace_mcp/specctra.py::session_to_operations` are currently validated without a
+committed real DipTrace-generated DSN/SES pair. Synthetic inverse tests cannot establish
+host conventions.
+
+**Experiment:** Export a multilayer board with at least one routed trace and via to DSN,
+route a small change in a compatible external router, import the SES into DipTrace, and
+re-export. Preserve the original DSN, SES, source board XML, and final board XML unchanged.
+
+**Who can perform:** Human with DipTrace and a compatible Specctra-format router.
+
+---
+
+## Q18: What hierarchy records are required for a real multi-sheet schematic?
+
+**Question:** Which IDs, paths, connectors, and net records must agree for DipTrace to
+preserve a hierarchical multi-sheet schematic?
+
+**Why the code depends on it:** `src/diptrace_mcp/adapters.py::_schematic_sheets` normalizes
+known sheet data, while `src/diptrace_mcp/semantic_compiler.py::_apply_add_sheet` and
+`src/diptrace_mcp/semantic_compiler.py::_apply_add_wire` author only the currently
+implemented structures. A flat or synthetic fixture cannot prove hierarchy semantics.
+
+**Experiment:** Build a minimal two-level hierarchy with repeated block instances, local and
+global nets, hierarchy connectors, and cross-sheet references. Export, import without
+changes, save, and re-export. Compare all hierarchy paths, block IDs, connector endpoints,
+and logical net memberships.
+
+**Who can perform:** Human with DipTrace and a controlled hierarchical schematic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,9 @@ misclassified as attributes are excluded. Current coverage against this measured
 | Passthrough (unknown XML, kept byte-for-byte) | 174 |
 | **Coverage** | **28.5%** |
 
-See [FORMAT_COVERAGE.md](FORMAT_COVERAGE.md) for the full element-by-element inventory, and [OPEN_QUESTIONS.md](OPEN_QUESTIONS.md) for facts the specification does not settle.
+See [FORMAT_COVERAGE.md](FORMAT_COVERAGE.md) for the full element-by-element inventory, and
+[OPEN_QUESTIONS.md](OPEN_QUESTIONS.md) for the current maintained set of high-impact unresolved
+compatibility questions.
 
 Current practical classification:
 

--- a/tests/test_spec_inventory.py
+++ b/tests/test_spec_inventory.py
@@ -3,11 +3,34 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 _INVENTORY_PATH = Path("reference/diptrace-xml/spec_inventory.json")
 _COVERAGE_PATH = Path("docs/FORMAT_COVERAGE.md")
 _OPEN_QUESTIONS_PATH = Path("docs/OPEN_QUESTIONS.md")
+
+
+def _open_question_blocks() -> list[tuple[int, str, str]]:
+    content = _OPEN_QUESTIONS_PATH.read_text(encoding="utf-8")
+    headers = list(
+        re.finditer(
+            r"^## Q(?P<number>\d+): (?P<title>.+)$",
+            content,
+            flags=re.MULTILINE,
+        )
+    )
+    blocks: list[tuple[int, str, str]] = []
+    for index, header in enumerate(headers):
+        end = headers[index + 1].start() if index + 1 < len(headers) else len(content)
+        blocks.append(
+            (
+                int(header.group("number")),
+                header.group("title").strip(),
+                content[header.end() : end],
+            )
+        )
+    return blocks
 
 
 def _load_inventory() -> dict:
@@ -167,20 +190,72 @@ class TestOpenQuestions:
         """The open questions file must exist."""
         assert _OPEN_QUESTIONS_PATH.exists(), f"{_OPEN_QUESTIONS_PATH} does not exist"
 
-    def test_open_questions_has_entries(self) -> None:
-        """The open questions file must have at least 5 entries."""
-        content = _OPEN_QUESTIONS_PATH.read_text(encoding="utf-8")
-        # Count entries by looking for "## Q" headers
-        q_count = content.count("## Q")
-        assert q_count >= 5, f"Expected at least 5 open questions, found {q_count}"
+    def test_questions_are_sequential_and_have_nonempty_required_sections(self) -> None:
+        """Every question must carry the evidence-oriented structure."""
+        blocks = _open_question_blocks()
+        assert len(blocks) >= 13
+        assert [number for number, _, _ in blocks] == list(
+            range(1, len(blocks) + 1)
+        )
+        for number, title, block in blocks:
+            assert title.endswith("?"), f"Q{number} title is not a question"
+            for label in (
+                "Question",
+                "Why the code depends on it",
+                "Experiment",
+                "Who can perform",
+            ):
+                match = re.search(
+                    rf"\*\*{re.escape(label)}:\*\*\s*(.+?)"
+                    r"(?=\n\n\*\*|\n\n---|\Z)",
+                    block,
+                    flags=re.DOTALL,
+                )
+                assert match is not None, f"Q{number} missing {label}"
+                assert match.group(1).strip(), f"Q{number} has empty {label}"
 
-    def test_open_questions_have_experiment(self) -> None:
-        """Each open question must have an experiment section."""
-        content = _OPEN_QUESTIONS_PATH.read_text(encoding="utf-8")
-        assert "Experiment:" in content
-        assert "Who can perform:" in content
+    def test_each_dependency_section_has_a_stable_code_symbol(self) -> None:
+        """Line numbers drift; every dependency must cite a stable symbol."""
+        for number, _, block in _open_question_blocks():
+            why = re.search(
+                r"\*\*Why the code depends on it:\*\*\s*(.+?)"
+                r"(?=\n\n\*\*|\n\n---|\Z)",
+                block,
+                flags=re.DOTALL,
+            )
+            assert why is not None
+            assert re.search(
+                r"`src/diptrace_mcp/[a-z0-9_]+\.py::"
+                r"[A-Za-z_][A-Za-z0-9_.]*`",
+                why.group(1),
+            ), f"Q{number} lacks a stable code-symbol reference"
 
-    def test_component_angle_question_present(self) -> None:
-        """The Component/@Angle question must be present."""
+    def test_required_human_gated_unknowns_are_present(self) -> None:
+        """Keep every high-consequence unknown named by the work order."""
         content = _OPEN_QUESTIONS_PATH.read_text(encoding="utf-8")
-        assert "Component" in content and "Angle" in content and "radians" in content
+        question_six = next(
+            title
+            for number, title, _ in _open_question_blocks()
+            if number == 6
+        )
+        assert 'Selected="Y"' in question_six
+        required = (
+            "ImpMode=All",
+            "9.6e-09",
+            "copper-pour fill data",
+            "routing_compiler.py::_write_points",
+            "standalone Component and Pattern Editor XML",
+            "preserve the source encoding and BOM",
+        )
+        for phrase in required:
+            assert phrase in content
+        assert "does not state whether selection/highlighting persists" in content
+        assert "16 trace-point" in content
+
+    def test_answered_and_duplicate_questions_are_absent(self) -> None:
+        """Do not retain questions answered by the spec or duplicate numeric format."""
+        content = _OPEN_QUESTIONS_PATH.read_text(encoding="utf-8")
+        assert "Does DipTrace write `Component/@Angle` when the value is 0?" not in content
+        assert "maximum number of significant digits" not in content
+        assert "lists every fact" not in content
+        assert "not exhaustive" in content


### PR DESCRIPTION
WO-9 rewrites OPEN_QUESTIONS as a maintained, non-exhaustive evidence backlog. It adds the high-risk ImpMode=All omission/deletion experiment, separates documented and unknown Selected behavior, adds scientific-notation acceptance, copper-fill, library XML, routed Point and source-encoding questions, removes answered/duplicate entries, and replaces the weak substring guard with per-question structural and stable-symbol assertions.