### PR TITLE
Evidence: add review-only operator capture workflow

### DIFF
--- a/docs/EVIDENCE_CAPTURE.md
+++ b/docs/EVIDENCE_CAPTURE.md
@@ -1,0 +1,317 @@
+# Operator-assisted DipTrace evidence capture
+
+## Outcome
+
+`scripts/capture_diptrace_evidence.py` is a standard-library CLI for collecting an
+operator-produced source/open-save/re-export XML triple. It writes only to a quarantine rooted at
+an explicitly allowed directory and emits a review-only candidate manifest.
+
+It deliberately does **not**:
+
+- write to `tests/fixtures/acceptance/`;
+- call a result “golden”, “verified”, or “DipTrace-authenticated”;
+- grant `diptrace_exported`, `diptrace_open_save_verified`, or
+  `diptrace_roundtrip_verified`;
+- infer that an operator claim, a valid XML parse, or matching hashes proves provenance;
+- invent an expected numeric value or DipTrace serialization convention.
+
+Those properties make it suitable as the collection half of the evidence harness. Promotion into
+a trusted registry remains a separate, reviewable repository action.
+
+## Why the engine should be a script, with an optional thin skill
+
+The durable component should be a Python script. Path containment, XML hardening, hashing, atomic
+state-file replacement, recoverable multi-file finalization, stage ordering, and canonical manifest
+generation require deterministic code and direct tests. Encoding those rules only as
+natural-language skill instructions would make the evidence chain depend on agent compliance.
+
+A small `capture-diptrace-evidence` skill is still useful as the operator-facing layer. It should:
+
+1. turn an item from `docs/OPEN_QUESTIONS.md` or a probe pack into a concrete recipe;
+2. explain one action at a time to the Windows/DipTrace operator;
+3. run this CLI for `init`, `record`, `check`, `status`, and `finalize`;
+4. surface discrepancies and stop instead of answering for the operator;
+5. hand the candidate manifest to the independent review/ingest workflow.
+
+The skill must never duplicate hashing or trust decisions. Its bundled `scripts/` resource should
+be this tested engine (or a stable wrapper around a repository-installed command). The skill body
+can remain short because recipe shape and trust rules belong in repository documentation.
+
+## Capture model
+
+Each session binds these inputs:
+
+- one immutable recipe snapshot and SHA-256 computed from the same single byte read;
+- an operator label, reported DipTrace version/build, OS, and redistribution claim;
+- a required checklist designed for one experiment;
+- three distinct file roles captured in order:
+  - `source`: XML exported directly from the prepared design;
+  - `open_save`: a separate XML file saved by DipTrace after opening the source;
+  - `reexport`: a fresh XML export from the saved design.
+
+The files may be byte-identical. Equality is evidence, not a failure. They must nevertheless have
+different role paths so the manifest cannot silently reuse one file for every step.
+
+For each role the script records:
+
+- a byte-identical quarantine copy;
+- SHA-256 and byte size;
+- `Source/@Type`, `Source/@Version`, and `Source/@Units`;
+- counts for every descendant element name below `<Source>` and every direct child of `<Source>`;
+- stage-specific operator attestations and notes;
+- directly observed discrepancies such as a units change between stages.
+
+Element counts are intentionally syntactic. They make object loss reviewable without pretending
+that every tag is a normalized engineering object.
+
+The operator-reported DipTrace application version/build and literal `Source/@Version` are stored
+as separate facts. The collector does not assume they use the same versioning convention.
+
+## Recipe contract
+
+Recipes use `diptrace-capture-recipe-v1` and contain:
+
+- `recipe_id`, `title`, and `purpose`;
+- an optional exact `expected_source_type`;
+- `required_features`, written by the experiment author;
+- a non-empty `operator_checklist`, with stable ids, prompts, required flags, and optional stages.
+
+A checklist item bound to a stage cannot be answered until that stage has been recorded. The stage
+annotation is therefore an enforced observation boundary, not presentation-only metadata.
+
+The collector does not claim it can recognize the requested features in arbitrary DipTrace XML.
+The operator confirms their presence, while an independent reviewer compares the quarantined
+artifacts and UI evidence if required. A later recipe-specific validator may add a **refusal** for
+an absent, structurally documented element; it must not manufacture expected DipTrace behavior.
+
+The generic [recipe template](evidence_capture/pcb-format-question.recipe.template.json) must have
+its feature placeholders replaced before a real capture.
+The [Q1 Component angle recipe](evidence_capture/q1-component-angle.recipe.json) is a concrete
+experiment derived from `docs/OPEN_QUESTIONS.md`; it records the literal result and does not assume
+whether the value is radians or degrees.
+
+## Storage and trust boundary
+
+Given `--root C:\capture-work` (or the corresponding WSL path), the script creates:
+
+```text
+C:\capture-work\.diptrace-capture\
+├── sessions\<session>\state.json
+├── quarantine\<session>\source\source.xml
+├── quarantine\<session>\open_save\open_save.xml
+├── quarantine\<session>\reexport\reexport.xml
+└── candidates\
+    ├── <session>.candidate.json
+    └── <session>.candidate.json.sha256
+```
+
+All supplied files must resolve inside `--root`; inputs from the capture store itself are refused.
+On POSIX, including the documented WSL workflow, the collector pins an open descriptor for the
+allowed root, opens every descendant component relative to that descriptor with `O_NOFOLLOW`, and
+publishes temporary files relative to the already-open destination directory. A concurrent rename
+or symlink swap therefore cannot redirect a capture-store read or write outside the pinned root.
+
+Native Windows lacks the complete descriptor-relative API in Python's standard library. There the
+collector uses the explicitly named `cooperative_static_checks` mode: capture-store symlinks and
+junctions, plus input redirects that visibly escape the root, are refused, but the operator must use
+a private capture root and must not let another process rename or replace its paths during a
+command. Use WSL when containment must remain race-resistant under concurrent filesystem mutation.
+Every candidate records `filesystem_safety.mode` and `filesystem_safety.race_resistant`, so a
+reviewer can enforce the required mode.
+
+Mutations use an advisory lock that the OS releases after a crash. State replacement is atomic;
+candidate manifest/digest publication is recoverable and refuses conflicting existing artifacts.
+
+Quarantine is not an authenticated store: the operator controls the allowed root. Hash validation
+detects a changed quarantined artifact before finalization, and the detached candidate digest makes
+later change visible, but neither fact identifies who operated DipTrace.
+
+Every emitted candidate contains:
+
+```json
+{
+  "authority": "operator_supplied_unverified",
+  "trust_grant": "none",
+  "candidate_only": true,
+  "review_status": "pending_independent_review",
+  "requires_independent_review": true,
+  "must_not_copy_to_acceptance_without_review": true,
+  "filesystem_safety": {
+    "mode": "descriptor_relative_posix",
+    "race_resistant": true
+  }
+}
+```
+
+The shown filesystem mode is the POSIX/WSL value; native Windows records
+`cooperative_static_checks` and `false`. There is deliberately no high-trust `validation_level`
+field.
+
+## Interactive run
+
+Keep the recipe and all three exports inside the allowed root. For Q1, copy
+`docs/evidence_capture/q1-component-angle.recipe.json` into that root first:
+
+```bash
+python scripts/capture_diptrace_evidence.py init \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --recipe q1-component-angle.recipe.json
+
+python scripts/capture_diptrace_evidence.py status \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001
+
+python scripts/capture_diptrace_evidence.py record \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --stage source \
+  --file source.xml
+
+python scripts/capture_diptrace_evidence.py check \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --item same_component_definition \
+  --answer yes \
+  --note "U_CTRL and U_PROBE use the same component and pattern"
+```
+
+Repeat `record` for `open_save` and `reexport`, and answer every required Q1 checklist item from the
+recipe. Then:
+
+```bash
+python scripts/capture_diptrace_evidence.py finalize \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001
+```
+
+Interactive prompts default to “no”; silence cannot become an attestation.
+
+## Non-interactive run
+
+Non-interactive mode is for a controlled operator UI or automation that already collected explicit
+answers. It never synthesizes a human confirmation:
+
+```bash
+python scripts/capture_diptrace_evidence.py init \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --recipe q1-component-angle.recipe.json \
+  --answers operator-answers.json \
+  --non-interactive --json
+
+python scripts/capture_diptrace_evidence.py record \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --stage source \
+  --file source.xml \
+  --attestations source.attestations.json \
+  --non-interactive --json
+```
+
+`--answers` and `--attestations` are required in non-interactive mode and forbidden in interactive
+mode. The JSON schemas are strict; unknown fields and non-boolean confirmations are rejected.
+Committed attestation templates for
+[source](evidence_capture/source.attestations.template.json),
+[open/save](evidence_capture/open-save.attestations.template.json), and
+[re-export](evidence_capture/reexport.attestations.template.json) deliberately contain only
+`false`. Copy the appropriate template into the allowed root, and change each value to `true` only
+after the named action has actually occurred. An unchanged template is refused.
+
+## Resume, interruption, and abort
+
+State is persisted after each action. To continue after closing the terminal:
+
+```bash
+python scripts/capture_diptrace_evidence.py resume \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001
+```
+
+`resume` validates the complete persisted state structure, verifies its session/root binding, and
+reports the next stage and unresolved checklist items. Corrupt or shape-invalid state fails with a
+typed `invalid_session_state` error rather than continuing from partial data. A crash after the
+quarantine copy but before the state update can reuse the byte-identical orphan. A crash after
+candidate-manifest creation but before the state update recovers only when the existing manifest is
+exactly bound to the session state.
+
+To abandon a bad run without destroying evidence:
+
+```bash
+python scripts/capture_diptrace_evidence.py abort \
+  --root /mnt/c/capture-work \
+  --session pcb-angle-001 \
+  --reason "Wrong design revision selected" \
+  --non-interactive
+```
+
+Abort preserves state and quarantine artifacts. Start a new session id for the corrected run.
+
+## Review and promotion proposal
+
+Repository integration should use two deliberately separate commands:
+
+1. **Capture (this script):** produces an untrusted candidate under an operator-owned allowed root.
+2. **Ingest/review (future, separately implemented command):** validates the manifest and detached
+   hash, compares every role, checks redistribution permission, shows a repository diff, and
+   requires a reviewed allowlist change before any fixture receives a trusted authority.
+
+The trusted mapping should be a committed `candidate manifest SHA-256 -> approved fixture roles`
+registry. Adding an entry is the repository-level assertion; the capture script must not be able to
+write it. CI can then verify the allowlist and fixture hashes without DipTrace.
+
+Promotion should also reject:
+
+- candidates with `review_blockers`;
+- missing or changed quarantine files;
+- recipes with placeholder text;
+- source-type disagreements;
+- incomplete checklist items;
+- reuse of one filesystem object for multiple roles;
+- any candidate whose authority/trust-boundary constants changed;
+- any requested fixture without explicit redistribution permission.
+
+## Repository layout
+
+```text
+scripts/capture_diptrace_evidence.py
+tests/test_capture_diptrace_evidence.py
+docs/EVIDENCE_CAPTURE.md
+docs/evidence_capture/
+```
+
+The example directory contains recipe and input templates, never captured output. Do not place
+example output in `tests/fixtures/acceptance/`. Tests continue generating synthetic stand-ins only
+under temporary directories. A future skill may be added after skill consolidation, but it must
+invoke this repository command rather than fork it.
+
+## Validation
+
+The test suite covers:
+
+- UTF-8 and UTF-16 DTD/entity refusal;
+- root/type/units validation and literal object counts;
+- root containment and symlink escape;
+- POSIX root/path replacement races through descriptor-relative regression tests;
+- redirected per-session and quarantine descendant refusal;
+- single-read recipe snapshot/SHA binding and strict corrupt-state refusal;
+- strict recipes, answers, and attestations;
+- ordered stage recording and source-type parity;
+- refusal to answer a stage-bound checklist item before its artifact is recorded;
+- byte-identical quarantine and SHA binding;
+- incomplete captures and quarantine tampering;
+- idempotent finalization and interrupted-finalize recovery;
+- stale/live locks, resume, and evidence-preserving abort;
+- interactive answers and non-interactive required inputs;
+- a complete subprocess-driven `init` → three `record` stages → checklist → `finalize` example;
+- a no-redistribution candidate that remains untrusted and blocked.
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest -q tests/test_capture_diptrace_evidence.py
+./.venv/bin/python -m ruff check --no-cache \
+  scripts/capture_diptrace_evidence.py tests/test_capture_diptrace_evidence.py
+./.venv/bin/python -m mypy --strict --no-incremental \
+  scripts/capture_diptrace_evidence.py
+```

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -30,6 +30,10 @@ states no unit for `Component/@Angle`.
 and export XML without passing the file through MCP. Read the literal value. Approximately
 `1.5708` means radians; `90` means degrees.
 
+The repository provides a stricter two-component control/probe
+[operator capture recipe](evidence_capture/q1-component-angle.recipe.json). It records the literal
+values and UI observations without treating either convention as the expected answer.
+
 **Who can perform:** Human with a licensed DipTrace installation.
 
 ---

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -389,6 +389,13 @@ list_nets(path="BoardA/controller.xml", query="GND")
 
 Relative paths are resolved from `DIPTRACE_MCP_WORKSPACE`.
 
+### 7.4 Collect Operator Evidence
+
+Project maintainers investigating an unresolved format question can use the
+[operator-assisted evidence capture workflow](EVIDENCE_CAPTURE.md). The collector quarantines
+three operator-supplied XML roles and emits a review-only candidate manifest. It does not grant
+fixture trust or copy anything into the acceptance tree.
+
 ## 8. Tools and Resources
 
 The runtime source of truth is MCP `tools/list`, together with `get_capabilities` for the

--- a/docs/evidence_capture/open-save.attestations.template.json
+++ b/docs/evidence_capture/open-save.attestations.template.json
@@ -1,0 +1,4 @@
+{
+  "opened_in_diptrace": false,
+  "saved_by_diptrace": false
+}

--- a/docs/evidence_capture/operator-answers.template.json
+++ b/docs/evidence_capture/operator-answers.template.json
@@ -1,0 +1,9 @@
+{
+  "diptrace_build": "REPLACE_WITH_BUILD_SHOWN_BY_DIPTRACE",
+  "diptrace_version": "REPLACE_WITH_VERSION_SHOWN_BY_DIPTRACE",
+  "notes": "Replace every placeholder before a real capture.",
+  "operating_system": "Windows 11 REPLACE_WITH_VERSION",
+  "operator_label": "REPLACE_WITH_NON_PERSONAL_LABEL",
+  "redistribution_basis": "",
+  "redistribution_permitted": false
+}

--- a/docs/evidence_capture/pcb-format-question.recipe.template.json
+++ b/docs/evidence_capture/pcb-format-question.recipe.template.json
@@ -1,0 +1,43 @@
+{
+  "expected_source_type": "DipTrace-PCB",
+  "operator_checklist": [
+    {
+      "id": "requested_objects_visible",
+      "prompt": "Confirm every object named in required_features is present and visible in DipTrace before the source export.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "control_objects_visible",
+      "prompt": "Confirm the unchanged control objects are present in the same design.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "open_save_completed",
+      "prompt": "Open the captured source in DipTrace, save it under a new filename, and do not make an intentional design edit.",
+      "required": true,
+      "stage": "open_save"
+    },
+    {
+      "id": "fresh_reexport_completed",
+      "prompt": "Export fresh XML from the saved design under a third filename.",
+      "required": true,
+      "stage": "reexport"
+    },
+    {
+      "id": "unexpected_ui_change",
+      "prompt": "Record any unexpected visible change in the operator note.",
+      "required": false,
+      "stage": "reexport"
+    }
+  ],
+  "purpose": "Collect a source/open-save/re-export triple for one explicitly documented format question.",
+  "recipe_id": "pcb-format-question-template",
+  "required_features": [
+    "Replace this line with the exact object/setting combination under investigation.",
+    "Include at least one unchanged control object selected by the experiment author."
+  ],
+  "schema_version": "diptrace-capture-recipe-v1",
+  "title": "PCB format question evidence capture"
+}

--- a/docs/evidence_capture/q1-component-angle.recipe.json
+++ b/docs/evidence_capture/q1-component-angle.recipe.json
@@ -1,0 +1,57 @@
+{
+  "expected_source_type": "DipTrace-PCB",
+  "operator_checklist": [
+    {
+      "id": "same_component_definition",
+      "prompt": "Confirm in DipTrace that U_CTRL and U_PROBE are two instances of the same component and pattern, with matching non-rotation properties.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "control_refdes_and_angle",
+      "prompt": "Confirm the control component has RefDes U_CTRL and the DipTrace UI shows rotation 0 degrees.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "probe_refdes_and_angle",
+      "prompt": "Confirm the probe component has RefDes U_PROBE and the DipTrace UI shows rotation 90 degrees.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "direct_source_export",
+      "prompt": "Confirm source.xml was exported directly by DipTrace after the UI checks, without MCP, hand editing, or another XML writer.",
+      "required": true,
+      "stage": "source"
+    },
+    {
+      "id": "open_save_without_design_edit",
+      "prompt": "Confirm source.xml was opened and saved under a distinct filename in DipTrace without an intentional design edit.",
+      "required": true,
+      "stage": "open_save"
+    },
+    {
+      "id": "fresh_reexport",
+      "prompt": "Confirm reexport.xml is a fresh DipTrace XML export of the open/save result under a third filename.",
+      "required": true,
+      "stage": "reexport"
+    },
+    {
+      "id": "literal_values_not_interpreted",
+      "prompt": "Record the literal Component/@Angle values for U_CTRL and U_PROBE in the operator note without converting or interpreting either value.",
+      "required": true,
+      "stage": "reexport"
+    }
+  ],
+  "purpose": "Collect independent evidence for OPEN_QUESTIONS Q1 by recording literal Component/@Angle values for a 0-degree control and a 90-degree probe without assuming radians or degrees.",
+  "recipe_id": "q1-component-angle",
+  "required_features": [
+    "One PCB containing exactly two instances of the same component definition and pattern.",
+    "Control RefDes U_CTRL shown as 0 degrees in the DipTrace UI.",
+    "Probe RefDes U_PROBE shown as 90 degrees in the DipTrace UI.",
+    "No intentional difference between the two instances other than RefDes, placement, and rotation."
+  ],
+  "schema_version": "diptrace-capture-recipe-v1",
+  "title": "Q1 Component Angle unit evidence"
+}

--- a/docs/evidence_capture/reexport.attestations.template.json
+++ b/docs/evidence_capture/reexport.attestations.template.json
@@ -1,0 +1,4 @@
+{
+  "fresh_diptrace_export": false,
+  "no_programmatic_xml_generation": false
+}

--- a/docs/evidence_capture/source.attestations.template.json
+++ b/docs/evidence_capture/source.attestations.template.json
@@ -1,0 +1,4 @@
+{
+  "direct_diptrace_export": false,
+  "no_programmatic_xml_generation": false
+}

--- a/scripts/capture_diptrace_evidence.py
+++ b/scripts/capture_diptrace_evidence.py
@@ -1,0 +1,1997 @@
+#!/usr/bin/env python3
+"""Operator-assisted collection of reviewable DipTrace XML evidence candidates.
+
+This collector intentionally stops at a quarantine/candidate boundary.  It does
+not write into a fixture tree and cannot grant a DipTrace validation level.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import sys
+import tempfile
+import xml.parsers.expat as expat
+from collections import Counter
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NoReturn
+
+STATE_SCHEMA = "diptrace-operator-capture-state-v1"
+RECIPE_SCHEMA = "diptrace-capture-recipe-v1"
+CANDIDATE_SCHEMA = "diptrace-capture-candidate-v1"
+STORE_NAME = ".diptrace-capture"
+STAGES = ("source", "open_save", "reexport")
+SOURCE_TYPES = frozenset(
+    {
+        "DipTrace-PCB",
+        "DipTrace-Schematic",
+        "DipTrace-ComponentLibrary",
+        "DipTrace-PatternLibrary",
+    }
+)
+UNITS = frozenset({"mm", "inch", "mil"})
+SESSION_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+ITEM_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+MAX_XML_BYTES = 128 * 1024 * 1024
+FORBIDDEN_XML_TEXT = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
+FORBIDDEN_XML_BYTES = re.compile(rb"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
+SECURE_DIR_FD_AVAILABLE = (
+    os.name == "posix"
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.mkdir in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+    and os.rename in os.supports_dir_fd
+    and os.link in os.supports_dir_fd
+)
+
+
+class CaptureError(Exception):
+    """A typed, user-correctable capture error."""
+
+    def __init__(self, message: str, *, code: str, exit_code: int = 2) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class XmlInventory:
+    source_type: str
+    version: str | None
+    units: str | None
+    root_tag: str
+    element_count: int
+    element_counts: dict[str, int]
+    direct_child_counts: dict[str, int]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "source_type": self.source_type,
+            "version": self.version,
+            "units": self.units,
+            "root_tag": self.root_tag,
+            "element_count": self.element_count,
+            "element_counts": self.element_counts,
+            "direct_child_counts": self.direct_child_counts,
+        }
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _decoded_xml_candidates(data: bytes) -> Iterator[str]:
+    """Yield safe, fixed-codec decodings used only by the DTD/entity guard."""
+
+    codecs = ("utf-8-sig", "utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be", "iso-8859-1")
+    for codec in codecs:
+        try:
+            yield data.decode(codec)
+        except (UnicodeError, LookupError, ValueError):
+            continue
+
+
+def reject_unsafe_xml(data: bytes) -> None:
+    """Reject entity-capable XML before handing bytes to ElementTree."""
+
+    if FORBIDDEN_XML_BYTES.search(data):
+        raise CaptureError(
+            "XML declarations containing DTDs or entities are forbidden",
+            code="forbidden_xml_declaration",
+            exit_code=3,
+        )
+    # The decoded pass closes the null-interleaved UTF-16/32 gap.  Codec names
+    # are fixed here; no attacker-controlled codec is ever passed to decode().
+    for text in _decoded_xml_candidates(data):
+        if FORBIDDEN_XML_TEXT.search(text):
+            raise CaptureError(
+                "XML declarations containing DTDs or entities are forbidden",
+                code="forbidden_xml_declaration",
+                exit_code=3,
+            )
+
+
+def inspect_xml(data: bytes) -> XmlInventory:
+    if len(data) > MAX_XML_BYTES:
+        raise CaptureError(
+            f"XML exceeds the {MAX_XML_BYTES}-byte capture limit",
+            code="xml_too_large",
+        )
+    reject_unsafe_xml(data)
+
+    all_counts: Counter[str] = Counter()
+    child_counts: Counter[str] = Counter()
+    root_tag: str | None = None
+    root_attributes: dict[str, str] = {}
+    depth = 0
+
+    def reject_declaration(*_args: Any) -> None:
+        raise CaptureError(
+            "XML declarations containing DTDs or entities are forbidden",
+            code="forbidden_xml_declaration",
+            exit_code=3,
+        )
+
+    def reject_external_entity(*_args: Any) -> int:
+        reject_declaration()
+        return 0
+
+    def start_element(name: str, attributes: dict[str, str]) -> None:
+        nonlocal depth, root_tag, root_attributes
+        name = local_name(name)
+        if root_tag is None:
+            root_tag = name
+            root_attributes = {local_name(key): value for key, value in attributes.items()}
+        else:
+            all_counts[name] += 1
+            if depth == 1:
+                child_counts[name] += 1
+        depth += 1
+
+    def end_element(_name: str) -> None:
+        nonlocal depth
+        depth -= 1
+
+    parser = expat.ParserCreate()
+    parser.StartDoctypeDeclHandler = reject_declaration
+    parser.EntityDeclHandler = reject_declaration
+    parser.ExternalEntityRefHandler = reject_external_entity
+    parser.StartElementHandler = start_element
+    parser.EndElementHandler = end_element
+    try:
+        parser.Parse(data, True)
+    except CaptureError:
+        raise
+    except (expat.ExpatError, ValueError, UnicodeError) as exc:
+        raise CaptureError(f"Cannot parse DipTrace XML: {exc}", code="xml_parse_error") from exc
+
+    if root_tag != "Source":
+        raise CaptureError(
+            f"Expected a <Source> root, got <{root_tag}>",
+            code="not_diptrace_source",
+        )
+    source_type = root_attributes.get("Type")
+    if source_type not in SOURCE_TYPES:
+        raise CaptureError(
+            f"Unsupported or missing Source/@Type: {source_type!r}",
+            code="unsupported_source_type",
+        )
+    version = root_attributes.get("Version")
+    units = root_attributes.get("Units")
+    if units is not None and units not in UNITS:
+        raise CaptureError(
+            f"Unsupported Source/@Units: {units!r}",
+            code="unsupported_document_units",
+        )
+    return XmlInventory(
+        source_type=source_type,
+        version=version,
+        units=units,
+        root_tag=root_tag,
+        element_count=sum(all_counts.values()),
+        element_counts=dict(sorted(all_counts.items())),
+        direct_child_counts=dict(sorted(child_counts.items())),
+    )
+
+
+def _strict_json_bytes(raw: bytes, *, role: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise CaptureError(f"Invalid JSON in {role}: {exc}", code=f"{role}_invalid_json") from exc
+    if not isinstance(value, dict):
+        raise CaptureError(f"{role} must be a JSON object", code=f"{role}_invalid_shape")
+    return value
+
+
+def _require_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CaptureError(f"{field} must be a non-empty string", code="invalid_manifest_field")
+    return value.strip()
+
+
+def validate_recipe(value: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "schema_version",
+        "recipe_id",
+        "title",
+        "purpose",
+        "expected_source_type",
+        "required_features",
+        "operator_checklist",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise CaptureError(
+            f"Recipe has unknown fields: {', '.join(unknown)}",
+            code="invalid_recipe",
+        )
+    if value.get("schema_version") != RECIPE_SCHEMA:
+        raise CaptureError(
+            f"Recipe schema_version must be {RECIPE_SCHEMA!r}",
+            code="invalid_recipe",
+        )
+    recipe_id = _require_text(value.get("recipe_id"), "recipe_id")
+    if not SESSION_RE.fullmatch(recipe_id):
+        raise CaptureError("recipe_id is not a safe slug", code="invalid_recipe")
+    title = _require_text(value.get("title"), "title")
+    purpose = _require_text(value.get("purpose"), "purpose")
+    expected_type = value.get("expected_source_type")
+    if expected_type is not None and expected_type not in SOURCE_TYPES:
+        raise CaptureError("expected_source_type is invalid", code="invalid_recipe")
+
+    features = value.get("required_features", [])
+    if not isinstance(features, list) or any(
+        not isinstance(item, str) or not item.strip() for item in features
+    ):
+        raise CaptureError("required_features must be a list of strings", code="invalid_recipe")
+
+    checklist = value.get("operator_checklist")
+    if not isinstance(checklist, list) or not checklist:
+        raise CaptureError("operator_checklist must be a non-empty list", code="invalid_recipe")
+    seen: set[str] = set()
+    normalized_checklist: list[dict[str, Any]] = []
+    for raw_item in checklist:
+        if not isinstance(raw_item, dict):
+            raise CaptureError("Each checklist item must be an object", code="invalid_recipe")
+        if set(raw_item) - {"id", "prompt", "required", "stage"}:
+            raise CaptureError("Checklist item has unknown fields", code="invalid_recipe")
+        item_id = _require_text(raw_item.get("id"), "operator_checklist[].id")
+        if not ITEM_RE.fullmatch(item_id) or item_id in seen:
+            raise CaptureError(
+                "Checklist item ids must be unique safe slugs",
+                code="invalid_recipe",
+            )
+        seen.add(item_id)
+        prompt = _require_text(raw_item.get("prompt"), "operator_checklist[].prompt")
+        required = raw_item.get("required", True)
+        if not isinstance(required, bool):
+            raise CaptureError("Checklist required must be boolean", code="invalid_recipe")
+        stage = raw_item.get("stage")
+        if stage is not None and stage not in STAGES:
+            raise CaptureError("Checklist stage is invalid", code="invalid_recipe")
+        normalized_checklist.append(
+            {"id": item_id, "prompt": prompt, "required": required, "stage": stage}
+        )
+
+    return {
+        "schema_version": RECIPE_SCHEMA,
+        "recipe_id": recipe_id,
+        "title": title,
+        "purpose": purpose,
+        "expected_source_type": expected_type,
+        "required_features": [item.strip() for item in features],
+        "operator_checklist": normalized_checklist,
+    }
+
+
+def _validate_answers(value: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "operator_label",
+        "diptrace_version",
+        "diptrace_build",
+        "operating_system",
+        "redistribution_permitted",
+        "redistribution_basis",
+        "notes",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise CaptureError(
+            f"Answers have unknown fields: {', '.join(unknown)}",
+            code="invalid_answers",
+        )
+    permitted = value.get("redistribution_permitted")
+    if not isinstance(permitted, bool):
+        raise CaptureError("redistribution_permitted must be boolean", code="invalid_answers")
+    basis = value.get("redistribution_basis", "")
+    if not isinstance(basis, str):
+        raise CaptureError("redistribution_basis must be a string", code="invalid_answers")
+    if permitted and not basis.strip():
+        raise CaptureError(
+            "redistribution_basis is required when redistribution is permitted",
+            code="invalid_answers",
+        )
+    notes = value.get("notes", "")
+    if not isinstance(notes, str):
+        raise CaptureError("notes must be a string", code="invalid_answers")
+    return {
+        "operator_label": _require_text(value.get("operator_label"), "operator_label"),
+        "diptrace_version": _require_text(value.get("diptrace_version"), "diptrace_version"),
+        "diptrace_build": _require_text(value.get("diptrace_build"), "diptrace_build"),
+        "operating_system": _require_text(value.get("operating_system"), "operating_system"),
+        "redistribution_permitted": permitted,
+        "redistribution_basis": basis.strip(),
+        "notes": notes.strip(),
+    }
+
+
+def _interactive_answers() -> dict[str, Any]:
+    print("Operator and environment metadata (claims remain unverified until review).")
+    values: dict[str, Any] = {
+        "operator_label": input("Operator label (avoid personal data): ").strip(),
+        "diptrace_version": input("DipTrace version shown by the application: ").strip(),
+        "diptrace_build": input("DipTrace build number: ").strip(),
+        "operating_system": input("Operating system/version: ").strip(),
+    }
+    permission = input(
+        "May this design be redistributed in the repository? [y/N]: "
+    ).strip().lower()
+    values["redistribution_permitted"] = permission in {"y", "yes"}
+    values["redistribution_basis"] = input(
+        "Redistribution basis (license/ownership; blank if not permitted): "
+    ).strip()
+    values["notes"] = input("Optional session notes: ").strip()
+    return _validate_answers(values)
+
+
+def _interactive_attestations(stage: str) -> dict[str, bool]:
+    prompts = {
+        "source": {
+            "direct_diptrace_export": "Was this XML exported directly by DipTrace?",
+            "no_programmatic_xml_generation": "Was it free of hand/MCP/programmatic XML edits?",
+        },
+        "open_save": {
+            "opened_in_diptrace": "Was the source opened in DipTrace?",
+            "saved_by_diptrace": "Was this file saved by DipTrace?",
+        },
+        "reexport": {
+            "fresh_diptrace_export": (
+                "Was this XML freshly re-exported by DipTrace after open/save?"
+            ),
+            "no_programmatic_xml_generation": "Was it free of hand/MCP/programmatic XML edits?",
+        },
+    }
+    answers: dict[str, bool] = {}
+    for key, prompt in prompts[stage].items():
+        reply = input(f"{prompt} [y/N]: ").strip().lower()
+        answers[key] = reply in {"y", "yes"}
+    return validate_attestations(stage, answers)
+
+
+def validate_attestations(stage: str, value: Mapping[str, Any]) -> dict[str, bool]:
+    required = {
+        "source": {"direct_diptrace_export", "no_programmatic_xml_generation"},
+        "open_save": {"opened_in_diptrace", "saved_by_diptrace"},
+        "reexport": {"fresh_diptrace_export", "no_programmatic_xml_generation"},
+    }[stage]
+    if set(value) != required:
+        raise CaptureError(
+            f"{stage} attestations must contain exactly: {', '.join(sorted(required))}",
+            code="invalid_attestations",
+        )
+    if any(not isinstance(value[key], bool) for key in required):
+        raise CaptureError("Attestation values must be boolean", code="invalid_attestations")
+    if not all(value[key] for key in required):
+        raise CaptureError(
+            "Every stage attestation must be explicitly confirmed",
+            code="attestation_not_confirmed",
+        )
+    return {key: bool(value[key]) for key in sorted(required)}
+
+
+def _invalid_state(detail: str) -> NoReturn:
+    raise CaptureError(detail, code="invalid_session_state", exit_code=3)
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], *, field: str) -> None:
+    if set(value) != expected:
+        _invalid_state(f"{field} has missing or unknown fields")
+
+
+def _state_relative_path(value: Any, *, field: str) -> Path:
+    if not isinstance(value, str) or not value:
+        _invalid_state(f"{field} must be a non-empty relative path")
+    path = Path(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        _invalid_state(f"{field} must be a safe relative path")
+    return path
+
+
+def _state_text(value: Any, *, field: str, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        _invalid_state(f"{field} must be a non-empty string")
+    return value
+
+
+def _state_counter(value: Any, *, field: str) -> dict[str, int]:
+    if not isinstance(value, dict):
+        _invalid_state(f"{field} must be an object")
+    result: dict[str, int] = {}
+    for key, count in value.items():
+        if (
+            not isinstance(key, str)
+            or not key
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count < 0
+        ):
+            _invalid_state(f"{field} contains an invalid counter")
+        result[key] = count
+    return result
+
+
+def validate_state(
+    value: Mapping[str, Any],
+    *,
+    expected_session_id: str,
+    expected_root: str,
+) -> dict[str, Any]:
+    """Validate the complete persisted v1 state before any field is consumed."""
+
+    required = {
+        "schema_version",
+        "session_id",
+        "status",
+        "allowed_root",
+        "created_at",
+        "updated_at",
+        "recipe",
+        "operator_claims",
+        "required_stages",
+        "stage_sequence",
+        "stages",
+        "checklist",
+        "events",
+    }
+    if not required.issubset(value) or set(value) - required - {"candidate", "abort_reason"}:
+        _invalid_state("Session state has missing or unknown top-level fields")
+    if value.get("schema_version") != STATE_SCHEMA:
+        _invalid_state("Session state schema_version is invalid")
+    if value.get("session_id") != expected_session_id:
+        _invalid_state("Session state id does not match its directory")
+    if value.get("allowed_root") != expected_root:
+        raise CaptureError(
+            "Session is bound to a different allowed root",
+            code="session_root_mismatch",
+            exit_code=3,
+        )
+    status = value.get("status")
+    if status not in {"active", "aborted", "candidate_ready"}:
+        _invalid_state("Session status is invalid")
+    _state_text(value.get("created_at"), field="created_at")
+    _state_text(value.get("updated_at"), field="updated_at")
+
+    recipe_record = value.get("recipe")
+    if not isinstance(recipe_record, dict):
+        _invalid_state("recipe must be an object")
+    _require_exact_keys(
+        recipe_record,
+        {"source_path", "source_sha256", "snapshot"},
+        field="recipe",
+    )
+    recipe_path = _state_relative_path(recipe_record.get("source_path"), field="recipe.source_path")
+    if recipe_path.parts[0] == STORE_NAME:
+        _invalid_state("recipe.source_path may not point into the capture store")
+    recipe_sha = recipe_record.get("source_sha256")
+    if not isinstance(recipe_sha, str) or SHA256_RE.fullmatch(recipe_sha) is None:
+        _invalid_state("recipe.source_sha256 is invalid")
+    snapshot = recipe_record.get("snapshot")
+    if not isinstance(snapshot, dict):
+        _invalid_state("recipe.snapshot must be an object")
+    try:
+        normalized_recipe = validate_recipe(snapshot)
+    except CaptureError as exc:
+        raise CaptureError(
+            f"Session recipe snapshot is invalid: {exc}",
+            code="invalid_session_state",
+            exit_code=3,
+        ) from exc
+    if normalized_recipe != snapshot:
+        _invalid_state("Session recipe snapshot is not normalized")
+
+    operator_claims = value.get("operator_claims")
+    if not isinstance(operator_claims, dict):
+        _invalid_state("operator_claims must be an object")
+    try:
+        normalized_claims = _validate_answers(operator_claims)
+    except CaptureError as exc:
+        raise CaptureError(
+            f"Session operator claims are invalid: {exc}",
+            code="invalid_session_state",
+            exit_code=3,
+        ) from exc
+    if normalized_claims != operator_claims:
+        _invalid_state("Session operator claims are not normalized")
+
+    if value.get("required_stages") != list(STAGES):
+        _invalid_state("required_stages must match the capture protocol")
+    sequence = value.get("stage_sequence")
+    if not isinstance(sequence, list) or sequence != list(STAGES[: len(sequence)]):
+        _invalid_state("stage_sequence must be an ordered prefix of the capture protocol")
+    stages = value.get("stages")
+    if not isinstance(stages, dict) or set(stages) != set(sequence):
+        _invalid_state("stages must exactly match stage_sequence")
+    for stage in sequence:
+        record = stages.get(stage)
+        if not isinstance(record, dict):
+            _invalid_state(f"stages.{stage} must be an object")
+        _require_exact_keys(
+            record,
+            {
+                "stage",
+                "captured_at",
+                "original_path",
+                "quarantine_path",
+                "sha256",
+                "size_bytes",
+                "xml_inventory",
+                "operator_attestations",
+                "operator_note",
+                "warnings",
+            },
+            field=f"stages.{stage}",
+        )
+        if record.get("stage") != stage:
+            _invalid_state(f"stages.{stage}.stage is inconsistent")
+        _state_text(record.get("captured_at"), field=f"stages.{stage}.captured_at")
+        original_path = _state_relative_path(
+            record.get("original_path"),
+            field=f"stages.{stage}.original_path",
+        )
+        if original_path.parts[0] == STORE_NAME:
+            _invalid_state(f"stages.{stage}.original_path points into the capture store")
+        quarantine_path = _state_relative_path(
+            record.get("quarantine_path"),
+            field=f"stages.{stage}.quarantine_path",
+        )
+        expected_prefix = Path(STORE_NAME) / "quarantine" / expected_session_id / stage
+        try:
+            quarantine_path.relative_to(expected_prefix)
+        except ValueError:
+            _invalid_state(f"stages.{stage}.quarantine_path is outside its stage area")
+        digest = record.get("sha256")
+        if not isinstance(digest, str) or SHA256_RE.fullmatch(digest) is None:
+            _invalid_state(f"stages.{stage}.sha256 is invalid")
+        size = record.get("size_bytes")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            _invalid_state(f"stages.{stage}.size_bytes is invalid")
+
+        inventory = record.get("xml_inventory")
+        if not isinstance(inventory, dict):
+            _invalid_state(f"stages.{stage}.xml_inventory must be an object")
+        _require_exact_keys(
+            inventory,
+            {
+                "source_type",
+                "version",
+                "units",
+                "root_tag",
+                "element_count",
+                "element_counts",
+                "direct_child_counts",
+            },
+            field=f"stages.{stage}.xml_inventory",
+        )
+        if (
+            inventory.get("source_type") not in SOURCE_TYPES
+            or inventory.get("root_tag") != "Source"
+        ):
+            _invalid_state(f"stages.{stage}.xml_inventory identity is invalid")
+        if inventory.get("version") is not None and not isinstance(
+            inventory.get("version"), str
+        ):
+            _invalid_state(f"stages.{stage}.xml_inventory.version is invalid")
+        if inventory.get("units") is not None and inventory.get("units") not in UNITS:
+            _invalid_state(f"stages.{stage}.xml_inventory.units is invalid")
+        element_counts = _state_counter(
+            inventory.get("element_counts"),
+            field=f"stages.{stage}.xml_inventory.element_counts",
+        )
+        _state_counter(
+            inventory.get("direct_child_counts"),
+            field=f"stages.{stage}.xml_inventory.direct_child_counts",
+        )
+        element_count = inventory.get("element_count")
+        if (
+            not isinstance(element_count, int)
+            or isinstance(element_count, bool)
+            or element_count != sum(element_counts.values())
+        ):
+            _invalid_state(f"stages.{stage}.xml_inventory.element_count is inconsistent")
+        attestations = record.get("operator_attestations")
+        if not isinstance(attestations, dict):
+            _invalid_state(f"stages.{stage}.operator_attestations must be an object")
+        try:
+            normalized_attestations = validate_attestations(stage, attestations)
+        except CaptureError as exc:
+            raise CaptureError(
+                f"Session stage attestations are invalid: {exc}",
+                code="invalid_session_state",
+                exit_code=3,
+            ) from exc
+        if normalized_attestations != attestations:
+            _invalid_state(f"stages.{stage}.operator_attestations are not normalized")
+        if not isinstance(record.get("operator_note"), str):
+            _invalid_state(f"stages.{stage}.operator_note must be a string")
+        warnings = record.get("warnings")
+        if not isinstance(warnings, list) or any(not isinstance(item, str) for item in warnings):
+            _invalid_state(f"stages.{stage}.warnings must be a list of strings")
+
+    checklist = value.get("checklist")
+    if not isinstance(checklist, dict):
+        _invalid_state("checklist must be an object")
+    recipe_items = {item["id"]: item for item in normalized_recipe["operator_checklist"]}
+    if set(checklist) != set(recipe_items):
+        _invalid_state("checklist does not match the recipe snapshot")
+    for item_id, recipe_item in recipe_items.items():
+        item = checklist.get(item_id)
+        if not isinstance(item, dict):
+            _invalid_state(f"checklist.{item_id} must be an object")
+        _require_exact_keys(
+            item,
+            {"prompt", "required", "stage", "answer", "note", "answered_at"},
+            field=f"checklist.{item_id}",
+        )
+        if any(item.get(key) != recipe_item[key] for key in ("prompt", "required", "stage")):
+            _invalid_state(f"checklist.{item_id} does not match the recipe")
+        answer = item.get("answer")
+        if answer not in {"pending", "yes", "no", "not_applicable"}:
+            _invalid_state(f"checklist.{item_id}.answer is invalid")
+        if not isinstance(item.get("note"), str):
+            _invalid_state(f"checklist.{item_id}.note must be a string")
+        answered_at = item.get("answered_at")
+        if answer == "pending":
+            if answered_at is not None:
+                _invalid_state(f"checklist.{item_id}.answered_at must be null while pending")
+        else:
+            _state_text(answered_at, field=f"checklist.{item_id}.answered_at")
+
+    events = value.get("events")
+    if not isinstance(events, list) or not events:
+        _invalid_state("events must be a non-empty list")
+    event_keys = {
+        "at", "kind", "detail", "sha256", "answer", "artifacts_preserved", "trust_grant"
+    }
+    for event in events:
+        if (
+            not isinstance(event, dict)
+            or set(event) - event_keys
+            or not isinstance(event.get("at"), str)
+            or not isinstance(event.get("kind"), str)
+        ):
+            _invalid_state("events contains an invalid event")
+
+    candidate = value.get("candidate")
+    if status == "candidate_ready":
+        if not isinstance(candidate, dict):
+            _invalid_state("candidate_ready state requires candidate metadata")
+        _require_exact_keys(
+            candidate,
+            {"manifest_path", "manifest_sha256", "digest_path", "review_status"},
+            field="candidate",
+        )
+        manifest_path = _state_relative_path(
+            candidate.get("manifest_path"),
+            field="candidate.manifest_path",
+        )
+        digest_path = _state_relative_path(
+            candidate.get("digest_path"),
+            field="candidate.digest_path",
+        )
+        expected_candidate_dir = Path(STORE_NAME) / "candidates"
+        try:
+            manifest_path.relative_to(expected_candidate_dir)
+            digest_path.relative_to(expected_candidate_dir)
+        except ValueError:
+            _invalid_state("candidate artifacts are outside the candidates directory")
+        candidate_sha = candidate.get("manifest_sha256")
+        if not isinstance(candidate_sha, str) or SHA256_RE.fullmatch(candidate_sha) is None:
+            _invalid_state("candidate.manifest_sha256 is invalid")
+        if candidate.get("review_status") != "pending_independent_review":
+            _invalid_state("candidate.review_status is invalid")
+        if sequence != list(STAGES):
+            _invalid_state("candidate_ready state requires all stages")
+    elif candidate is not None:
+        _invalid_state("candidate metadata is only valid for candidate_ready state")
+
+    abort_reason = value.get("abort_reason")
+    if status == "aborted":
+        _state_text(abort_reason, field="abort_reason")
+    elif abort_reason is not None:
+        _invalid_state("abort_reason is only valid for aborted state")
+    return dict(value)
+
+
+class CaptureRepository:
+    """Stateful quarantine rooted at an explicitly allowed directory."""
+
+    def __init__(self, root: Path | str) -> None:
+        candidate = Path(root).expanduser()
+        try:
+            self.root = candidate.resolve(strict=True)
+        except OSError as exc:
+            raise CaptureError(
+                f"Allowed root does not exist: {candidate}",
+                code="root_missing",
+            ) from exc
+        if not self.root.is_dir():
+            raise CaptureError("Allowed root must be a directory", code="root_not_directory")
+        self._root_fd: int | None = None
+        self.path_safety_mode = (
+            "descriptor_relative_posix"
+            if SECURE_DIR_FD_AVAILABLE
+            else "cooperative_static_checks"
+        )
+        if SECURE_DIR_FD_AVAILABLE:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            try:
+                expected = os.stat(self.root, follow_symlinks=False)
+                root_fd = os.open(self.root, flags)
+                actual = os.fstat(root_fd)
+            except OSError as exc:
+                raise CaptureError(
+                    f"Cannot pin the allowed root safely: {exc}",
+                    code="unsafe_allowed_root",
+                    exit_code=3,
+                ) from exc
+            if (expected.st_dev, expected.st_ino) != (actual.st_dev, actual.st_ino):
+                os.close(root_fd)
+                raise CaptureError(
+                    "Allowed root changed while it was being opened",
+                    code="unsafe_allowed_root",
+                    exit_code=3,
+                )
+            self._root_fd = root_fd
+        self.store = self.root / STORE_NAME
+        self.sessions = self.store / "sessions"
+        self.quarantine = self.store / "quarantine"
+        self.candidates = self.store / "candidates"
+        self._ensure_store_dirs()
+
+    def __del__(self) -> None:
+        root_fd = getattr(self, "_root_fd", None)
+        if root_fd is not None:
+            with suppress(OSError):
+                os.close(root_fd)
+            self._root_fd = None
+
+    def _ensure_store_dirs(self) -> None:
+        for path in (self.store, self.sessions, self.quarantine, self.candidates):
+            self._ensure_safe_directory(path, create=True)
+
+    @staticmethod
+    def _is_redirecting_path(path: Path) -> bool:
+        if path.is_symlink():
+            return True
+        is_junction = getattr(path, "is_junction", None)
+        return bool(is_junction is not None and is_junction())
+
+    def _relative_parts(self, path: Path, *, base: Path | None = None) -> tuple[str, ...]:
+        try:
+            relative = path.relative_to(self.root)
+            if base is not None:
+                relative.relative_to(base.relative_to(self.root))
+        except ValueError as exc:
+            raise CaptureError(
+                f"Path escapes the allowed root: {path}",
+                code="path_outside_allowed_root",
+                exit_code=3,
+            ) from exc
+        if any(part in {"", ".", ".."} for part in relative.parts):
+            raise CaptureError(
+                f"Path contains an unsafe component: {path}",
+                code="path_outside_allowed_root",
+                exit_code=3,
+            )
+        return relative.parts
+
+    @contextmanager
+    def _open_safe_directory_fd(self, path: Path, *, create: bool) -> Iterator[int]:
+        if self._root_fd is None:
+            raise CaptureError(
+                "Descriptor-relative path operations are unavailable",
+                code="secure_path_api_unavailable",
+                exit_code=3,
+            )
+        parts = self._relative_parts(path)
+        current_fd = os.dup(self._root_fd)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        try:
+            for part in parts:
+                if create:
+                    try:
+                        os.mkdir(part, mode=0o700, dir_fd=current_fd)
+                    except FileExistsError:
+                        pass
+                    except OSError as exc:
+                        raise CaptureError(
+                            f"Cannot create capture directory component {part!r}: {exc}",
+                            code="unsafe_store_path",
+                            exit_code=3,
+                        ) from exc
+                try:
+                    next_fd = os.open(part, flags, dir_fd=current_fd)
+                except FileNotFoundError as exc:
+                    raise CaptureError(
+                        f"Capture directory does not exist: {path}",
+                        code="capture_directory_missing",
+                    ) from exc
+                except OSError as exc:
+                    raise CaptureError(
+                        f"Capture directory component is unsafe: {part}",
+                        code="unsafe_store_path",
+                        exit_code=3,
+                    ) from exc
+                os.close(current_fd)
+                current_fd = next_fd
+                if not stat.S_ISDIR(os.fstat(current_fd).st_mode):
+                    raise CaptureError(
+                        f"Capture directory component is unsafe: {part}",
+                        code="unsafe_store_path",
+                        exit_code=3,
+                    )
+            yield current_fd
+        finally:
+            with suppress(OSError):
+                os.close(current_fd)
+
+    def _ensure_safe_directory(self, path: Path, *, create: bool) -> Path:
+        """Create/check every descendant without accepting a symlink component."""
+
+        if self._root_fd is not None:
+            with self._open_safe_directory_fd(path, create=create):
+                return path
+        try:
+            relative = path.relative_to(self.root)
+        except ValueError as exc:
+            raise CaptureError(
+                f"Directory escapes the allowed root: {path}",
+                code="path_outside_allowed_root",
+                exit_code=3,
+            ) from exc
+        current = self.root
+        for part in relative.parts:
+            current = current / part
+            if create:
+                current.mkdir(mode=0o700, exist_ok=True)
+            if not current.exists():
+                raise CaptureError(
+                    f"Capture directory does not exist: {current}",
+                    code="capture_directory_missing",
+                )
+            if self._is_redirecting_path(current) or not current.is_dir():
+                raise CaptureError(
+                    f"Capture directory component is unsafe: {current}",
+                    code="unsafe_store_path",
+                    exit_code=3,
+                )
+            resolved = current.resolve(strict=True)
+            self._assert_within_root(resolved)
+            if resolved != current:
+                raise CaptureError(
+                    f"Capture directory component may not redirect: {current}",
+                    code="unsafe_store_path",
+                    exit_code=3,
+                )
+        return path
+
+    def _assert_within_root(self, path: Path) -> None:
+        try:
+            path.relative_to(self.root)
+        except ValueError as exc:
+            raise CaptureError(
+                f"Path escapes the allowed root: {path}",
+                code="path_outside_allowed_root",
+                exit_code=3,
+            ) from exc
+
+    def allowed_file(self, path: Path | str, *, role: str) -> Path:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self.root / candidate
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as exc:
+            raise CaptureError(
+                f"{role} does not exist: {candidate}",
+                code=f"{role}_missing",
+            ) from exc
+        self._assert_within_root(resolved)
+        if not resolved.is_file():
+            raise CaptureError(f"{role} must be a file", code=f"{role}_not_file")
+        try:
+            resolved.relative_to(self.store)
+        except ValueError:
+            return resolved
+        raise CaptureError(
+            f"{role} may not come from the capture store itself",
+            code="capture_store_input_forbidden",
+            exit_code=3,
+        )
+
+    def _read_root_file(self, path: Path, *, base: Path, role: str) -> bytes:
+        parts = self._relative_parts(path, base=base)
+        if not parts:
+            raise CaptureError(f"{role} must be a file", code=f"{role}_not_file")
+        if self._root_fd is None:
+            if self._is_redirecting_path(path):
+                raise CaptureError(
+                    f"{role} may not be a symlink or junction",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                )
+            try:
+                resolved = path.resolve(strict=True)
+                self._assert_within_root(resolved)
+                resolved.relative_to(base)
+                return resolved.read_bytes()
+            except (OSError, ValueError) as exc:
+                raise CaptureError(
+                    f"{role} is missing or outside its allowed area",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                ) from exc
+
+        parent = self.root.joinpath(*parts[:-1])
+        with self._open_safe_directory_fd(parent, create=False) as parent_fd:
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            try:
+                descriptor = os.open(parts[-1], flags, dir_fd=parent_fd)
+            except OSError as exc:
+                raise CaptureError(
+                    f"{role} is missing or unsafe",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                ) from exc
+            try:
+                if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                    raise CaptureError(
+                        f"{role} must be a regular file",
+                        code=f"unsafe_{role}",
+                        exit_code=3,
+                    )
+                with os.fdopen(descriptor, "rb") as handle:
+                    descriptor = -1
+                    return handle.read()
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+
+    def _store_file_exists(self, path: Path, *, base: Path, role: str) -> bool:
+        parts = self._relative_parts(path, base=base)
+        if not parts:
+            return False
+        if self._root_fd is None:
+            self._ensure_safe_directory(path.parent, create=False)
+            if self._is_redirecting_path(path):
+                raise CaptureError(
+                    f"{role} may not be a symlink or junction",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                )
+            return path.exists()
+        with self._open_safe_directory_fd(path.parent, create=False) as parent_fd:
+            try:
+                result = os.stat(parts[-1], dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                raise CaptureError(
+                    f"Cannot inspect {role}: {exc}",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                ) from exc
+            if stat.S_ISLNK(result.st_mode):
+                raise CaptureError(
+                    f"{role} may not be a symlink",
+                    code=f"unsafe_{role}",
+                    exit_code=3,
+                )
+            return True
+
+    def read_allowed_file(self, path: Path | str, *, role: str) -> tuple[Path, bytes]:
+        resolved = self.allowed_file(path, role=role)
+        return resolved, self._read_root_file(resolved, base=self.root, role=role)
+
+    @staticmethod
+    def validate_session_id(session_id: str) -> str:
+        if not SESSION_RE.fullmatch(session_id):
+            raise CaptureError(
+                "Session id must be 1-64 lowercase slug characters",
+                code="invalid_session_id",
+            )
+        return session_id
+
+    def session_dir(self, session_id: str) -> Path:
+        return self.sessions / self.validate_session_id(session_id)
+
+    def state_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "state.json"
+
+    @contextmanager
+    def mutation_lock(self, session_id: str) -> Iterator[None]:
+        session_dir = self._ensure_safe_directory(
+            self.session_dir(session_id),
+            create=True,
+        )
+        lock_path = session_dir / ".lock"
+        flags = os.O_CREAT | os.O_RDWR
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        if self._root_fd is None and self._is_redirecting_path(lock_path):
+            raise CaptureError(
+                "Session lock may not be a symlink or junction",
+                code="unsafe_session_lock",
+                exit_code=3,
+            )
+        try:
+            if self._root_fd is not None:
+                with self._open_safe_directory_fd(session_dir, create=False) as session_fd:
+                    descriptor = os.open(".lock", flags, 0o600, dir_fd=session_fd)
+            else:
+                descriptor = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise CaptureError(
+                f"Cannot safely open the session lock: {exc}",
+                code="unsafe_session_lock",
+                exit_code=3,
+            ) from exc
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            os.close(descriptor)
+            raise CaptureError(
+                "Session lock must be a regular file",
+                code="unsafe_session_lock",
+                exit_code=3,
+            )
+        if self._root_fd is None and self._is_redirecting_path(lock_path):
+            os.close(descriptor)
+            raise CaptureError(
+                "Session lock may not be a symlink or junction",
+                code="unsafe_session_lock",
+                exit_code=3,
+            )
+        lock_handle = os.fdopen(descriptor, "a+b")
+        unlock: Any
+        try:
+            try:
+                import fcntl
+
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+                def unlock() -> None:
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+            except ImportError:
+                import msvcrt
+
+                lock_handle.seek(0)
+                if not lock_handle.read(1):
+                    lock_handle.write(b"\0")
+                    lock_handle.flush()
+                lock_handle.seek(0)
+                try:
+                    msvcrt.locking(  # type: ignore[attr-defined]
+                        lock_handle.fileno(),
+                        msvcrt.LK_NBLCK,  # type: ignore[attr-defined]
+                        1,
+                    )
+                except OSError as exc:
+                    raise CaptureError(
+                        "Session is locked by another capture command",
+                        code="session_locked",
+                        exit_code=4,
+                    ) from exc
+
+                def unlock() -> None:
+                    lock_handle.seek(0)
+                    msvcrt.locking(  # type: ignore[attr-defined]
+                        lock_handle.fileno(),
+                        msvcrt.LK_UNLCK,  # type: ignore[attr-defined]
+                        1,
+                    )
+
+            except BlockingIOError as exc:
+                raise CaptureError(
+                    "Session is locked by another capture command",
+                    code="session_locked",
+                    exit_code=4,
+                ) from exc
+            lock_handle.seek(0)
+            lock_handle.truncate()
+            lock_handle.write(f"pid={os.getpid()}\nacquired_at={utc_now()}\n".encode())
+            lock_handle.flush()
+            os.fsync(lock_handle.fileno())
+            yield
+        finally:
+            if "unlock" in locals():
+                unlock()
+            lock_handle.close()
+
+    def _atomic_write(self, path: Path, data: bytes, *, exclusive: bool = False) -> None:
+        self._ensure_safe_directory(path.parent, create=True)
+        if self._root_fd is not None:
+            parts = self._relative_parts(path)
+            leaf = parts[-1]
+            with self._open_safe_directory_fd(path.parent, create=False) as parent_fd:
+                try:
+                    existing = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    existing = None
+                except OSError as exc:
+                    raise CaptureError(
+                        f"Cannot inspect destination {path}: {exc}",
+                        code="unsafe_store_path",
+                        exit_code=3,
+                    ) from exc
+                if existing is not None and stat.S_ISLNK(existing.st_mode):
+                    raise CaptureError(
+                        f"Destination may not be a symlink: {path}",
+                        code="unsafe_store_path",
+                        exit_code=3,
+                    )
+                if exclusive and existing is not None:
+                    raise CaptureError(f"Refusing to overwrite {path}", code="artifact_exists")
+
+                temp_name = f".{leaf}.{secrets.token_hex(16)}"
+                flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW
+                flags |= getattr(os, "O_CLOEXEC", 0)
+                try:
+                    descriptor = os.open(temp_name, flags, 0o600, dir_fd=parent_fd)
+                    with os.fdopen(descriptor, "wb") as handle:
+                        handle.write(data)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    if exclusive:
+                        try:
+                            os.link(
+                                temp_name,
+                                leaf,
+                                src_dir_fd=parent_fd,
+                                dst_dir_fd=parent_fd,
+                                follow_symlinks=False,
+                            )
+                        except FileExistsError as exc:
+                            raise CaptureError(
+                                f"Refusing to overwrite {path}",
+                                code="artifact_exists",
+                            ) from exc
+                    else:
+                        os.rename(
+                            temp_name,
+                            leaf,
+                            src_dir_fd=parent_fd,
+                            dst_dir_fd=parent_fd,
+                        )
+                    os.fsync(parent_fd)
+                finally:
+                    with suppress(FileNotFoundError):
+                        os.unlink(temp_name, dir_fd=parent_fd)
+            return
+
+        if self._is_redirecting_path(path):
+            raise CaptureError(
+                f"Destination may not be a symlink or junction: {path}",
+                code="unsafe_store_path",
+                exit_code=3,
+            )
+        if exclusive and path.exists():
+            raise CaptureError(f"Refusing to overwrite {path}", code="artifact_exists")
+        descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temp_path, 0o600)
+            if exclusive and path.exists():
+                raise CaptureError(f"Refusing to overwrite {path}", code="artifact_exists")
+            if exclusive:
+                try:
+                    os.link(temp_path, path, follow_symlinks=False)
+                except FileExistsError as exc:
+                    raise CaptureError(
+                        f"Refusing to overwrite {path}",
+                        code="artifact_exists",
+                    ) from exc
+            else:
+                os.replace(temp_path, path)
+        finally:
+            with suppress(FileNotFoundError):
+                temp_path.unlink()
+
+    def _read_store_file(self, path: Path, *, base: Path, role: str) -> bytes:
+        return self._read_root_file(path, base=base, role=role)
+
+    def _write_state(self, state: Mapping[str, Any]) -> None:
+        session_id = str(state["session_id"])
+        self._atomic_write(self.state_path(session_id), canonical_json_bytes(state))
+
+    def load_state(self, session_id: str) -> dict[str, Any]:
+        session_dir = self.session_dir(session_id)
+        try:
+            session_dir = self._ensure_safe_directory(
+                session_dir,
+                create=False,
+            )
+        except CaptureError as exc:
+            if exc.code == "capture_directory_missing":
+                raise CaptureError(
+                    f"Unknown session: {session_id}",
+                    code="session_not_found",
+                ) from exc
+            raise
+        path = session_dir / "state.json"
+        if not self._store_file_exists(
+            path,
+            base=self.sessions,
+            role="session_state",
+        ):
+            raise CaptureError(f"Unknown session: {session_id}", code="session_not_found")
+        raw = self._read_store_file(path, base=self.sessions, role="session_state")
+        value = _strict_json_bytes(raw, role="session_state")
+        return validate_state(
+            value,
+            expected_session_id=session_id,
+            expected_root=str(self.root),
+        )
+
+    def init_session(
+        self,
+        session_id: str,
+        recipe_path: Path | str,
+        answers: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        session_id = self.validate_session_id(session_id)
+        recipe_source, recipe_bytes = self.read_allowed_file(recipe_path, role="recipe")
+        recipe = validate_recipe(_strict_json_bytes(recipe_bytes, role="recipe"))
+        normalized_answers = _validate_answers(answers)
+        with self.mutation_lock(session_id):
+            state_path = self.state_path(session_id)
+            if self._store_file_exists(
+                state_path,
+                base=self.sessions,
+                role="session_state",
+            ):
+                raise CaptureError("Session already exists", code="session_exists", exit_code=4)
+            now = utc_now()
+            state: dict[str, Any] = {
+                "schema_version": STATE_SCHEMA,
+                "session_id": session_id,
+                "status": "active",
+                "allowed_root": str(self.root),
+                "created_at": now,
+                "updated_at": now,
+                "recipe": {
+                    "source_path": str(recipe_source.relative_to(self.root)),
+                    "source_sha256": sha256_bytes(recipe_bytes),
+                    "snapshot": recipe,
+                },
+                "operator_claims": normalized_answers,
+                "required_stages": list(STAGES),
+                "stage_sequence": [],
+                "stages": {},
+                "checklist": {
+                    item["id"]: {
+                        "prompt": item["prompt"],
+                        "required": item["required"],
+                        "stage": item["stage"],
+                        "answer": "pending",
+                        "note": "",
+                        "answered_at": None,
+                    }
+                    for item in recipe["operator_checklist"]
+                },
+                "events": [
+                    {
+                        "at": now,
+                        "kind": "session_initialized",
+                        "detail": "Operator-supplied claims are unverified",
+                    }
+                ],
+            }
+            self._write_state(state)
+            return state
+
+    @staticmethod
+    def _require_active(state: Mapping[str, Any]) -> None:
+        if state.get("status") != "active":
+            raise CaptureError(
+                f"Session is not active (status={state.get('status')!r})",
+                code="session_not_active",
+                exit_code=4,
+            )
+
+    def _quarantine_stage(self, session_id: str, stage: str, source: Path, data: bytes) -> Path:
+        suffix = source.suffix.lower()
+        if suffix not in {".xml", ".dip", ".dch", ".eli", ".lib"}:
+            suffix = ".xml"
+        destination = self.quarantine / session_id / stage / f"{stage}{suffix}"
+        self._ensure_safe_directory(destination.parent, create=True)
+        if self._is_redirecting_path(destination):
+            raise CaptureError(
+                f"Quarantine destination for {stage!r} may not be a symlink",
+                code="unsafe_quarantine_path",
+                exit_code=3,
+            )
+        if self._store_file_exists(
+            destination,
+            base=self.quarantine,
+            role="quarantine_artifact",
+        ):
+            existing = self._read_store_file(
+                destination,
+                base=self.quarantine,
+                role="quarantine_artifact",
+            )
+            if sha256_bytes(existing) == sha256_bytes(data):
+                return destination
+            raise CaptureError(
+                f"Stage {stage!r} has a different orphaned quarantined artifact",
+                code="quarantine_conflict",
+                exit_code=4,
+            )
+        self._atomic_write(destination, data, exclusive=True)
+        return destination
+
+    def record_stage(
+        self,
+        session_id: str,
+        stage: str,
+        source_path: Path | str,
+        attestations: Mapping[str, Any],
+        *,
+        note: str = "",
+    ) -> dict[str, Any]:
+        if stage not in STAGES:
+            raise CaptureError(f"Unknown stage: {stage}", code="invalid_stage")
+        normalized_attestations = validate_attestations(stage, attestations)
+        source, data = self.read_allowed_file(source_path, role="stage_file")
+        inventory = inspect_xml(data)
+        digest = sha256_bytes(data)
+
+        with self.mutation_lock(session_id):
+            state = self.load_state(session_id)
+            self._require_active(state)
+            if stage in state["stages"]:
+                raise CaptureError(
+                    f"Stage {stage!r} is already recorded",
+                    code="stage_already_recorded",
+                    exit_code=4,
+                )
+            expected_stage = STAGES[len(state["stages"])]
+            if stage != expected_stage:
+                raise CaptureError(
+                    f"Record stages in order; next required stage is {expected_stage!r}",
+                    code="stage_out_of_order",
+                    exit_code=4,
+                )
+            recipe_expected = state["recipe"]["snapshot"]["expected_source_type"]
+            if recipe_expected is not None and inventory.source_type != recipe_expected:
+                raise CaptureError(
+                    f"Recipe expects {recipe_expected}, got {inventory.source_type}",
+                    code="source_type_mismatch",
+                )
+            source_inventory = state["stages"].get("source", {}).get("xml_inventory")
+            if (
+                source_inventory is not None
+                and inventory.source_type != source_inventory["source_type"]
+            ):
+                raise CaptureError(
+                    "All captured stages must have the same Source/@Type",
+                    code="source_type_mismatch",
+                )
+            for previous_stage, previous_record in state["stages"].items():
+                previous_source = self.root / previous_record["original_path"]
+                try:
+                    same_role = source.samefile(previous_source)
+                except OSError:
+                    same_role = source == previous_source
+                if same_role:
+                    raise CaptureError(
+                        f"{stage} and {previous_stage} must use different source files",
+                        code="evidence_role_conflict",
+                    )
+
+            destination = self._quarantine_stage(session_id, stage, source, data)
+            warnings: list[str] = []
+            if source_inventory is not None and inventory.units != source_inventory["units"]:
+                warnings.append("Source/@Units changed between capture stages")
+
+            now = utc_now()
+            state["stages"][stage] = {
+                "stage": stage,
+                "captured_at": now,
+                "original_path": str(source.relative_to(self.root)),
+                "quarantine_path": str(destination.relative_to(self.root)),
+                "sha256": digest,
+                "size_bytes": len(data),
+                "xml_inventory": inventory.as_dict(),
+                "operator_attestations": normalized_attestations,
+                "operator_note": note.strip(),
+                "warnings": warnings,
+            }
+            state["stage_sequence"].append(stage)
+            state["updated_at"] = now
+            state["events"].append(
+                {"at": now, "kind": "stage_recorded", "detail": stage, "sha256": digest}
+            )
+            self._write_state(state)
+            return dict(state["stages"][stage])
+
+    def answer_checklist(
+        self,
+        session_id: str,
+        item_id: str,
+        answer: str,
+        *,
+        note: str = "",
+    ) -> dict[str, Any]:
+        if answer not in {"yes", "no", "not_applicable"}:
+            raise CaptureError("Checklist answer is invalid", code="invalid_checklist_answer")
+        with self.mutation_lock(session_id):
+            state = self.load_state(session_id)
+            self._require_active(state)
+            item = state["checklist"].get(item_id)
+            if item is None:
+                raise CaptureError(
+                    f"Unknown checklist item: {item_id}",
+                    code="unknown_checklist_item",
+                )
+            item_stage = item["stage"]
+            if item_stage is not None and item_stage not in state["stages"]:
+                raise CaptureError(
+                    f"Checklist item {item_id!r} belongs to stage {item_stage!r}, "
+                    "which has not been recorded yet",
+                    code="checklist_stage_not_recorded",
+                    exit_code=4,
+                )
+            now = utc_now()
+            item["answer"] = answer
+            item["note"] = note.strip()
+            item["answered_at"] = now
+            state["updated_at"] = now
+            state["events"].append(
+                {
+                    "at": now,
+                    "kind": "checklist_answered",
+                    "detail": item_id,
+                    "answer": answer,
+                }
+            )
+            self._write_state(state)
+            return dict(item)
+
+    def _artifact_integrity_errors(self, state: Mapping[str, Any]) -> list[str]:
+        errors: list[str] = []
+        for stage, record in state["stages"].items():
+            relative = record.get("quarantine_path")
+            if not isinstance(relative, str):
+                errors.append(f"{stage}:missing_quarantine_path")
+                continue
+            candidate = self.root / relative
+            try:
+                artifact = self._read_store_file(
+                    candidate,
+                    base=self.quarantine,
+                    role="quarantine_artifact",
+                )
+                actual = sha256_bytes(artifact)
+            except CaptureError:
+                errors.append(f"{stage}:quarantine_artifact_missing_or_unsafe")
+                continue
+            if actual != record.get("sha256"):
+                errors.append(f"{stage}:quarantine_sha256_mismatch")
+        return errors
+
+    def readiness(self, state: Mapping[str, Any]) -> dict[str, Any]:
+        missing_stages = [stage for stage in STAGES if stage not in state["stages"]]
+        pending_required = [
+            item_id
+            for item_id, item in state["checklist"].items()
+            if item["required"] and item["answer"] != "yes"
+        ]
+        integrity_errors = self._artifact_integrity_errors(state)
+        review_blockers: list[str] = []
+        if not state["operator_claims"]["redistribution_permitted"]:
+            review_blockers.append("redistribution_permission_not_granted")
+        for stage, record in state["stages"].items():
+            review_blockers.extend(f"{stage}:{warning}" for warning in record["warnings"])
+        return {
+            "ready_to_finalize": not missing_stages
+            and not pending_required
+            and not integrity_errors,
+            "missing_stages": missing_stages,
+            "pending_required_checklist": pending_required,
+            "integrity_errors": integrity_errors,
+            "review_blockers": review_blockers,
+            "next_stage": missing_stages[0] if missing_stages else None,
+        }
+
+    def status(self, session_id: str) -> dict[str, Any]:
+        state = self.load_state(session_id)
+        candidate_integrity_errors: list[str] = []
+        candidate = state.get("candidate")
+        if isinstance(candidate, dict):
+            try:
+                manifest_path = self.root / candidate["manifest_path"]
+                digest_path = self.root / candidate["digest_path"]
+                manifest_bytes = self._read_store_file(
+                    manifest_path,
+                    base=self.candidates,
+                    role="candidate_manifest",
+                )
+                digest_bytes = self._read_store_file(
+                    digest_path,
+                    base=self.candidates,
+                    role="candidate_digest",
+                )
+                manifest_sha = sha256_bytes(manifest_bytes)
+                expected_digest = f"{manifest_sha}  {manifest_path.name}\n"
+                if manifest_sha != candidate["manifest_sha256"]:
+                    candidate_integrity_errors.append("candidate_sha256_mismatch")
+                if digest_bytes.decode("ascii") != expected_digest:
+                    candidate_integrity_errors.append("candidate_digest_mismatch")
+            except (KeyError, UnicodeError, CaptureError):
+                candidate_integrity_errors.append("candidate_artifact_missing_or_invalid")
+        return {
+            "session_id": session_id,
+            "status": state["status"],
+            "recipe_id": state["recipe"]["snapshot"]["recipe_id"],
+            "recorded_stages": list(state["stage_sequence"]),
+            "readiness": self.readiness(state),
+            "candidate": candidate,
+            "candidate_integrity_errors": candidate_integrity_errors,
+            "updated_at": state["updated_at"],
+        }
+
+    def resume(self, session_id: str) -> dict[str, Any]:
+        with self.mutation_lock(session_id):
+            state = self.load_state(session_id)
+            self._require_active(state)
+            now = utc_now()
+            state["updated_at"] = now
+            state["events"].append(
+                {"at": now, "kind": "session_resumed", "detail": "State integrity checked"}
+            )
+            self._write_state(state)
+        return self.status(session_id)
+
+    def abort(self, session_id: str, reason: str) -> dict[str, Any]:
+        if not reason.strip():
+            raise CaptureError("Abort reason is required", code="abort_reason_required")
+        with self.mutation_lock(session_id):
+            state = self.load_state(session_id)
+            self._require_active(state)
+            now = utc_now()
+            state["status"] = "aborted"
+            state["abort_reason"] = reason.strip()
+            state["updated_at"] = now
+            state["events"].append(
+                {
+                    "at": now,
+                    "kind": "session_aborted",
+                    "detail": reason.strip(),
+                    "artifacts_preserved": True,
+                }
+            )
+            self._write_state(state)
+        return self.status(session_id)
+
+    def _bind_candidate_to_state(
+        self,
+        state: dict[str, Any],
+        *,
+        manifest_path: Path,
+        manifest_sha: str,
+        digest_path: Path,
+        event_time: str,
+        recovered: bool,
+    ) -> dict[str, Any]:
+        state["status"] = "candidate_ready"
+        state["updated_at"] = event_time
+        state["candidate"] = {
+            "manifest_path": str(manifest_path.relative_to(self.root)),
+            "manifest_sha256": manifest_sha,
+            "digest_path": str(digest_path.relative_to(self.root)),
+            "review_status": "pending_independent_review",
+        }
+        state["events"].append(
+            {
+                "at": event_time,
+                "kind": "candidate_recovered" if recovered else "candidate_emitted",
+                "detail": str(manifest_path.relative_to(self.root)),
+                "sha256": manifest_sha,
+                "trust_grant": "none",
+            }
+        )
+        self._write_state(state)
+        return dict(state["candidate"])
+
+    def _recover_candidate(
+        self,
+        state: dict[str, Any],
+        manifest_path: Path,
+        digest_path: Path,
+    ) -> dict[str, Any]:
+        """Finish a finalize operation interrupted after the manifest write."""
+
+        manifest_bytes = self._read_store_file(
+            manifest_path,
+            base=self.candidates,
+            role="candidate_manifest",
+        )
+        candidate = _strict_json_bytes(manifest_bytes, role="candidate_manifest")
+        required_matches = (
+            candidate.get("schema_version") == CANDIDATE_SCHEMA
+            and candidate.get("session_id") == state["session_id"]
+            and candidate.get("authority") == "operator_supplied_unverified"
+            and candidate.get("trust_grant") == "none"
+            and candidate.get("candidate_only") is True
+            and candidate.get("filesystem_safety")
+            == {
+                "mode": self.path_safety_mode,
+                "race_resistant": self._root_fd is not None,
+            }
+            and candidate.get("recipe") == state["recipe"]
+            and candidate.get("operator_claims") == state["operator_claims"]
+            and candidate.get("stage_sequence") == state["stage_sequence"]
+            and candidate.get("stages") == state["stages"]
+            and candidate.get("checklist") == state["checklist"]
+        )
+        if not required_matches:
+            raise CaptureError(
+                "Existing candidate manifest is not bound to this session state",
+                code="candidate_recovery_mismatch",
+                exit_code=3,
+            )
+        manifest_sha = sha256_bytes(manifest_bytes)
+        expected_digest = f"{manifest_sha}  {manifest_path.name}\n".encode("ascii")
+        if self._store_file_exists(
+            digest_path,
+            base=self.candidates,
+            role="candidate_digest",
+        ):
+            existing_digest = self._read_store_file(
+                digest_path,
+                base=self.candidates,
+                role="candidate_digest",
+            )
+            if existing_digest != expected_digest:
+                raise CaptureError(
+                    "Existing candidate digest does not match the manifest",
+                    code="candidate_digest_mismatch",
+                    exit_code=3,
+                )
+        else:
+            self._atomic_write(digest_path, expected_digest, exclusive=True)
+        return self._bind_candidate_to_state(
+            state,
+            manifest_path=manifest_path,
+            manifest_sha=manifest_sha,
+            digest_path=digest_path,
+            event_time=utc_now(),
+            recovered=True,
+        )
+
+    def finalize(self, session_id: str) -> dict[str, Any]:
+        with self.mutation_lock(session_id):
+            state = self.load_state(session_id)
+            manifest_path = self.candidates / f"{session_id}.candidate.json"
+            digest_path = self.candidates / f"{session_id}.candidate.json.sha256"
+            if state["status"] == "candidate_ready":
+                manifest_bytes = self._read_store_file(
+                    manifest_path,
+                    base=self.candidates,
+                    role="candidate_manifest",
+                )
+                manifest_sha = sha256_bytes(manifest_bytes)
+                if manifest_sha != state["candidate"]["manifest_sha256"]:
+                    raise CaptureError(
+                        "Candidate manifest changed after finalization",
+                        code="candidate_sha256_mismatch",
+                        exit_code=3,
+                    )
+                expected_digest = f"{manifest_sha}  {manifest_path.name}\n"
+                digest_bytes = self._read_store_file(
+                    digest_path,
+                    base=self.candidates,
+                    role="candidate_digest",
+                )
+                if digest_bytes.decode("ascii") != expected_digest:
+                    raise CaptureError(
+                        "Candidate digest changed after finalization",
+                        code="candidate_digest_mismatch",
+                        exit_code=3,
+                    )
+                return dict(state["candidate"])
+            self._require_active(state)
+            readiness = self.readiness(state)
+            if not readiness["ready_to_finalize"]:
+                raise CaptureError(
+                    "Capture is incomplete; inspect status for missing stages/checklist items",
+                    code="capture_incomplete",
+                    exit_code=4,
+                )
+            if self._store_file_exists(
+                manifest_path,
+                base=self.candidates,
+                role="candidate_manifest",
+            ):
+                return self._recover_candidate(state, manifest_path, digest_path)
+            now = utc_now()
+            candidate: dict[str, Any] = {
+                "schema_version": CANDIDATE_SCHEMA,
+                "session_id": session_id,
+                "created_at": now,
+                "authority": "operator_supplied_unverified",
+                "trust_grant": "none",
+                "candidate_only": True,
+                "review_status": "pending_independent_review",
+                "requires_independent_review": True,
+                "must_not_copy_to_acceptance_without_review": True,
+                "filesystem_safety": {
+                    "mode": self.path_safety_mode,
+                    "race_resistant": self._root_fd is not None,
+                },
+                "eligible_for_registry_review": not readiness["review_blockers"],
+                "review_blockers": readiness["review_blockers"],
+                "recipe": state["recipe"],
+                "operator_claims": state["operator_claims"],
+                "stage_sequence": state["stage_sequence"],
+                "stages": state["stages"],
+                "checklist": state["checklist"],
+                "capture_invariants": {
+                    "stages_recorded_in_order": state["stage_sequence"] == list(STAGES),
+                    "all_sha256_bound": all(
+                        SHA256_RE.fullmatch(record["sha256"]) is not None
+                        for record in state["stages"].values()
+                    ),
+                    "source_type_consistent": len(
+                        {
+                            record["xml_inventory"]["source_type"]
+                            for record in state["stages"].values()
+                        }
+                    )
+                    == 1,
+                    "artifacts_quarantined": True,
+                    "trust_promoted_by_capture_tool": False,
+                },
+            }
+            manifest_bytes = canonical_json_bytes(candidate)
+            self._atomic_write(manifest_path, manifest_bytes, exclusive=True)
+            manifest_sha = sha256_bytes(manifest_bytes)
+            self._atomic_write(
+                digest_path,
+                f"{manifest_sha}  {manifest_path.name}\n".encode("ascii"),
+                exclusive=True,
+            )
+            return self._bind_candidate_to_state(
+                state,
+                manifest_path=manifest_path,
+                manifest_sha=manifest_sha,
+                digest_path=digest_path,
+                event_time=now,
+                recovered=False,
+            )
+
+
+def _load_json_within(repository: CaptureRepository, path: str, *, role: str) -> dict[str, Any]:
+    _resolved, raw = repository.read_allowed_file(path, role=role)
+    return _strict_json_bytes(raw, role=role)
+
+
+def _print_result(value: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False))
+        return
+    status = value.get("status")
+    if status is not None:
+        print(f"Session {value.get('session_id')}: {status}")
+        readiness = value.get("readiness")
+        if isinstance(readiness, dict):
+            if readiness.get("next_stage"):
+                print(f"Next stage: {readiness['next_stage']}")
+            pending = readiness.get("pending_required_checklist", [])
+            if pending:
+                print(f"Required checklist items: {', '.join(pending)}")
+            blockers = readiness.get("review_blockers", [])
+            if blockers:
+                print(f"Review blockers: {len(blockers)}")
+        return
+    print(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+def _add_common(command: argparse.ArgumentParser) -> None:
+    command.add_argument("--root", required=True, help="Allowed capture root")
+    command.add_argument("--session", required=True, help="Safe capture session id")
+    command.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collect operator-supplied DipTrace XML into quarantine and emit a "
+            "review-only candidate manifest. This command never grants fixture trust."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init = subparsers.add_parser("init", help="Create a resumable capture session")
+    _add_common(init)
+    init.add_argument("--recipe", required=True, help="Recipe JSON inside the allowed root")
+    init.add_argument("--answers", help="Non-interactive answers JSON inside the allowed root")
+    init.add_argument("--non-interactive", action="store_true")
+
+    record = subparsers.add_parser("record", help="Validate and quarantine the next stage")
+    _add_common(record)
+    record.add_argument("--stage", choices=STAGES, required=True)
+    record.add_argument("--file", required=True, help="Stage file inside the allowed root")
+    record.add_argument("--attestations", help="Non-interactive attestation JSON")
+    record.add_argument("--note", default="")
+    record.add_argument("--non-interactive", action="store_true")
+
+    check = subparsers.add_parser("check", help="Answer one recipe checklist item")
+    _add_common(check)
+    check.add_argument("--item", required=True)
+    check.add_argument("--answer", choices=("yes", "no", "not_applicable"), required=True)
+    check.add_argument("--note", default="")
+
+    for name, help_text in (
+        ("status", "Show progress and the next required action"),
+        ("resume", "Validate persistent state and resume after interruption"),
+        ("finalize", "Emit a review-only candidate manifest"),
+    ):
+        command = subparsers.add_parser(name, help=help_text)
+        _add_common(command)
+
+    abort = subparsers.add_parser("abort", help="Abort without deleting captured evidence")
+    _add_common(abort)
+    abort.add_argument("--reason")
+    abort.add_argument("--non-interactive", action="store_true")
+    return parser
+
+
+def run_cli(arguments: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(arguments)
+    repository = CaptureRepository(args.root)
+
+    if args.command == "init":
+        if args.non_interactive:
+            if not args.answers:
+                raise CaptureError(
+                    "--answers is required with --non-interactive",
+                    code="answers_required",
+                )
+            answers = _load_json_within(repository, args.answers, role="answers")
+        else:
+            if args.answers:
+                raise CaptureError(
+                    "--answers requires --non-interactive",
+                    code="unexpected_answers",
+                )
+            answers = _interactive_answers()
+        result = repository.init_session(args.session, args.recipe, answers)
+        _print_result(repository.status(args.session), as_json=args.json)
+        return 0
+
+    if args.command == "record":
+        if args.non_interactive:
+            if not args.attestations:
+                raise CaptureError(
+                    "--attestations is required with --non-interactive",
+                    code="attestations_required",
+                )
+            attestations = _load_json_within(
+                repository, args.attestations, role="attestations"
+            )
+        else:
+            if args.attestations:
+                raise CaptureError(
+                    "--attestations requires --non-interactive",
+                    code="unexpected_attestations",
+                )
+            attestations = _interactive_attestations(args.stage)
+        result = repository.record_stage(
+            args.session,
+            args.stage,
+            args.file,
+            attestations,
+            note=args.note,
+        )
+        _print_result(result, as_json=args.json)
+        return 0
+
+    if args.command == "check":
+        result = repository.answer_checklist(
+            args.session,
+            args.item,
+            args.answer,
+            note=args.note,
+        )
+        _print_result(result, as_json=args.json)
+        return 0
+
+    if args.command == "status":
+        _print_result(repository.status(args.session), as_json=args.json)
+        return 0
+
+    if args.command == "resume":
+        _print_result(repository.resume(args.session), as_json=args.json)
+        return 0
+
+    if args.command == "abort":
+        reason = args.reason
+        if args.non_interactive and not reason:
+            raise CaptureError(
+                "--reason is required with --non-interactive",
+                code="abort_reason_required",
+            )
+        if not args.non_interactive and reason is None:
+            reason = input("Reason for abort (artifacts will be preserved): ").strip()
+        _print_result(repository.abort(args.session, reason or ""), as_json=args.json)
+        return 0
+
+    if args.command == "finalize":
+        result = repository.finalize(args.session)
+        _print_result(result, as_json=args.json)
+        return 0
+
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+def main() -> NoReturn:
+    try:
+        exit_code = run_cli()
+    except CaptureError as exc:
+        print(
+            json.dumps(
+                {"ok": False, "error": {"code": exc.code, "message": str(exc)}},
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(exc.exit_code) from exc
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture_diptrace_evidence.py
+++ b/scripts/capture_diptrace_evidence.py
@@ -1090,6 +1090,7 @@ class CaptureRepository:
             )
         lock_handle = os.fdopen(descriptor, "a+b")
         unlock: Any
+        windows_locking = False
         try:
             try:
                 import fcntl
@@ -1102,8 +1103,9 @@ class CaptureRepository:
             except ImportError:
                 import msvcrt
 
+                windows_locking = True
                 lock_handle.seek(0)
-                if not lock_handle.read(1):
+                if os.fstat(lock_handle.fileno()).st_size == 0:
                     lock_handle.write(b"\0")
                     lock_handle.flush()
                 lock_handle.seek(0)
@@ -1134,11 +1136,12 @@ class CaptureRepository:
                     code="session_locked",
                     exit_code=4,
                 ) from exc
-            lock_handle.seek(0)
-            lock_handle.truncate()
-            lock_handle.write(f"pid={os.getpid()}\nacquired_at={utc_now()}\n".encode())
-            lock_handle.flush()
-            os.fsync(lock_handle.fileno())
+            if not windows_locking:
+                lock_handle.seek(0)
+                lock_handle.truncate()
+                lock_handle.write(f"pid={os.getpid()}\nacquired_at={utc_now()}\n".encode())
+                lock_handle.flush()
+                os.fsync(lock_handle.fileno())
             yield
         finally:
             if "unlock" in locals():

--- a/tests/test_capture_diptrace_evidence.py
+++ b/tests/test_capture_diptrace_evidence.py
@@ -1,0 +1,857 @@
+from __future__ import annotations
+
+import builtins
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import capture_diptrace_evidence as capture_module  # noqa: E402
+from capture_diptrace_evidence import (  # noqa: E402
+    CANDIDATE_SCHEMA,
+    SECURE_DIR_FD_AVAILABLE,
+    CaptureError,
+    CaptureRepository,
+    _interactive_answers,
+    inspect_xml,
+    run_cli,
+)
+
+
+def write_json(path: Path, value: object) -> Path:
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def recipe(*, expected_source_type: str | None = "DipTrace-PCB") -> dict[str, object]:
+    return {
+        "schema_version": "diptrace-capture-recipe-v1",
+        "recipe_id": "pcb-angle-probe",
+        "title": "PCB angle probe",
+        "purpose": "Collect operator-produced XML for an unresolved format question.",
+        "expected_source_type": expected_source_type,
+        "required_features": ["one visibly rotated component", "one unrotated control"],
+        "operator_checklist": [
+            {
+                "id": "features_seen",
+                "prompt": "Confirm both requested controls are visible in DipTrace.",
+                "required": True,
+                "stage": "source",
+            },
+            {
+                "id": "unrelated_change",
+                "prompt": "Record whether DipTrace changed unrelated objects.",
+                "required": False,
+                "stage": "reexport",
+            },
+        ],
+    }
+
+
+def answers(*, redistribution_permitted: bool = True) -> dict[str, object]:
+    return {
+        "operator_label": "lab-operator-a",
+        "diptrace_version": "5.3.0.1",
+        "diptrace_build": "build-123",
+        "operating_system": "Windows 11 24H2",
+        "redistribution_permitted": redistribution_permitted,
+        "redistribution_basis": "Original test design created for this project"
+        if redistribution_permitted
+        else "",
+        "notes": "No customer data.",
+    }
+
+
+def attestations(stage: str) -> dict[str, bool]:
+    return {
+        "source": {
+            "direct_diptrace_export": True,
+            "no_programmatic_xml_generation": True,
+        },
+        "open_save": {
+            "opened_in_diptrace": True,
+            "saved_by_diptrace": True,
+        },
+        "reexport": {
+            "fresh_diptrace_export": True,
+            "no_programmatic_xml_generation": True,
+        },
+    }[stage]
+
+
+def xml_bytes(
+    *,
+    source_type: str = "DipTrace-PCB",
+    version: str = "5.3.0.1",
+    units: str = "mm",
+    marker: str = "",
+) -> bytes:
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<Source Type="{source_type}" Version="{version}" Units="{units}">'
+        f"<Components><Component Id=\"1\"><Pads><Pad Id=\"2\"/></Pads></Component>"
+        f"</Components>{marker}</Source>"
+    ).encode()
+
+
+@pytest.fixture
+def capture_root(tmp_path: Path) -> Path:
+    write_json(tmp_path / "recipe.json", recipe())
+    return tmp_path
+
+
+def initialized_repository(
+    capture_root: Path,
+    *,
+    session: str = "capture-001",
+    redistribution_permitted: bool = True,
+) -> CaptureRepository:
+    repository = CaptureRepository(capture_root)
+    repository.init_session(
+        session,
+        "recipe.json",
+        answers(redistribution_permitted=redistribution_permitted),
+    )
+    return repository
+
+
+def record_all(
+    repository: CaptureRepository,
+    root: Path,
+    *,
+    session: str = "capture-001",
+) -> None:
+    for index, stage in enumerate(("source", "open_save", "reexport"), start=1):
+        path = root / f"{stage}.xml"
+        path.write_bytes(xml_bytes(marker=f"<!-- stage {index} -->"))
+        repository.record_stage(session, stage, path, attestations(stage))
+
+
+def make_ready(
+    repository: CaptureRepository,
+    root: Path,
+    *,
+    session: str = "capture-001",
+) -> None:
+    record_all(repository, root, session=session)
+    repository.answer_checklist(session, "features_seen", "yes", note="Observed on screen")
+
+
+def test_inspect_xml_records_literal_identity_and_object_counts() -> None:
+    inventory = inspect_xml(xml_bytes())
+    assert inventory.source_type == "DipTrace-PCB"
+    assert inventory.version == "5.3.0.1"
+    assert inventory.units == "mm"
+    assert inventory.element_count == 4
+    assert inventory.element_counts == {
+        "Component": 1,
+        "Components": 1,
+        "Pad": 1,
+        "Pads": 1,
+    }
+    assert inventory.direct_child_counts == {"Components": 1}
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-16-le", "utf-16-be"])
+def test_entity_or_doctype_is_rejected_in_supported_encodings(encoding: str) -> None:
+    hostile = (
+        '<?xml version="1.0"?><!DOCTYPE Source [<!ENTITY x "boom">]>'
+        '<Source Type="DipTrace-PCB" Version="5.3.0.1" Units="mm"><X>&x;</X></Source>'
+    ).encode(encoding)
+    with pytest.raises(CaptureError, match="DTDs or entities") as caught:
+        inspect_xml(hostile)
+    assert caught.value.code == "forbidden_xml_declaration"
+    assert caught.value.exit_code == 3
+
+
+def test_parser_level_handler_rejects_doctype_if_outer_guard_is_bypassed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hostile = (
+        b'<!DOCTYPE Source [<!ENTITY x "boom">]>'
+        b'<Source Type="DipTrace-PCB"><X>&x;</X></Source>'
+    )
+    monkeypatch.setattr(capture_module, "reject_unsafe_xml", lambda _data: None)
+    with pytest.raises(CaptureError) as caught:
+        inspect_xml(hostile)
+    assert caught.value.code == "forbidden_xml_declaration"
+
+
+def test_clean_utf16_document_is_accepted() -> None:
+    text = (
+        '<?xml version="1.0" encoding="UTF-16"?>'
+        '<Source Type="DipTrace-Schematic" Version="5.3.0.1" Units="inch">'
+        "<Sheets><Sheet/></Sheets></Source>"
+    )
+    inventory = inspect_xml(text.encode("utf-16"))
+    assert inventory.source_type == "DipTrace-Schematic"
+    assert inventory.units == "inch"
+    assert inventory.element_counts == {"Sheet": 1, "Sheets": 1}
+
+
+def test_wrong_root_source_type_and_units_are_typed_errors() -> None:
+    with pytest.raises(CaptureError) as wrong_root:
+        inspect_xml(b"<Board/>")
+    assert wrong_root.value.code == "not_diptrace_source"
+
+    with pytest.raises(CaptureError) as wrong_type:
+        inspect_xml(b'<Source Type="Not-DipTrace"/>')
+    assert wrong_type.value.code == "unsupported_source_type"
+
+    with pytest.raises(CaptureError) as wrong_units:
+        inspect_xml(b'<Source Type="DipTrace-PCB" Units="cm"/>')
+    assert wrong_units.value.code == "unsupported_document_units"
+
+
+def test_allowed_root_rejects_files_outside_it(capture_root: Path) -> None:
+    outside = Path(str(capture_root) + "-outside.xml")
+    outside.write_bytes(xml_bytes())
+    repository = CaptureRepository(capture_root)
+    try:
+        with pytest.raises(CaptureError) as caught:
+            repository.allowed_file(outside, role="stage_file")
+        assert caught.value.code == "path_outside_allowed_root"
+        assert caught.value.exit_code == 3
+    finally:
+        outside.unlink()
+
+
+def test_allowed_root_rejects_symlink_escape(capture_root: Path) -> None:
+    outside = Path(str(capture_root) + "-outside.xml")
+    outside.write_bytes(xml_bytes())
+    link = capture_root / "escaped.xml"
+    try:
+        try:
+            link.symlink_to(outside)
+        except OSError:
+            pytest.skip("Symlinks are unavailable on this platform")
+        repository = CaptureRepository(capture_root)
+        with pytest.raises(CaptureError) as caught:
+            repository.allowed_file(link, role="stage_file")
+        assert caught.value.code == "path_outside_allowed_root"
+    finally:
+        link.unlink(missing_ok=True)
+        outside.unlink()
+
+
+def test_session_directory_symlink_cannot_redirect_state_write(capture_root: Path) -> None:
+    repository = CaptureRepository(capture_root)
+    outside = Path(str(capture_root) + "-outside-session")
+    outside.mkdir()
+    redirected = repository.sessions / "redirected-session"
+    try:
+        try:
+            redirected.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks are unavailable on this platform")
+        with pytest.raises(CaptureError) as caught:
+            repository.init_session("redirected-session", "recipe.json", answers())
+        assert caught.value.code == "unsafe_store_path"
+        assert not (outside / "state.json").exists()
+        assert not (outside / ".lock").exists()
+    finally:
+        redirected.unlink(missing_ok=True)
+        outside.rmdir()
+
+
+def test_quarantine_descendant_symlink_cannot_redirect_artifact(
+    capture_root: Path,
+) -> None:
+    repository = initialized_repository(capture_root)
+    outside = Path(str(capture_root) + "-outside-quarantine")
+    outside.mkdir()
+    session_quarantine = repository.quarantine / "capture-001"
+    session_quarantine.mkdir()
+    redirected = session_quarantine / "source"
+    source = capture_root / "source.xml"
+    source.write_bytes(xml_bytes())
+    try:
+        try:
+            redirected.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks are unavailable on this platform")
+        with pytest.raises(CaptureError) as caught:
+            repository.record_stage(
+                "capture-001",
+                "source",
+                source,
+                attestations("source"),
+            )
+        assert caught.value.code == "unsafe_store_path"
+        assert not (outside / "source.xml").exists()
+    finally:
+        redirected.unlink(missing_ok=True)
+        outside.rmdir()
+
+
+@pytest.mark.skipif(
+    not SECURE_DIR_FD_AVAILABLE,
+    reason="Descriptor-relative containment is a POSIX safety contract",
+)
+def test_posix_root_descriptor_prevents_concurrent_root_redirection(tmp_path: Path) -> None:
+    root = tmp_path / "capture-root"
+    root.mkdir()
+    write_json(root / "recipe.json", recipe())
+    repository = initialized_repository(root)
+    moved_root = tmp_path / "capture-root-pinned"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root.rename(moved_root)
+    root.symlink_to(outside, target_is_directory=True)
+    try:
+        result = repository.resume("capture-001")
+        assert result["status"] == "active"
+        assert (moved_root / ".diptrace-capture/sessions/capture-001/state.json").is_file()
+        assert not (outside / ".diptrace-capture").exists()
+    finally:
+        root.unlink()
+        moved_root.rename(root)
+
+
+@pytest.mark.skipif(
+    not SECURE_DIR_FD_AVAILABLE,
+    reason="Descriptor-relative containment is a POSIX safety contract",
+)
+def test_posix_input_swap_after_validation_is_refused(
+    capture_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = CaptureRepository(capture_root)
+    source = capture_root / "source.xml"
+    source.write_bytes(xml_bytes())
+    outside = Path(str(capture_root) + "-outside.xml")
+    outside.write_bytes(xml_bytes(marker="<!-- outside -->"))
+    original_allowed_file = repository.allowed_file
+
+    def validate_then_swap(path: Path | str, *, role: str) -> Path:
+        resolved = original_allowed_file(path, role=role)
+        source.unlink()
+        source.symlink_to(outside)
+        return resolved
+
+    monkeypatch.setattr(repository, "allowed_file", validate_then_swap)
+    try:
+        with pytest.raises(CaptureError) as caught:
+            repository.read_allowed_file(source, role="stage_file")
+        assert caught.value.code == "unsafe_stage_file"
+        assert caught.value.exit_code == 3
+    finally:
+        source.unlink(missing_ok=True)
+        outside.unlink()
+
+
+def test_recipe_snapshot_and_sha_come_from_one_read(
+    capture_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = CaptureRepository(capture_root)
+    recipe_path = capture_root / "recipe.json"
+    original_bytes = recipe_path.read_bytes()
+    original_reader = repository._read_root_file
+    reads = 0
+
+    def read_then_change(path: Path, *, base: Path, role: str) -> bytes:
+        nonlocal reads
+        reads += 1
+        result = original_reader(path, base=base, role=role)
+        recipe_path.write_text("{}", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(repository, "_read_root_file", read_then_change)
+    state = repository.init_session("single-read", "recipe.json", answers())
+    assert reads == 1
+    assert state["recipe"]["source_sha256"] == hashlib.sha256(original_bytes).hexdigest()
+    assert state["recipe"]["snapshot"]["recipe_id"] == "pcb-angle-probe"
+
+
+def test_corrupt_state_is_a_typed_error(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    state_path = repository.state_path("capture-001")
+    state = json.loads(state_path.read_bytes())
+    del state["events"]
+    write_json(state_path, state)
+    with pytest.raises(CaptureError) as caught:
+        repository.status("capture-001")
+    assert caught.value.code == "invalid_session_state"
+    assert caught.value.exit_code == 3
+
+
+def test_recipe_and_answers_are_strict(capture_root: Path) -> None:
+    bad_recipe = recipe()
+    bad_recipe["invented"] = True
+    write_json(capture_root / "bad-recipe.json", bad_recipe)
+    repository = CaptureRepository(capture_root)
+    with pytest.raises(CaptureError) as caught:
+        repository.init_session("bad-recipe", "bad-recipe.json", answers())
+    assert caught.value.code == "invalid_recipe"
+
+    bad_answers = answers()
+    bad_answers["redistribution_permitted"] = "yes"
+    with pytest.raises(CaptureError) as caught:
+        repository.init_session("bad-answers", "recipe.json", bad_answers)
+    assert caught.value.code == "invalid_answers"
+
+
+def test_end_to_end_emits_review_only_hash_bound_candidate(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    make_ready(repository, capture_root)
+    assert repository.status("capture-001")["recorded_stages"] == [
+        "source",
+        "open_save",
+        "reexport",
+    ]
+
+    result = repository.finalize("capture-001")
+    manifest_path = capture_root / result["manifest_path"]
+    manifest_bytes = manifest_path.read_bytes()
+    manifest = json.loads(manifest_bytes)
+
+    assert manifest["schema_version"] == CANDIDATE_SCHEMA
+    assert manifest["authority"] == "operator_supplied_unverified"
+    assert manifest["trust_grant"] == "none"
+    assert manifest["candidate_only"] is True
+    assert manifest["review_status"] == "pending_independent_review"
+    assert manifest["requires_independent_review"] is True
+    assert manifest["must_not_copy_to_acceptance_without_review"] is True
+    assert manifest["capture_invariants"]["trust_promoted_by_capture_tool"] is False
+    assert set(manifest["stages"]) == {"source", "open_save", "reexport"}
+    assert manifest["capture_invariants"]["stages_recorded_in_order"] is True
+    assert manifest["stages"]["source"]["xml_inventory"]["source_type"] == "DipTrace-PCB"
+    assert manifest["stages"]["source"]["xml_inventory"]["version"] == "5.3.0.1"
+    assert manifest["stages"]["source"]["xml_inventory"]["units"] == "mm"
+    assert result["manifest_sha256"] == hashlib.sha256(manifest_bytes).hexdigest()
+    digest_path = capture_root / result["digest_path"]
+    assert digest_path.read_text().startswith(result["manifest_sha256"])
+    assert "tests/fixtures/acceptance" not in str(manifest_path)
+
+
+def test_quarantine_is_a_byte_identical_copy(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    source = capture_root / "source.xml"
+    original = xml_bytes(marker="<!-- exact bytes -->")
+    source.write_bytes(original)
+    record = repository.record_stage(
+        "capture-001",
+        "source",
+        source,
+        attestations("source"),
+    )
+    quarantined = capture_root / record["quarantine_path"]
+    assert quarantined.read_bytes() == original
+    assert record["sha256"] == hashlib.sha256(original).hexdigest()
+    assert record["original_path"] == "source.xml"
+    assert not Path(record["original_path"]).is_absolute()
+
+
+def test_stages_must_be_recorded_in_order(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    path = capture_root / "reexport.xml"
+    path.write_bytes(xml_bytes())
+    with pytest.raises(CaptureError) as caught:
+        repository.record_stage(
+            "capture-001",
+            "reexport",
+            path,
+            attestations("reexport"),
+        )
+    assert caught.value.code == "stage_out_of_order"
+
+
+def test_stages_cannot_reuse_one_source_file(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    path = capture_root / "shared.xml"
+    path.write_bytes(xml_bytes())
+    repository.record_stage(
+        "capture-001",
+        "source",
+        path,
+        attestations("source"),
+    )
+    with pytest.raises(CaptureError) as caught:
+        repository.record_stage(
+            "capture-001",
+            "open_save",
+            path,
+            attestations("open_save"),
+        )
+    assert caught.value.code == "evidence_role_conflict"
+
+
+def test_stage_type_must_match_recipe_and_first_stage(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    wrong = capture_root / "source.xml"
+    wrong.write_bytes(xml_bytes(source_type="DipTrace-Schematic"))
+    with pytest.raises(CaptureError) as caught:
+        repository.record_stage(
+            "capture-001",
+            "source",
+            wrong,
+            attestations("source"),
+        )
+    assert caught.value.code == "source_type_mismatch"
+
+
+def test_attestations_must_be_explicit_and_are_never_treated_as_authority(
+    capture_root: Path,
+) -> None:
+    repository = initialized_repository(capture_root)
+    source = capture_root / "source.xml"
+    source.write_bytes(xml_bytes())
+    with pytest.raises(CaptureError) as caught:
+        repository.record_stage(
+            "capture-001",
+            "source",
+            source,
+            {
+                "direct_diptrace_export": True,
+                "no_programmatic_xml_generation": False,
+            },
+        )
+    assert caught.value.code == "attestation_not_confirmed"
+
+
+def test_checklist_item_cannot_be_answered_before_its_stage(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    with pytest.raises(CaptureError) as caught:
+        repository.answer_checklist("capture-001", "features_seen", "yes")
+    assert caught.value.code == "checklist_stage_not_recorded"
+    assert caught.value.exit_code == 4
+
+    source = capture_root / "source.xml"
+    source.write_bytes(xml_bytes())
+    repository.record_stage(
+        "capture-001",
+        "source",
+        source,
+        attestations("source"),
+    )
+    assert repository.answer_checklist("capture-001", "features_seen", "yes")["answer"] == "yes"
+
+
+def test_incomplete_session_cannot_finalize(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    with pytest.raises(CaptureError) as caught:
+        repository.finalize("capture-001")
+    assert caught.value.code == "capture_incomplete"
+    status = repository.status("capture-001")
+    assert status["readiness"]["next_stage"] == "source"
+    assert status["readiness"]["pending_required_checklist"] == ["features_seen"]
+
+
+def test_quarantine_tampering_blocks_finalization(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    make_ready(repository, capture_root)
+    state = repository.load_state("capture-001")
+    stage_path = capture_root / state["stages"]["source"]["quarantine_path"]
+    stage_path.write_bytes(b"tampered")
+
+    status = repository.status("capture-001")
+    assert status["readiness"]["ready_to_finalize"] is False
+    assert status["readiness"]["integrity_errors"] == ["source:quarantine_sha256_mismatch"]
+    with pytest.raises(CaptureError) as caught:
+        repository.finalize("capture-001")
+    assert caught.value.code == "capture_incomplete"
+
+
+def test_finalize_is_idempotent_and_detects_later_manifest_tampering(
+    capture_root: Path,
+) -> None:
+    repository = initialized_repository(capture_root)
+    make_ready(repository, capture_root)
+    first = repository.finalize("capture-001")
+    assert repository.finalize("capture-001") == first
+
+    manifest_path = capture_root / first["manifest_path"]
+    manifest_path.write_text("{}", encoding="utf-8")
+    with pytest.raises(CaptureError) as caught:
+        repository.finalize("capture-001")
+    assert caught.value.code == "candidate_sha256_mismatch"
+
+
+def test_candidate_digest_tampering_is_reported(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    make_ready(repository, capture_root)
+    result = repository.finalize("capture-001")
+    digest_path = capture_root / result["digest_path"]
+    digest_path.write_text("0" * 64 + "  wrong.json\n", encoding="ascii")
+    status = repository.status("capture-001")
+    assert status["candidate_integrity_errors"] == ["candidate_digest_mismatch"]
+    with pytest.raises(CaptureError) as caught:
+        repository.finalize("capture-001")
+    assert caught.value.code == "candidate_digest_mismatch"
+
+
+def test_finalize_recovers_after_interruption_between_manifest_and_state(
+    capture_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = initialized_repository(capture_root)
+    make_ready(repository, capture_root)
+    original = repository._bind_candidate_to_state
+
+    def interrupt(*args: object, **kwargs: object) -> dict[str, object]:
+        raise RuntimeError("simulated process interruption")
+
+    monkeypatch.setattr(repository, "_bind_candidate_to_state", interrupt)
+    with pytest.raises(RuntimeError, match="interruption"):
+        repository.finalize("capture-001")
+    monkeypatch.setattr(repository, "_bind_candidate_to_state", original)
+
+    recovered = repository.finalize("capture-001")
+    state = repository.load_state("capture-001")
+    assert state["status"] == "candidate_ready"
+    assert state["events"][-1]["kind"] == "candidate_recovered"
+    assert recovered["manifest_sha256"]
+
+
+def test_existing_lock_file_does_not_block_resume(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    lock_path = repository.session_dir("capture-001") / ".lock"
+    lock_path.write_text("stale text from terminated process", encoding="utf-8")
+    result = repository.resume("capture-001")
+    assert result["status"] == "active"
+
+
+def test_live_lock_conflict_is_typed(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    with (
+        repository.mutation_lock("capture-001"),
+        pytest.raises(CaptureError) as caught,
+        repository.mutation_lock("capture-001"),
+    ):
+        pass
+    assert caught.value.code == "session_locked"
+    assert caught.value.exit_code == 4
+
+
+def test_abort_preserves_quarantine_and_cannot_resume(capture_root: Path) -> None:
+    repository = initialized_repository(capture_root)
+    source = capture_root / "source.xml"
+    source.write_bytes(xml_bytes())
+    record = repository.record_stage(
+        "capture-001",
+        "source",
+        source,
+        attestations("source"),
+    )
+    quarantined = capture_root / record["quarantine_path"]
+    result = repository.abort("capture-001", "Operator found the wrong design revision")
+    assert result["status"] == "aborted"
+    assert quarantined.exists()
+    assert repository.load_state("capture-001")["abort_reason"].startswith("Operator")
+    with pytest.raises(CaptureError) as caught:
+        repository.resume("capture-001")
+    assert caught.value.code == "session_not_active"
+
+
+def test_no_redistribution_permission_is_a_review_blocker_not_a_trust_claim(
+    capture_root: Path,
+) -> None:
+    repository = initialized_repository(capture_root, redistribution_permitted=False)
+    make_ready(repository, capture_root)
+    result = repository.finalize("capture-001")
+    manifest = json.loads((capture_root / result["manifest_path"]).read_bytes())
+    assert manifest["eligible_for_registry_review"] is False
+    assert manifest["review_blockers"] == ["redistribution_permission_not_granted"]
+    assert manifest["trust_grant"] == "none"
+
+
+def test_noninteractive_cli_requires_answers_and_attestations(capture_root: Path) -> None:
+    with pytest.raises(CaptureError) as missing_answers:
+        run_cli(
+            [
+                "init",
+                "--root",
+                str(capture_root),
+                "--session",
+                "cli-session",
+                "--recipe",
+                "recipe.json",
+                "--non-interactive",
+            ]
+        )
+    assert missing_answers.value.code == "answers_required"
+
+    write_json(capture_root / "answers.json", answers())
+    assert (
+        run_cli(
+            [
+                "init",
+                "--root",
+                str(capture_root),
+                "--session",
+                "cli-session",
+                "--recipe",
+                "recipe.json",
+                "--answers",
+                "answers.json",
+                "--non-interactive",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    stage_file = capture_root / "source.xml"
+    stage_file.write_bytes(xml_bytes())
+    with pytest.raises(CaptureError) as missing_attestations:
+        run_cli(
+            [
+                "record",
+                "--root",
+                str(capture_root),
+                "--session",
+                "cli-session",
+                "--stage",
+                "source",
+                "--file",
+                "source.xml",
+                "--non-interactive",
+            ]
+        )
+    assert missing_attestations.value.code == "attestations_required"
+
+
+def test_interactive_answers_are_validated(monkeypatch: pytest.MonkeyPatch) -> None:
+    replies = iter(
+        [
+            "operator-b",
+            "5.3.0.1",
+            "build-456",
+            "Windows 11",
+            "yes",
+            "Owned by project",
+            "session note",
+        ]
+    )
+    monkeypatch.setattr(builtins, "input", lambda _prompt: next(replies))
+    value = _interactive_answers()
+    assert value["operator_label"] == "operator-b"
+    assert value["redistribution_permitted"] is True
+    assert value["redistribution_basis"] == "Owned by project"
+
+
+def test_committed_quick_start_completes_literal_cli_cycle(tmp_path: Path) -> None:
+    examples = Path(__file__).resolve().parents[1] / "docs" / "evidence_capture"
+    script = Path(__file__).resolve().parents[1] / "scripts" / "capture_diptrace_evidence.py"
+    for source in examples.iterdir():
+        if source.is_file():
+            (tmp_path / source.name).write_bytes(source.read_bytes())
+    answers_template = json.loads((tmp_path / "operator-answers.template.json").read_bytes())
+    assert answers_template["redistribution_permitted"] is False
+    assert answers_template["redistribution_basis"] == ""
+    answers_template.update(
+        {
+            "operator_label": "example-operator",
+            "diptrace_version": "5.3.0.1",
+            "diptrace_build": "example-build",
+            "operating_system": "Windows 11",
+            "redistribution_permitted": True,
+            "redistribution_basis": "Synthetic test stand-in generated under tmp_path",
+        }
+    )
+    write_json(tmp_path / "operator-answers.json", answers_template)
+    repository = CaptureRepository(tmp_path)
+    repository.init_session(
+        "example-session",
+        "pcb-format-question.recipe.template.json",
+        answers_template,
+    )
+    assert repository.status("example-session")["recipe_id"] == "pcb-format-question-template"
+
+    for stage in ("source", "open_save", "reexport"):
+        (tmp_path / f"{stage}.xml").write_bytes(
+            xml_bytes(marker=f"<!-- synthetic {stage} stand-in -->")
+        )
+        template_path = tmp_path / {
+            "source": "source.attestations.template.json",
+            "open_save": "open-save.attestations.template.json",
+            "reexport": "reexport.attestations.template.json",
+        }[stage]
+        stage_attestations = json.loads(template_path.read_bytes())
+        assert stage_attestations and not any(stage_attestations.values())
+        write_json(
+            tmp_path / f"{stage}.attestations.json",
+            {key: True for key in stage_attestations},
+        )
+
+    def invoke(*arguments: str) -> dict[str, object]:
+        completed = subprocess.run(
+            [sys.executable, str(script), *arguments],
+            cwd=Path(__file__).resolve().parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stderr
+        value = json.loads(completed.stdout)
+        assert isinstance(value, dict)
+        return value
+
+    common = ("--root", str(tmp_path), "--session", "q1-example-session", "--json")
+    initialized = invoke(
+        "init",
+        *common,
+        "--recipe",
+        "q1-component-angle.recipe.json",
+        "--answers",
+        "operator-answers.json",
+        "--non-interactive",
+    )
+    assert initialized["status"] == "active"
+    status = invoke("status", *common)
+    readiness = status["readiness"]
+    assert isinstance(readiness, dict)
+    assert readiness["next_stage"] == "source"
+
+    checklist_by_stage = {
+        "source": (
+            "same_component_definition",
+            "control_refdes_and_angle",
+            "probe_refdes_and_angle",
+            "direct_source_export",
+        ),
+        "open_save": ("open_save_without_design_edit",),
+        "reexport": ("fresh_reexport", "literal_values_not_interpreted"),
+    }
+    for stage in ("source", "open_save", "reexport"):
+        recorded = invoke(
+            "record",
+            *common,
+            "--stage",
+            stage,
+            "--file",
+            f"{stage}.xml",
+            "--attestations",
+            f"{stage}.attestations.json",
+            "--non-interactive",
+        )
+        assert recorded["stage"] == stage
+        for item_id in checklist_by_stage[stage]:
+            checked = invoke(
+                "check",
+                *common,
+                "--item",
+                item_id,
+                "--answer",
+                "yes",
+                "--note",
+                f"Synthetic CLI exercise for {item_id}",
+            )
+            assert checked["answer"] == "yes"
+
+    finalized = invoke("finalize", *common)
+    assert finalized["review_status"] == "pending_independent_review"
+    manifest_path = tmp_path / str(finalized["manifest_path"])
+    manifest = json.loads(manifest_path.read_bytes())
+    assert manifest["trust_grant"] == "none"
+    assert manifest["candidate_only"] is True
+    assert manifest["filesystem_safety"]["mode"] == (
+        "descriptor_relative_posix"
+        if SECURE_DIR_FD_AVAILABLE
+        else "cooperative_static_checks"
+    )


### PR DESCRIPTION
## What this actually delivers

- adds a standard-library, operator-assisted CLI for collecting a three-stage DipTrace XML evidence set (`source`, `open_save`, `reexport`);
- adds a concrete, runnable Q1 recipe for the unknown `Component/@Angle` convention;
- records operator attestations, immutable recipe binding, hashes, XML metadata, and per-element counts;
- quarantines captures under an explicitly allowed root and emits a review-only candidate manifest;
- documents the capture/review boundary and links the workflow from the open question and usage guides.

This is intentionally the collection half of the evidence harness. It does not register evidence,
write into `tests/fixtures/acceptance/`, authenticate the operator, or grant any trust level.
Every candidate remains `operator_supplied_unverified` with `trust_grant: none` until a separately
reviewed ingest/allowlist change exists.

## Why this is a script rather than a new skill

The path, XML, hashing, ordering, recovery, and trust-boundary rules need deterministic code and
direct tests. A later thin operator-facing skill can explain the recipe one step at a time and call
this CLI, but it must not duplicate hashing or make trust decisions. Adding that skill now would
also conflict with the planned WO-17 consolidation of the existing 57 skill packages.

## Safety and failure behavior

- DTDs and entities are rejected by whole-byte/decoded scans and Expat handlers.
- Inputs must remain below the allowed root and the capture store cannot be used as an input.
- The three roles must use distinct filesystem objects and are recorded in order.
- Non-interactive attestations are strict JSON booleans; committed templates default to `false`.
- Interrupted writes use atomic replacement and state/candidate recovery is binding-checked.
- Placeholder recipes, missing attestations, changed quarantined bytes, and incomplete checklists
  fail closed.

## Verification

- `pytest -q`: 413 passed, 1 platform-specific skip
- focused capture/link tests: 37 passed
- `ruff check --no-cache src tests benchmarks scripts`: clean
- `mypy --strict --no-incremental src/diptrace_mcp scripts/capture_diptrace_evidence.py`: clean
- PCB skill generator, format coverage generator, and spec inventory checks: clean
- `tests/fixtures/acceptance/`: unchanged

## Remaining human and follow-up work

- no real DipTrace run is claimed by this PR;
- the operator identity is not cryptographically authenticated;
- trusted ingest and the committed signed-hash allowlist remain WO-16 work;
- native-Windows path containment has an explicitly recorded platform contract; the WSL/POSIX path
  uses descriptor-relative containment.
