### PR TITLE
docs: audit local reference materials and separate evidence claims

### DIFF
--- a/docs/EVIDENCE_CAPTURE.md
+++ b/docs/EVIDENCE_CAPTURE.md
@@ -90,6 +90,30 @@ The [Q1 Component angle recipe](evidence_capture/q1-component-angle.recipe.json)
 experiment derived from `docs/OPEN_QUESTIONS.md`; it records the literal result and does not assume
 whether the value is radians or degrees.
 
+## Designing a controlled recipe
+
+For a before/after format experiment, make one intentional GUI change per probe. If two settings
+must change together, document why they cannot be isolated; otherwise split them into separate
+recipes. A broad “representative library” capture is useful for vocabulary discovery but cannot
+answer which setting caused a byte or semantic difference.
+
+Include unchanged controls in the same prepared design:
+
+- use two otherwise equivalent objects when one is the probe and one is the control;
+- record the source role before the intentional change;
+- leave the control object's relevant settings untouched through open/save/re-export;
+- state the single intended difference in the recipe and record every additional observed
+  difference as a discrepancy, not as part of the expected result.
+
+Screenshots may support the operator's report of the selected object, dialog, field value, warning,
+or application build. They are never the authoritative format artifact: XML role copies, hashes,
+the recipe snapshot, and explicit attestations remain the machine-reviewable candidate evidence.
+A screenshot must not be used to fill a missing XML role, infer an undocumented unit, or upgrade
+the candidate's trust level.
+
+If the GUI cannot reproduce the prepared state or isolate the intended change, stop the session
+with a review blocker. Do not repair the exported bytes by hand.
+
 ## Storage and trust boundary
 
 Given `--root C:\capture-work` (or the corresponding WSL path), the script creates:

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -249,22 +249,46 @@ identify its envelope and compression only from reproducible decode evidence.
 ## Q11: What are the standalone Component and Pattern Editor XML mutation semantics?
 
 **Question:** What complete XML structures, identity rules, and replacement behavior do
-the standalone Component and Pattern Editors require for safe library mutation?
+the standalone Component and Pattern Editors require for safe library mutation? In
+particular, is `UID32` persistent identity or a value regenerated during save/export, and
+how do full-library saves differ from partial/current-object exports?
 
 **Why the code depends on it:** `src/diptrace_mcp/library_adapters.py::get_library_model`
 and `src/diptrace_mcp/library_adapters.py::_components` read observed library structures,
