### PR TITLE
fix: restore full pytest CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Version links and release dates will be added only for an actual release.
 - Public package metadata for repository, documentation, and issue links,
   plus EDA-focused classifiers without a premature license classifier.
 
+### Fixed
+
+- Full pytest CI regression introduced by the release-artifact validation work.
+
 ### Clarified
 
 - The license release blocker is resolved: Apache-2.0 is committed as

--- a/docs/LICENSE_DECISION.md
+++ b/docs/LICENSE_DECISION.md
@@ -76,7 +76,8 @@ checklist.
 - Documentation and fixture treatment: code, documentation, and packaged
   skills are covered by the same license. Fixtures and evidence artifacts with
   unresolved redistribution permission are not distributed: the release
-  allowlist excludes `tests/fixtures/acceptance/` and `docs/private/`.
+  allowlist excludes `tests/fixtures/acceptance/`; it also excludes the
+  intentionally untracked docs/private directory.
 - Dependency and notice audit: direct runtime dependencies are `mcp` (MIT),
   `pydantic` (MIT), and `typing-extensions` (PSF); the optional geometry extra
   adds `shapely` (BSD-3-Clause). No third-party code is vendored into the


### PR DESCRIPTION
Diagnose and repair the common full-pytest failure currently affecting Linux, macOS, and Windows. This PR will be merged only after the complete matrix is green.