-but there is no public Component/Pattern XML format specification and no native library
-writer. Reader success does not prove mutation semantics.
+but the repository's reproducible inventory has no standalone Component/Pattern format
+source and there is no native library writer. Reader success does not prove mutation
+semantics. A local
+[reference-material audit](REFERENCE_MATERIALS_AUDIT.md#contradictions-and-unsupported-claims)
+also found mutually contradictory, unverified statements about `UID32`; neither statement
+is promoted here.
 
 **What is documented:** The public plug-in specification documents editor export/import
 modes such as `Library All`, `Library Add`, `Library Insert`, `Component All`, `Part All`,
 and `Edit`. It does not document the complete library XML schema or identity/canonicalization
 rules.
 
-**Experiment:** Export minimal Component and Pattern libraries, then vary one setting at a
-time: multi-part structure, pin and pad identity, pattern attachment, mask, paste,
-courtyard, additional fields, and embedded graphics. For each, retain export → import →
-save → re-export pairs and compare identity references and object counts.
+**Experiment:** Use separate disposable copies of minimal Component and Pattern libraries
+and capture these controls without assuming an answer:
+
+1. hash the exact legacy binary input before opening it, record the editor/build and GUI
+   export steps, and retain the source export, open/save result, and re-export as separate
+   artifacts; until the collector has a typed `input_artifacts` field, record the binary
+   SHA-256 in operator notes and an independent lab record and do not call that association
+   a machine-enforced provenance binding;
+2. export the same untouched library twice, then open/save without an intentional semantic
+   change; compare every `UID32` occurrence and its referenced object path to determine
+   whether values survive export, save, copy, and re-export;
+3. from the same source library, compare `Library All` with partial/current-component or
+   current-part export. Record every root attribute (`Type`, `Version`, `Units`, and any
+   additional attributes), top-level container, object ID, `UID32`, ordering, and omitted
+   subtree. Import each only into a disposable copy and perform a full-save/re-export;
+4. only after those controls, vary one GUI setting at a time: multi-part structure, pin and
+   pad identity, pattern attachment, mask, paste, courtyard, additional fields, and embedded
+   graphics. Retain export → import → save → re-export roles and compare identity
+   references and object counts.
+
+The binary-input hash identifies the local starting bytes; it does not prove authorship,
+redistribution permission, or that DipTrace bound a particular XML export to those bytes.
 
 **Who can perform:** Human with licensed Component and Pattern Editors and permission to
 share sanitized fixtures.

--- a/docs/REFERENCE_MATERIALS_AUDIT.md
+++ b/docs/REFERENCE_MATERIALS_AUDIT.md
@@ -1,0 +1,258 @@
+# Local Reference Materials Audit
+
+## Decision
+
+The local `etc/` directory is useful as a **lead and operator-input collection**, not as a new
+source of authoritative DipTrace facts. None of its bytes are part of this repository at the
+audited commit, and this report does not propose adding them.
+
+The safe disposition is:
+
+- retain the four generated specification bundles and the plug-in context pack outside Git until
+  their source repository, exact revision, author, license, and redistribution permission can be
+  verified;
+- treat all statements attributed to “DipTrace serializer, repository revision 7276” as
+  unverified;
+- treat the legacy `.eli` and `.lib` files as operator-owned binary inputs, not XML fixtures and
+  not redistributable test data;
+- use a small, stratified subset of those libraries to produce candidate XML through the
+  [operator-assisted evidence workflow](EVIDENCE_CAPTURE.md);
+- reuse only facts independently supported by the already committed public specification
+  extracts;
+- turn contradictions into open questions or capture recipes rather than reader/writer
+  conventions.
+
+There is no new fact in `etc/` that should directly change production code or
+`spec_inventory.json` on the strength of these files alone.
+
+## Scope and method
+
+This audit was made against commit `8343e1f284bb31d348d1d62a0e095e210048bbf7`. The inspected
+`etc/` directory was a local, untracked directory beside that checkout. It was not copied into the
+audit checkout and must not be described as shipped, bundled, or committed.
+
+The audit:
+
+- read every one of the 22 small Markdown, DOCX, and PDF documents;
+- read only the eight-byte format prefix of each legacy library;
+- fully hashed a deterministic, size-stratified sample of 12 `.eli` and 12 `.lib` files;
+- did not fully read or hash all 966 legacy libraries;
+- compared claims with the committed public source extracts, inventory, documentation, code, and
+  tests;
+- copied no source bytes into this document or the generated inventory.
+
+The reproducible read-only inventory command is:
+
+```bash
+python scripts/audit_reference_materials.py \
+  --root /path/to/local/etc
+```
+
+It prints JSON to standard output. By default it hashes all small documents, counts the complete
+library population, identifies every library by its eight-byte prefix, and hashes only the
+stratified sample. It never emits file contents.
+
+## Inventory
+
+| Kind | Files | Bytes | Minimum | Maximum | Disposition |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `.eli` | 463 | 1,734,696,577 | 3,464 | 158,674,428 | local binary candidate inputs |
+| `.lib` | 503 | 352,771,704 | 2,907 | 17,559,294 | local binary candidate inputs |
+| `.md` | 13 | 268,183 | 4,678 | 72,546 | unverified explanatory/generated text |
+| `.docx` | 4 | 125,074 | 24,914 | 44,347 | rendering of generated specifications |
+| `.pdf` | 5 | 2,594,025 | 245,604 | 1,003,154 | four renderings plus one corpus proposal |
+| **Total** | **988** | **2,090,455,563** |  |  | local only |
+
+The arithmetic reconciles in both dimensions: 22 documents plus 966 legacy libraries equals 988
+files; 2,987,282 documentation bytes plus 2,087,468,281 library bytes equals 2,090,455,563 bytes.
+
+All 463 `.eli` files begin with the legacy `DTELIB` binary signature. All 503 `.lib` files begin
+with the legacy `DTCLIB` binary signature. None is XML by content, irrespective of its filename
+extension. This is an observation about this local collection only.
+
+The 12 Markdown/DOCX/PDF files under `DipTrace_XML_Specification/` form four three-format bundles.
+Within each bundle the title, structure, examples, and the revision-7276 assertion match. Normalized
+five-word-shingle similarity is 0.734–0.786 between Markdown and DOCX and 0.671–0.740 between DOCX
+and PDF. These are renderings of substantially the same source, not three independent witnesses.
+
+The fifth PDF, `Библиотека примеров DipTrace.pdf`, is a corpus plan. It proposes controlled
+single-change pairs, approximately 195 artifacts, and screenshots as supporting evidence. It is
+useful experiment-design input, but it has no author, source, license, or evidence manifest. Its
+statement that XML plus a manifest is authoritative conflicts with the repository trust model:
+operator-controlled manifests cannot mint high trust.
+
+## Provenance and legal assessment
+
+### Generated specifications
+
+Every generated specification says it was produced from “the DipTrace serializer, repository
+revision 7276.” The material does not include:
+
+- a repository URL or repository identity;
+- the serializer source or a patch;
+- a commit/tree hash corresponding to revision 7276;
+- a generator and reproducible invocation;
+- a signed source manifest;
+- an author;
+- a license or redistribution grant.
+
+The PDF metadata names `Typst 0.15.1` as creator and dates all four PDFs to 2026-07-24. The DOCX
+core properties have an empty creator and dates within seconds of the PDFs. This establishes
+rendering time, not source provenance. Revision 7276 may be real, but it cannot be checked from
+the supplied material, so its claims cannot be promoted as facts.
+
+The files also do not contain the official Component Editor and Pattern Editor PDFs named by the
+plug-in pack. They contain newly generated documents with different titles and the unsupported
+serializer-source claim. They are not substitutes for the named official PDFs.
+
+### Plug-in context pack
+
+The nine Markdown files mix three evidence classes without per-claim citations:
+
+1. text that is independently present in the public plug-in specification;
+2. interpretation of shipped example plug-ins that are not included here;
+3. alleged implementation/source behavior tied only to revision 7276.
+
+The pack-level verification note cannot authenticate classes 2 or 3. The safe reuse procedure is
+claim-by-claim: locate the same fact in the committed public extract, cite its page, and ignore the
+pack wording. If the public source does not say it, keep the item as an open question or operator
+probe.
+
+### Legacy libraries
+
+There is no origin manifest, DipTrace version manifest, creation history, owner statement, or
+redistribution license for the 966 binary libraries. Their names and content plausibly include
+Novarm and third-party component/vendor catalog data. A hash proves byte identity, not authorship
+or permission.
+
+Do not commit the binaries, their decoded contents, or large excerpts. A human may use them
+locally in licensed DipTrace, export a minimal sanitized test library, and pass that XML through
+the candidate evidence workflow. The candidate still needs independent review and an explicit
+redistribution decision.
+
+## Contradictions and unsupported claims
+
+The following are not minor wording issues. They would change writer safety or trust if accepted.
+
+| Claim in local material | Conflict or missing evidence | Required disposition |
+| --- | --- | --- |
+| All four generated specs are current behavior from source revision 7276. | No source repository, revision mapping, generator, author, or license is supplied. | Do not cite as implementation authority. |
+| Ordinary component/part rotation angles are radians. | [`OPEN_QUESTIONS.md` Q1](OPEN_QUESTIONS.md#q1-is-componentangle-in-radians-or-degrees) correctly records that the public PCB/Schematic specs do not state the unit. | Keep Q1 open; use the existing two-component capture recipe. |
+| XML is “Always UTF-8.” | [`OPEN_QUESTIONS.md` Q8/Q9](OPEN_QUESTIONS.md#q8-which-encoding-bom-and-line-endings-does-diptrace-export) separates what DipTrace emits from what MCP must preserve. The parser intentionally accepts additional encodings. | Do not narrow the parser or writer from this claim. |
+| Every `Real` follows root units. | [`OPEN_QUESTIONS.md` Q16](OPEN_QUESTIONS.md#q16-how-does-the-same-design-scale-across-root-unitsmm-inch-and-mil) exists because fixed-unit exceptions are not ruled out. | Keep field-by-field unit experiments. |
+| Root `Version` is the DipTrace product version. | The evidence workflow deliberately records the application build and XML `Version` separately; current compatibility evidence shows that they are related but not interchangeable. | Preserve the literal value and do not use it as an application-build assertion. |
+| Coordinate Y values are stored negated or sign-flipped. | The plug-in pack itself says not to assume a Y-axis flip, while the generated specs repeatedly describe serializer-side sign changes. No raw source-to-file derivation is supplied. | Preserve file values as read; use controlled UI-coordinate probes before adding any conversion. |
+| Full-file lists must be dense and are bound positionally. | [`OPEN_QUESTIONS.md` Q4](OPEN_QUESTIONS.md#q4-does-diptrace-address-top-level-list-entries-by-id-or-by-position) deliberately treats sparse-ID behavior as unknown. | Do not add positional renumbering. |
+| Cancel never imports, exit codes are ignored, timestamp alone decides success, and there is no size limit. | [`OPEN_QUESTIONS.md` Q3](OPEN_QUESTIONS.md#q3-does-cancel-prevent-an-impmodeall-exchange-from-being-re-imported) and [Q12](OPEN_QUESTIONS.md#q12-how-does-diptrace-acknowledge-plug-in-failure-or-output-corruption) require real process experiments. | Keep the handshake fail-closed; do not close either question. |
+| `ImpMode=All`, nested ID-less lists, `Edit`, and `Enabled="N"` have the stronger replacement/delete semantics stated in the pack. | The public plug-in document names modes and selectors but does not fully specify these deletion and nested-subtree consequences. The committed reference currently states them more strongly than its cited public inventory proves. | Require a primary citation or controlled evidence; retain safety refusals meanwhile. |
+| `UID32` is stable. | The same local collection's generated CompEdit and PattEdit specs say it is regenerated on every save. Neither claim has authoritative provenance. | Add UID lifetime/identity to the Q11 experiment; do not use it as stable identity. |
+| Schematic has no `Dim` setting and `Patterns` has no export effect. | The committed public plug-in extract explicitly lists Schematic `Dim` and `Patterns`; the current profile uses both. | Keep the public settings; treat actual runtime effect as a version-specific probe. |
+| Hierarchy `BlockId`, sheet fallback, and positional resolution behavior are fully specified. | [`OPEN_QUESTIONS.md` Q18](OPEN_QUESTIONS.md#q18-what-hierarchy-records-are-required-for-a-real-multi-sheet-schematic) correctly records that real multi-sheet requirements are not settled. | Keep Q18 open and collect a controlled hierarchy fixture. |
+| An unresolved Component Library internal-connection reference causes a delayed DipTrace access violation. | The public format text can establish documented reference fields, but the crash claim depends only on the unavailable implementation/source provenance. | Validate references defensively, but do not document a host crash as proven behavior. |
+| Component/Pattern XML specifications are among the maintained committed references. | [`spec_inventory.json`](../reference/diptrace-xml/spec_inventory.json) records only PCB, Schematic, and plug-in sources. [`XML_COMPATIBILITY.md`](XML_COMPATIBILITY.md) currently overstates this at line 18. | Correct the documentation or add properly sourced, reproducible official extracts. |
+| The public inventory records `PadStyle`/`MainStack` and the listed shape enum. | The committed inventory has no `PadStyle` or `MainStack` element entry, although related text exists in the raw public PCB extract. | Fix the extractor/source citation before claiming inventory coverage. Do not backfill from revision-7276 text. |
+| A `.eli` or `.lib` extension implies native XML. | Every local library in this collection has a legacy binary signature. | Continue content-based root validation; export through DipTrace before XML analysis. |
+
+## Useful content and exact destinations
+
+This matrix separates what can be reused from what must remain evidence-gated.
+
+| Class | Useful item | Exact target | Action |
+| --- | --- | --- | --- |
+| Authoritative fact | PCB/Schematic and Component/Pattern Editor export/import modes, object tags, and the documented half of `Selected` behavior | [`DipTrace_Plugins.pages.json`](../reference/diptrace-xml/extracted_text/DipTrace_Plugins.pages.json), `plugin/settings/*.settings.xml`, `tests/test_plugin_settings.py` | Keep the committed public extract as the source. Strengthen the test so every shipped profile tag/value is checked against a small reviewed table derived from pages 4–8. Do not derive that table from `etc/plugin_sdk`. |
+| Authoritative fact | Root units and attribute semantics that occur in the public PCB/Schematic specifications | `scripts/extract_spec_inventory.py`, [`spec_inventory.json`](../reference/diptrace-xml/spec_inventory.json), and generator tests | Continue the reproducible extractor path. A generated revision-7276 table must not bypass it. |
+| Explanatory content | One intentional GUI change per before/after pair; unchanged control objects; screenshots only as supporting evidence | [`EVIDENCE_CAPTURE.md`](EVIDENCE_CAPTURE.md), recipe-authoring section | Rephrase as project guidance. Do not copy the unknown-origin PDF or call candidates “golden.” |
+| Explanatory content | A prioritized probe catalog for mask, paste, courtyard, pad shape/hole, pour refill, hierarchy, and DSN/SES | [`OPEN_QUESTIONS.md`](OPEN_QUESTIONS.md) and the future generated probe pack | Generate recipes from maintained questions. Avoid a second 200-file hand-maintained roadmap. |
+| Observed candidate evidence | All 463 `.eli` and 503 `.lib` files are legacy binary in this local collection | `scripts/capture_diptrace_evidence.py` candidate manifest schema | Add optional `input_artifacts` hashes so an XML export can be tied to the local binary it came from without copying that binary. Authority must remain `operator_supplied_unverified`. |
+| Observed candidate evidence | Size-stratified component/pattern libraries can expose real 5.3 element and attribute vocabulary after licensed export | `docs/evidence_capture/` with a concrete Q11 library recipe; later independent ingest/review | Export small sanitized subsets, capture source/open-save/re-export XML, then compare paths/attributes against the committed inventory. Never infer schema from the binary header. |
+| Candidate schema lead | 27 element names appear as headings in the generated specs but not as element entries in the committed inventory, including `PadStyle`, `MainStack`, `Pattern`, `Model3D`, `SubFolders`, `Categories`, and `Terminal` | a future read-only vocabulary-diff report over captured XML; `library_adapters.py::_pad_styles`, `_patterns`, and `_components` | Use the names to prioritize probes only. Add a parser field after public documentation or reviewed real-export evidence exists. |
+| Unknown/contradiction | Component/part angle, source encoding, root-unit coverage, sparse IDs, cancel/failure behavior, native XML, and hierarchy resolution | Q1, Q3, Q4, Q8, Q9, Q12, Q14, Q16, and Q18 in [`OPEN_QUESTIONS.md`](OPEN_QUESTIONS.md) | Keep open. The local material supplies hypotheses, not answers. |
+| Unknown/contradiction | Library `UID32` lifetime, full-save versus partial-export root attributes, list identity, mask/paste defaults, and library mutation semantics | Q11 in [`OPEN_QUESTIONS.md`](OPEN_QUESTIONS.md); `library_adapters.py::get_library_model` | Extend Q11's experiment checklist. Do not add a library writer. |
+| Documentation correction | Maintained evidence and inventory claims are stronger than the committed provenance chain | [`XML_COMPATIBILITY.md`](XML_COMPATIBILITY.md) “Official Format Evidence”; [`REFERENCE.md`](../reference/diptrace-xml/REFERENCE.md) “Exchange lifecycle” and pattern/library sections | Label each claim as public-spec, observed fixture, or unresolved. Point to exact committed sources. |
+| Do not commit | Generated MD/DOCX/PDF specs, the nine-file context pack, the corpus-plan PDF, and all legacy binaries | repository-wide | Keep outside Git unless ownership and redistribution are resolved. Even with permission, prefer generated structured data and short cited explanations over a duplicate documentation dump. |
+
+## Real-library sampling result
+
+The deterministic sample spans the smallest and largest library plus ten equal-count size strata
+for each extension. Every sampled file has the expected legacy binary signature.
+
+| Kind | Sampled size range | Largest sampled example | What this proves |
+| --- | ---: | --- | --- |
+| `.eli` | 3,464–158,674,428 bytes | `res_networks.eli` | only byte identity and legacy component-library format |
+| `.lib` | 2,907–17,559,294 bytes | `_bga_p0.80.lib` | only byte identity and legacy pattern-library format |
+
+The full sample hashes are emitted by `scripts/audit_reference_materials.py`. They should remain
+local unless a reviewed evidence candidate needs to bind a specific binary input. Publishing a
+hash list does not grant redistribution permission and does not reveal XML vocabulary.
+
+For useful XML evidence, prefer this operator sequence:
+
+1. Choose a small library from a different size stratum and record its binary SHA-256 locally.
+2. Open it in the licensed matching editor.
+3. Save/export a minimal sanitized XML library under a new name.
+4. Capture source/open-save/re-export roles with the evidence collector.
+5. Record the DipTrace application build separately from XML `Version`.
+6. Record redistribution permission; default to no permission.
+7. Run an independent vocabulary and semantic diff.
+8. Promote only through a reviewed repository allowlist, once that mechanism exists.
+
+## Proposed separate pull requests
+
+### PR 1: provenance-only audit
+
+Commit this report, the read-only inventory script, and its synthetic tests. Do not include
+`etc/`, generated extracts, library bytes, or claims from revision 7276.
+
+### PR 2: documentation honesty
+
+- Correct `XML_COMPATIBILITY.md` so the maintained reproducible inventory is described as PCB and
+  Schematic plus the plug-in settings specification.
+- Add per-claim evidence labels to the exchange and library sections of
+  `reference/diptrace-xml/REFERENCE.md`.
+- Extend Q11 with the unresolved `UID32`, root-attribute, and binary-to-XML identity questions.
+- Keep Q1/Q3/Q4/Q8/Q9/Q12/Q14/Q16/Q18 open.
+
+### PR 3: operator library-evidence recipes
+
+- Add `input_artifacts` metadata to candidate manifests without copying arbitrary binaries.
+- Add concrete Component Editor and Pattern Editor recipes for Q11.
+- Add optional screenshot hashes as supporting, never authoritative, artifacts.
+- Add a read-only XML vocabulary diff against `spec_inventory.json`.
+- Refuse promotion until independent review, redistribution approval, and a committed allowlist
+  exist.
+
+### PR 4: only after evidence
+
+Regenerate structured inventory data, add schema/code validation, or change
+`library_adapters.py` only for facts that have a primary source citation or reviewed real-export
+evidence. Keep native Component/Pattern writers blocked until the mutation semantics are
+demonstrated.
+
+## Document hashes
+
+These hashes identify the exact local documents audited; they do not authenticate their origin.
+
+| Local path under `etc/` | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `DipTrace_XML_Specification/DipTrace_CompEdit_XML_Specification.docx` | 24,914 | `21ab21bb2d9907a13fb8deb3f85b79bd3673a96f371afa31684f17cd63590507` |
+| `DipTrace_XML_Specification/DipTrace_CompEdit_XML_Specification.md` | 29,379 | `cf76b6698cab8fa5300e48003a0516e4a53d0e2b58259d40439c600f8ac6fc48` |
+| `DipTrace_XML_Specification/DipTrace_CompEdit_XML_Specification.pdf` | 399,910 | `716070eccb4f451e2dfc4246e8997f932a0fd643b013c7dc3bef444623d6d31c` |
+| `DipTrace_XML_Specification/DipTrace_PCB_XML_Specification.docx` | 44,347 | `e342bb2a567b361306f3891f0ae3dcff6a2135bc9f7589fee24bf129f2363984` |
+| `DipTrace_XML_Specification/DipTrace_PCB_XML_Specification.md` | 72,546 | `ec70cb9ecc5766c500cad4ed7c99e1d712d6e02b9e4075a59bd02ede965916b9` |
+| `DipTrace_XML_Specification/DipTrace_PCB_XML_Specification.pdf` | 1,003,154 | `590c3772382c7987b49d5ba829e54868a659cca687c30302cd502989737b7ede` |
+| `DipTrace_XML_Specification/DipTrace_PattEdit_XML_Specification.docx` | 26,651 | `91fa331a354bfa09a528d931a9030f07d4fb9824f3ff7e16e1ca5fb90897ac4c` |
+| `DipTrace_XML_Specification/DipTrace_PattEdit_XML_Specification.md` | 33,081 | `b000a248bdbf7a2f17d24a12b9453928c8a4c1a2b96388800b085aa52838bdf3` |
+| `DipTrace_XML_Specification/DipTrace_PattEdit_XML_Specification.pdf` | 480,951 | `5ed6b7c287db920faabbe71cf3dee2d15b901d668a77ac0c6c5227438b34fd8d` |
+| `DipTrace_XML_Specification/DipTrace_Schematic_XML_Specification.docx` | 29,162 | `a33acecfd747eef424e577b50429a80f1652d1305f39267a9821b864c8357805` |
+| `DipTrace_XML_Specification/DipTrace_Schematic_XML_Specification.md` | 37,643 | `d6ed68ae448b453841ba7b83aff51dccf9966450b55f7cc4d58e0265d31f080a` |
+| `DipTrace_XML_Specification/DipTrace_Schematic_XML_Specification.pdf` | 464,406 | `213c3496bd154f701f5b5b5c0a458427f72cff5c2f84406478391536b7b7a63e` |
+| `plugin_sdk/01_plugin_architecture.md` | 25,223 | `1ff3a4ebc2efe1f2c6c00774c094c796c6b5ad5d2e83a1a428e24656a02ea00d` |
+| `plugin_sdk/02_diptrace_xml_conventions.md` | 11,779 | `bc394b87c01b59c8152e513a38467a311057f0ba9812e008d5f146613e6d2e56` |
+| `plugin_sdk/10_pcb_xml_reference.md` | 13,561 | `2f00698fba0e7a0f54e38ec828f7156fe6947efef75780260a4730aee6d2d223` |
+| `plugin_sdk/20_schematic_xml_reference.md` | 9,262 | `f010c7f29daed2a474ec27b2e96f760941cd7f83a078bb7d4351c1a561c28958` |
+| `plugin_sdk/30_compedit_xml_reference.md` | 8,275 | `e2178030ca0d09972dca821dd5598a146b840fdafc47141f9823104f6dba1d36` |
+| `plugin_sdk/40_pattedit_xml_reference.md` | 7,878 | `c4af40003ba20021ca21106ab1ce0945875a44b8d073a1fed7d27bec06b047a2` |
+| `plugin_sdk/50_common_operations.md` | 8,353 | `338cdfa5ab1e6df45256cb072a63b1173eea8e8634018a2263a1d94f3486673c` |
+| `plugin_sdk/60_common_mistakes.md` | 6,525 | `d1b38e4477ac9dd70251c79c7221315debb952a060d34172b9731ff92fdcf981` |
+| `plugin_sdk/README.md` | 4,678 | `23d5c0456ea8d6e168a7c784f6bc8c2019763213a953f49bd628ad9e3023994a` |
+| `Библиотека примеров DipTrace.pdf` | 245,604 | `a8fcd59eee261642882e836fb726faaaebc134bc1bcfebf997ad67fed25e5960` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,29 @@ See [FORMAT_COVERAGE.md](FORMAT_COVERAGE.md) for the full element-by-element inv
 [OPEN_QUESTIONS.md](OPEN_QUESTIONS.md) for the current maintained set of high-impact unresolved
 compatibility questions.
 
+### Local reference-material audit (not shipped evidence)
+
+An operator-supplied, untracked directory of generated format notes and legacy Component/Pattern
+library binaries was reviewed in
+[REFERENCE_MATERIALS_AUDIT.md](REFERENCE_MATERIALS_AUDIT.md). It is not bundled, indexed by the
+runtime, counted as a fixture pack, or used by the specification generator. The generated notes
+lack a reproducible source revision and redistribution grant; the libraries lack an origin/version
+manifest and contain legacy binary data rather than XML. Consequently, the audit changes probe
+priorities and documentation wording, but supplies no production convention and closes no open
+question.
+
+The useful next gates are human/evidence work:
+
+1. verify source identity, author, license, and redistribution permission before reusing any local
+   document or binary;
+2. extend candidate capture with typed `input_artifacts` hashes so a private binary input can be
+   associated with its exported XML without copying the binary into Git;
+3. use licensed Component/Pattern Editors to export minimal sanitized examples, with one
+   intentional GUI change and unchanged controls per experiment;
+4. capture source/open-save/re-export roles, keeping screenshots supporting-only;
+5. independently review and explicitly allowlist a redistributable candidate before it can become
+   a CI fixture or change the structured inventory.
+
 Current practical classification:
 
 | Area | Status | Main remaining gap |

--- a/docs/XML_COMPATIBILITY.md
+++ b/docs/XML_COMPATIBILITY.md
@@ -15,7 +15,34 @@ Standalone Component/Pattern Libraries are currently supported for normalized re
 
 ## Official Format Evidence
 
-The implementation is constrained by the official DipTrace XML and plug-in specifications plus controlled observed exports. The maintained references include PCB, Schematic, Component Editor, Pattern Editor, and executable plug-in XML documentation.
+The implementation uses three evidence classes; they are not interchangeable.
+
+### Public specification evidence
+
+The reproducible [specification inventory](../reference/diptrace-xml/spec_inventory.json) is
+generated from exactly three maintained public sources:
+
+- the PCB XML specification;
+- the Schematic XML specification;
+- the executable plug-in settings specification.
+
+The committed [per-page text bundles](../reference/diptrace-xml/extracted_text/) record the source
+URL and hashes used by the offline generator check. The plug-in specification documents
+Component Editor and Pattern Editor *exchange settings* and import/export mode names. It is not a
+standalone Component Library or Pattern Library XML format reference. No such standalone format
+source is part of the reproducible inventory.
+
+### Observed compatibility evidence
+
+Controlled exports and live acceptance runs may establish behavior for the exact captured
+DipTrace build and artifacts. Observations that are not retained as provenance-bearing,
+redistributable fixtures cannot become CI gates and are labelled as local observations below.
+
+### Open unknowns
+
+Standalone Component/Pattern Library identity, canonicalization, and safe mutation semantics remain
+open in [OPEN_QUESTIONS.md Q11](OPEN_QUESTIONS.md#q11-what-are-the-standalone-component-and-pattern-editor-xml-mutation-semantics).
+Reader support and a successful local parse do not close those writer questions.
 
 `Version` is preserved in document identity and compatibility reports, but it is not the sole compatibility gate. Readers use feature detection, tolerate documented optional/default fields, preserve unknown sections, and require each writer to validate the structures it needs.
 
@@ -23,7 +50,8 @@ A live import/re-export acceptance run with DipTrace 5.3 has confirmed real Sche
 
 ## Implemented Readers
 
-- `<Source>` and official standalone `<Library>` root validation;
+- `<Source>` root validation and feature-detected standalone `<Library>` root validation
+  (observed compatibility, not a standalone public format contract);
 - rejection of `DOCTYPE` and `ENTITY` declarations;
 - PCB outline, components, pads, holes, nets, ratlines, copper layers, physical stackup, and rules;
 - trace arcs, segment width/layer, vias, pour boundaries, text, keepouts, and differential pairs;

--- a/reference/diptrace-xml/REFERENCE.md
+++ b/reference/diptrace-xml/REFERENCE.md
@@ -5,6 +5,15 @@ This is a coding-agent guide to the extracted public
 [format coverage](../../docs/FORMAT_COVERAGE.md). Missing or unknown entries remain unknown; this
 guide does not supply facts that the cited specifications do not state.
 
+Evidence labels used below:
+
+- **Public specification** — stated by one of the three reproducible sources in
+  [`extracted_text/`](extracted_text/);
+- **Observed compatibility** — accepted by the current reader or seen in a fixture/run, but not a
+  standalone format contract;
+- **Open question / safety model** — deliberately conservative behavior pending the named
+  experiment in [`OPEN_QUESTIONS.md`](../../docs/OPEN_QUESTIONS.md).
+
 ## Reproducible inventory
 
 The PDFs are intentionally not committed. The repository instead contains canonical per-page
@@ -36,35 +45,61 @@ attributes; a prose mention such as “see `<Groups>` section” cannot re-ancho
 
 ## Exchange lifecycle
 
-DipTrace exports `plugin_exchange.xml`, launches the standalone executable with the exchange path
-as `argv[1]`, waits for it to exit, and imports that same path. PCB/Schematic data roots use
-hyphenated `DipTrace-PCB` / `DipTrace-Schematic`; plug-in settings use a separate underscore-based
-Type namespace.
+**Public specification:** Pages 3–8 of
+[`DipTrace_Plugins.pages.json`](extracted_text/DipTrace_Plugins.pages.json) state that DipTrace
+creates `plugin_exchange.xml`, passes its path to the executable, then reads the overwritten file.
+They define `ImpMode`/`ExpMode` and object filters. For PCB/Schematic `Selected` import filtering,
+incoming `Selected="Y"` is explicitly considered. For the library editors, the same source
+documents the named `Library All`, `Library Add`, `Library Insert`, `Component All`, `Part All`,
+and `Edit` modes and their high-level overwrite/add behavior.
 
-`ImpMode=All` replaces lists. `Edit` matches top-level objects by existing `Id`; new objects should
-omit `Id`. With PCB/Schematic Selected filtering, only incoming `Selected="Y"` objects are
-processed. Nested ID-less lists (`Traces`, net/bus `Wires`, point lists) are replaced wholesale
-when present. `Enabled="N"` is an import delete flag on objects that support it.
+**Public specification:** PCB/Schematic data roots use hyphenated `DipTrace-PCB` /
+`DipTrace-Schematic`; plug-in settings use a separate underscore-based `Type` namespace.
+
+**Open question / safety model:** The public plug-in source says that `ImpMode=All` imports all
+regardless of object filters; it does not define generic list replacement, top-level `Id` matching,
+the treatment of omitted objects, or wholesale replacement of nested ID-less containers. Current
+writers conservatively treat owned `Traces`, net/bus `Wires`, and point containers as replacement
+boundaries and require explicit destructive intent. This is an MCP safety rule, not a claim about
+DipTrace's complete import algorithm. See
+[Q2](../../docs/OPEN_QUESTIONS.md#q2-which-objects-can-an-impmodeall-apply-delete-because-the-exchange-export-omitted-them)
+and
+[Q4](../../docs/OPEN_QUESTIONS.md#q4-does-diptrace-address-top-level-list-entries-by-id-or-by-position).
+
+**Public specification with operation-specific scope:** Some PCB/Schematic records document
+`Enabled="N"` as a removed/non-existing object state. Do not generalize that attribute into a
+universal import-delete flag for every element.
 
 ## Shared serialization
 
-- Root `Units`: `mm`, `inch`, `mil`.
-- Canonical decimal separator: dot.
-- `Shape/@Angle` for text and pictures: radians CCW.
-- `Component/@Angle`: assumed to be radians by the current code, but unverified; see
+- **Public specification:** root `Units` values are `mm`, `inch`, `mil`.
+- **Writer policy:** numeric XML written by MCP uses a dot decimal separator.
+- **Public specification:** `Shape/@Angle` for text and pictures is radians CCW.
+- **Open question / safety model:** `Component/@Angle` is assumed to be radians by the current
+  code, but unverified; see
   [OPEN_QUESTIONS.md Q1](../../docs/OPEN_QUESTIONS.md#q1-is-componentangle-in-radians-or-degrees).
-- Discrete `Orientation`: `0`, `90`, `180`, `270` where documented.
-- `Model3D/Rotate`: degrees.
-- Preserve unknown XML and existing IDs.
-- Segment attributes belong to the segment end/second point.
-- External file references can contain both `Path` and `Var`; preserve both.
+- **Public specification:** discrete `Orientation` values are `0`, `90`, `180`, `270` where
+  documented.
+- **Observed compatibility:** the reader exposes literal `Model3D/Rotate` attributes without unit
+  conversion; the standalone library format source needed to establish their unit is not in the
+  reproducible inventory.
+- **Writer policy:** raw-preserving and targeted patch paths preserve unknown XML and existing IDs
+  outside the operation-owned region. An operation that owns a container may replace that
+  container only at its documented boundary, with the operation-specific disclosure, destructive
+  opt-in, or refusal required by its contract.
+- **Public specification:** segment attributes belong to the segment end/second point.
+- **Public specification and writer policy:** documented external file references can contain
+  both `Path` and `Var`; preserve both.
 
 ## Pattern / pad rules
 
-`PadStyle Type` is `Surface|Through`. Through drills use `HoleType=Round|Obround`, `Hole`, and
-`HoleH` for an obround height.
+**Observed compatibility:** The current reader recognizes `PadStyle Type` values
+`Surface|Through`. It recognizes through-drill fields `HoleType=Round|Obround`, `Hole`, and `HoleH`.
+These names occur in synthetic fixtures and observed inputs; the committed inventory does not
+contain standalone `PadStyle` or `MainStack` element definitions. They must not be used as a
+standalone library writer contract.
 
-A fiducial is special:
+The reader also recognizes this fiducial form:
 
 ```xml
 <PadStyle Name="FID" Type="Surface" Hole="1.2">
@@ -72,30 +107,44 @@ A fiducial is special:
 </PadStyle>
 ```
 
-`MainStack/Height` is omitted; `Width` is copper diameter. `PadStyle/Hole` means fiducial keepout
-diameter rather than drill geometry.
+The interpretations “omit `MainStack/Height`,” “`Width` is copper diameter,” and
+“`PadStyle/Hole` is fiducial keepout diameter” remain **open standalone-library semantics**. They
+require the controlled Q11 editor experiment before a writer may depend on them.
 
-The public specification inventory records these MainStack shapes: `Ellipse`, `Obround`,
-`Rectangle`, `Polygon`, `D-shape`, and `Fiducial`.
+**Observed compatibility:** The reader recognizes these `MainStack` shape literals: `Ellipse`,
+`Obround`, `Rectangle`, `Polygon`, `D-shape`, and `Fiducial`. Contrary to an earlier version of this
+guide, the public inventory does not record a `MainStack` element or this enum.
 
-Mask modes: `Common`, `Open`, `Tented`, `By Paste`. Paste modes: `Common`, `Solder`, `No Solder`,
-`Segments`. Common is represented by omission. `CustomSwell=-1000` and `CustomShrink=-1000` are
-unset. Segmented paste uses `TopSegments`/`BotSegments` with rectangle `Item` entries.
+**Public specification:** The embedded PCB pattern/pad section documents mask modes `Common`,
+`Open`, `Tented`, `By Paste`; paste modes `Common`, `Solder`, `No Solder`, `Segments`; and
+`TopSegments`/`BotSegments` rectangle entries. It does not say that `Common` must be represented by
+omission or define a `-1000` sentinel. **Observed compatibility:** the reader preserves explicit
+mode attributes, tolerates absent ones, and treats `CustomSwell=-1000` or `CustomShrink=-1000` as
+unset. That is compatibility policy, not a standalone writer convention.
 
-Pattern layers are individual textual literals such as `Top Silk`, `Bottom Silk`, `Top Assy`,
-`Bottom Assy`, `Top Mask`, `Bottom Mask`, `Top Paste`, `Bottom Paste`, `Top Courtyard`,
-`Bottom Courtyard`, `Top Outline`, and `Bottom Outline`. Do not invent `Top/Bottom ...` names.
+**Public specification:** The embedded PCB shape layer enum contains textual literals such as
+`Top Silk`, `Bottom Silk`, `Top Assy`, `Bottom Assy`, `Top Mask`, `Bottom Mask`, `Top Paste`,
+`Bottom Paste`, `Top Courtyard`, `Bottom Courtyard`, `Top Outline`, and `Bottom Outline`. Do not
+invent `Top/Bottom ...` names.
 
-`Model3D/Filename` is a container with `Path`/`Var`; `Rotate` is in degrees.
+**Observed compatibility:** The standalone-library reader normalizes
+`Model3D/Filename/Path` and `Model3D/Filename/Var` and exposes `Rotate` attributes literally;
+other raw XML is preserved. Keep this reader behavior separate from filename-shape and angle-unit
+writer evidence.
 
 ## Component Library aliases and references
 
-- Canonical attached footprint attribute: `Pattern/@Style`; reader may accept legacy
-  `PatternType`.
-- Canonical pin-to-pad numeric reference: `Pin/@PadId`; reader may accept legacy `PadIndex`.
-- `PadNumber` is the footprint pad name paired with that numeric reference.
-- `InternalConnections/IntCon @X/@Y` are pad Id references, not coordinates. Never delete or
-  renumber a referenced pad without updating these references.
+**Observed compatibility:** The reader prefers `Pattern/@Style` and accepts `PatternType`; it
+prefers `Pin/@PadId` and accepts `PadIndex`; it reads `PadNumber` as the paired footprint pad name.
+Those preferences describe current compatibility handling, not proven canonical standalone
+library spellings.
+
+**Public specification:** In the embedded PCB component-pattern section,
+`InternalConnections/IntCon/PadId/Item` values are pad IDs, and each nested `Ratline/@X` and
+`Ratline/@Y` is also a pad ID rather than a coordinate. This corrects the earlier claim that `X`
+and `Y` were attributes of `IntCon` itself. Safe mutation must preserve those references. Whether
+standalone editors use identical identity and renumbering rules remains part of
+[Q11](../../docs/OPEN_QUESTIONS.md#q11-what-are-the-standalone-component-and-pattern-editor-xml-mutation-semantics).
 
 ## PCB connectivity
 
@@ -109,7 +158,9 @@ is rebuilt from the style.
 
 A Part pin carries `NetId`; a Net `<Pins>` list references Part Id plus positional pin index.
 Wire endpoints use the documented endpoint tuple. `Dir` on the segment end point is `-1` unset,
-`0` horizontal, `1` vertical. Net/bus wire containers are replacement lists when supplied.
+`0` horizontal, `1` vertical. Current MCP writers own and replace a targeted net/bus wire
+container when explicitly asked to rewrite it. The public format source documents the container
+shape and point order, but not a generic plug-in-import replacement rule.
 
 ## Trust
 

--- a/scripts/audit_reference_materials.py
+++ b/scripts/audit_reference_materials.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Inventory a local reference-material directory without copying source bytes.
+
+The default intentionally hashes only small documentation files and a deterministic,
+size-stratified sample of legacy DipTrace libraries. It does not recursively hash every
+library and it never emits file contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DOCUMENT_EXTENSIONS = {".docx", ".md", ".pdf"}
+LIBRARY_EXTENSIONS = {".eli", ".lib"}
+DEFAULT_SAMPLE_PER_KIND = 12
+SAMPLE_SEED = "mcp-diptrace-reference-material-audit-v1"
+READ_CHUNK_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    relative_path: str
+    path: Path
+    size_bytes: int
+    extension: str
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(READ_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_files(root: Path) -> tuple[list[FileEntry], list[str]]:
+    entries: list[FileEntry] = []
+    skipped_symlinks: list[str] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            skipped_symlinks.append(relative)
+            continue
+        if not path.is_file():
+            continue
+        stat = path.stat()
+        entries.append(
+            FileEntry(
+                relative_path=relative,
+                path=path,
+                size_bytes=stat.st_size,
+                extension=path.suffix.lower(),
+            )
+        )
+    return entries, skipped_symlinks
+
+
+def _rank(seed: str, entry: FileEntry) -> str:
+    value = f"{seed}\0{entry.relative_path}\0{entry.size_bytes}".encode()
+    return hashlib.sha256(value).hexdigest()
+
+
+def _stratified_sample(
+    entries: Sequence[FileEntry],
+    *,
+    sample_count: int,
+    seed: str = SAMPLE_SEED,
+) -> list[FileEntry]:
+    """Select endpoints plus deterministic members of equal-count size strata."""
+    ordered = sorted(entries, key=lambda item: (item.size_bytes, item.relative_path))
+    if sample_count >= len(ordered):
+        return ordered
+    if sample_count <= 0:
+        return []
+    if sample_count == 1:
+        return [min(ordered, key=lambda item: _rank(seed, item))]
+
+    chosen = {ordered[0], ordered[-1]}
+    strata = max(sample_count - 2, 0)
+    for index in range(strata):
+        start = index * len(ordered) // strata
+        end = (index + 1) * len(ordered) // strata
+        bucket = ordered[start:end]
+        if bucket:
+            chosen.add(min(bucket, key=lambda item: _rank(f"{seed}:{index}", item)))
+
+    if len(chosen) < sample_count:
+        remaining = (entry for entry in ordered if entry not in chosen)
+        chosen.update(
+            sorted(remaining, key=lambda item: _rank(f"{seed}:fill", item))[
+                : sample_count - len(chosen)
+            ]
+        )
+    return sorted(chosen, key=lambda item: (item.size_bytes, item.relative_path))
+
+
+def _magic_label(path: Path) -> str:
+    with path.open("rb") as stream:
+        prefix = stream.read(8)
+    if prefix.startswith(b"\x06DTELIB"):
+        return "legacy_component_library_binary"
+    if prefix.startswith(b"\x06DTCLIB"):
+        return "legacy_pattern_library_binary"
+    if prefix.startswith((b"<?xml", b"\xef\xbb\xbf<?xml")):
+        return "xml_text"
+    return f"unknown:{prefix.hex()}"
+
+
+def _summaries(entries: Iterable[FileEntry]) -> dict[str, dict[str, int]]:
+    by_extension: dict[str, list[FileEntry]] = defaultdict(list)
+    for entry in entries:
+        by_extension[entry.extension or "<none>"].append(entry)
+    return {
+        extension: {
+            "count": len(group),
+            "bytes": sum(entry.size_bytes for entry in group),
+            "min_bytes": min(entry.size_bytes for entry in group),
+            "max_bytes": max(entry.size_bytes for entry in group),
+        }
+        for extension, group in sorted(by_extension.items())
+    }
+
+
+def build_inventory(root: Path, *, sample_per_kind: int) -> dict[str, Any]:
+    resolved = root.resolve(strict=True)
+    if not resolved.is_dir():
+        raise ValueError(f"Reference-material root is not a directory: {root}")
+    entries, skipped_symlinks = _safe_files(resolved)
+    documents = [entry for entry in entries if entry.extension in DOCUMENT_EXTENSIONS]
+    libraries = [entry for entry in entries if entry.extension in LIBRARY_EXTENSIONS]
+    classified = {*documents, *libraries}
+    other_entries = [entry for entry in entries if entry not in classified]
+
+    document_records = [
+        {
+            "path": entry.relative_path,
+            "size_bytes": entry.size_bytes,
+            "sha256": _sha256(entry.path),
+        }
+        for entry in documents
+    ]
+
+    library_records: dict[str, dict[str, Any]] = {}
+    hashed_library_count = 0
+    for extension in sorted(LIBRARY_EXTENSIONS):
+        population = [entry for entry in libraries if entry.extension == extension]
+        sample = _stratified_sample(
+            population,
+            sample_count=sample_per_kind,
+            seed=f"{SAMPLE_SEED}:{extension}",
+        )
+        magic_counts: dict[str, int] = defaultdict(int)
+        for entry in population:
+            magic_counts[_magic_label(entry.path)] += 1
+        library_records[extension] = {
+            "population_count": len(population),
+            "population_bytes": sum(entry.size_bytes for entry in population),
+            "population_magic_counts": dict(sorted(magic_counts.items())),
+            "sampling": {
+                "method": (
+                    "smallest and largest plus deterministic selections from "
+                    "equal-count size strata"
+                ),
+                "seed": f"{SAMPLE_SEED}:{extension}",
+                "requested_count": sample_per_kind,
+                "actual_count": len(sample),
+            },
+            "sample": [
+                {
+                    "path": entry.relative_path,
+                    "size_bytes": entry.size_bytes,
+                    "sha256": _sha256(entry.path),
+                    "magic": _magic_label(entry.path),
+                }
+                for entry in sample
+            ],
+        }
+        hashed_library_count += len(sample)
+
+    return {
+        "schema_version": 1,
+        "scope": {
+            "root_name": resolved.name,
+            "file_count": len(entries),
+            "bytes": sum(entry.size_bytes for entry in entries),
+            "documentation_file_count": len(documents),
+            "documentation_bytes": sum(entry.size_bytes for entry in documents),
+            "legacy_library_file_count": len(libraries),
+            "legacy_library_bytes": sum(entry.size_bytes for entry in libraries),
+            "other_file_count": len(other_entries),
+            "other_bytes": sum(entry.size_bytes for entry in other_entries),
+            "skipped_symlinks": skipped_symlinks,
+        },
+        "by_extension": _summaries(entries),
+        "documentation": document_records,
+        "legacy_library_samples": library_records,
+        "disclosure": {
+            "all_legacy_libraries_hashed": hashed_library_count == len(libraries),
+            "source_bytes_embedded": False,
+            "source_paths_are_relative": True,
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        required=True,
+        help="Local, uncommitted reference-material directory to inventory",
+    )
+    parser.add_argument(
+        "--sample-per-kind",
+        type=int,
+        default=DEFAULT_SAMPLE_PER_KIND,
+        help="Number of .eli and .lib files to hash (default: 12 each)",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.sample_per_kind < 0:
+        raise SystemExit("--sample-per-kind must be non-negative")
+    print(
+        json.dumps(
+            build_inventory(args.root, sample_per_kind=args.sample_per_kind),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_reference_materials.py
+++ b/tests/test_audit_reference_materials.py
@@ -1,0 +1,95 @@
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "audit_reference_materials.py"
+
+
+def _write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _run(root: Path, *, sample_count: int) -> dict[str, object]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--root",
+            str(root),
+            "--sample-per-kind",
+            str(sample_count),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_inventory_hashes_documents_and_samples_binary_libraries(tmp_path: Path) -> None:
+    secret = b"do-not-copy-this-source-body"
+    component_small = b"\x06DTELIB" + b"a"
+    component_large = b"\x06DTELIB" + b"b" * 10
+    pattern = b"\x06DTCLIB" + b"c"
+    _write(tmp_path / "notes" / "source.md", secret)
+    _write(tmp_path / "comps" / "small.eli", component_small)
+    _write(tmp_path / "comps" / "large.eli", component_large)
+    _write(tmp_path / "patterns" / "one.lib", pattern)
+
+    result = _run(tmp_path, sample_count=1)
+
+    library_bytes = len(component_small) + len(component_large) + len(pattern)
+    assert result["scope"] == {
+        "bytes": len(secret) + library_bytes,
+        "documentation_bytes": len(secret),
+        "documentation_file_count": 1,
+        "file_count": 4,
+        "legacy_library_bytes": library_bytes,
+        "legacy_library_file_count": 3,
+        "other_bytes": 0,
+        "other_file_count": 0,
+        "root_name": tmp_path.name,
+        "skipped_symlinks": [],
+    }
+    documents = result["documentation"]
+    assert isinstance(documents, list)
+    assert documents == [
+        {
+            "path": "notes/source.md",
+            "sha256": hashlib.sha256(secret).hexdigest(),
+            "size_bytes": len(secret),
+        }
+    ]
+    samples = result["legacy_library_samples"]
+    assert isinstance(samples, dict)
+    assert samples[".eli"]["population_count"] == 2
+    assert samples[".eli"]["population_magic_counts"] == {
+        "legacy_component_library_binary": 2
+    }
+    assert len(samples[".eli"]["sample"]) == 1
+    assert samples[".lib"]["population_magic_counts"] == {
+        "legacy_pattern_library_binary": 1
+    }
+    assert secret.decode() not in json.dumps(result)
+    assert result["disclosure"]["source_bytes_embedded"] is False
+    assert result["disclosure"]["all_legacy_libraries_hashed"] is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires privileges")
+def test_inventory_skips_symlinks(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (tmp_path / "redirect.md").symlink_to(outside)
+
+    result = _run(tmp_path, sample_count=0)
+
+    assert result["scope"]["skipped_symlinks"] == ["redirect.md"]
+    assert result["scope"]["file_count"] == 0
+    assert result["scope"]["documentation_file_count"] == 0
+    assert result["scope"]["legacy_library_file_count"] == 0
+    assert result["documentation"] == []

--- a/tests/test_spec_inventory.py
+++ b/tests/test_spec_inventory.py
@@ -9,6 +9,9 @@ from pathlib import Path
 _INVENTORY_PATH = Path("reference/diptrace-xml/spec_inventory.json")
 _COVERAGE_PATH = Path("docs/FORMAT_COVERAGE.md")
 _OPEN_QUESTIONS_PATH = Path("docs/OPEN_QUESTIONS.md")
+_XML_COMPATIBILITY_PATH = Path("docs/XML_COMPATIBILITY.md")
+_IMPLEMENTATION_REFERENCE_PATH = Path("reference/diptrace-xml/REFERENCE.md")
+_EVIDENCE_CAPTURE_PATH = Path("docs/EVIDENCE_CAPTURE.md")
 
 
 def _open_question_blocks() -> list[tuple[int, str, str]]:
@@ -183,6 +186,42 @@ class TestFormatCoverage:
         assert "Coverage" in content
 
 
+class TestDocumentationEvidenceClasses:
+    """Keep source authority separate from observations and open questions."""
+
+    def test_compatibility_baseline_labels_each_evidence_class(self) -> None:
+        content = _XML_COMPATIBILITY_PATH.read_text(encoding="utf-8")
+        for heading in (
+            "### Public specification evidence",
+            "### Observed compatibility evidence",
+            "### Open unknowns",
+        ):
+            assert heading in content
+        assert "standalone Component Library or Pattern Library XML format reference" in content
+        assert "official standalone `<Library>` root validation" not in content
+
+    def test_implementation_reference_labels_unverified_semantics(self) -> None:
+        content = _IMPLEMENTATION_REFERENCE_PATH.read_text(encoding="utf-8")
+        for label in (
+            "**Public specification:**",
+            "**Observed compatibility:**",
+            "**Open question / safety model:**",
+        ):
+            assert label in content
+        assert "`ImpMode=All` replaces lists." not in content
+        assert "public specification inventory records these MainStack shapes" not in content
+        assert "**Writer policy:** preserve unknown XML and existing IDs." not in content
+        assert "outside the operation-owned region" in content
+
+    def test_capture_guidance_keeps_gui_controls_and_screenshots_bounded(self) -> None:
+        content = _EVIDENCE_CAPTURE_PATH.read_text(encoding="utf-8")
+        assert "## Designing a controlled recipe" in content
+        assert "one intentional GUI change per probe" in content
+        assert "unchanged controls" in content
+        assert "Screenshots may support" in content
+        assert "never the authoritative format artifact" in content
+
+
 class TestOpenQuestions:
     """Tests for the open questions document."""
 
@@ -251,6 +290,22 @@ class TestOpenQuestions:
             assert phrase in content
         assert "does not state whether selection/highlighting persists" in content
         assert "16 trace-point" in content
+
+    def test_library_question_keeps_identity_and_source_binding_open(self) -> None:
+        """Q11 must cover each unresolved library-evidence boundary."""
+        question_eleven = next(
+            block
+            for number, _, block in _open_question_blocks()
+            if number == 11
+        )
+        for phrase in (
+            "`UID32`",
+            "partial/current-component",
+            "full-save/re-export",
+            "`input_artifacts`",
+        ):
+            assert phrase in question_eleven
+        assert re.search(r"binary\s+SHA-256", question_eleven)
 
     def test_answered_and_duplicate_questions_are_absent(self) -> None:
         """Do not retain questions answered by the spec or duplicate numeric format."""


### PR DESCRIPTION
## Outcome

- inventories the local, untracked `etc/` reference-material collection without copying source bytes;
- classifies generated notes and legacy `.eli`/`.lib` libraries as operator leads, not authoritative or redistributable fixtures;
- separates public-specification, observed-compatibility, and open-question claims in the XML documentation;
- extends Q11 and the evidence-capture guidance with controlled Component/Pattern Editor experiments;
- records the evidence gates in the roadmap without treating the local 2 GB corpus as a shipped feature.

## Safety and provenance

- no file from `etc/` is added, modified, or promoted into the specification inventory;
- all 966 legacy library magic headers were inspected, while full hashing is explicitly limited to a deterministic 12 + 12 sample;
- all 22 small documents were hashed for audit identity only; hashes do not assert origin, authorship, or redistribution permission;
- no revision-7276 claim closes an open question or changes production code.

## Validation

- full pytest: 419 passed, 1 skipped
- focused documentation/audit tests: 25 passed
- Ruff and strict mypy: clean
- skill generator, format-coverage check, and offline inventory check: green
