### PR TITLE
Finalize v0.1.2 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
-No unreleased user-visible changes are recorded.
+### Documentation
+
+- Finalized the post-publication `v0.1.2` provenance with the immutable release
+  commit, exact-head CI run, public asset inventory, checksum verification, and
+  public-download smoke results.
+- Distinguished the frozen candidate coverage measurement from the exact-head
+  GitHub CI coverage measurement.
+- Reconciled the public release checklist with the verification work that was
+  completed during publication.
 
 ## 0.1.2 - 2026-08-01
 
@@ -27,15 +35,19 @@ No unreleased user-visible changes are recorded.
 
 ### Validation
 
-- Fresh Python 3.12.3/Shapely 2.1.2/GEOS 3.13.1 run: 991 passed, 4 skipped;
-  total coverage 85.941378% (16,922 statements, 2,379 missed).
-- The required Linux, macOS, Windows, geometry, fallback, static-analysis,
-  generated-artifact, and native-bridge matrix is the merge gate for the exact
-  final PR head.
-- Candidate wheel/sdist audit, clean-wheel installation and stdio smoke,
-  direct-wheel/sdist-rebuilt-wheel comparison, and headless bridge smoke pass;
-  exact CI bridge provenance, plugin ZIP, checksums, and public-download
-  verification remain required before publication.
+- Frozen candidate/local run: Python 3.12.3, Shapely 2.1.2, GEOS 3.13.1,
+  991 passed, 4 skipped, 16,922 statements, 2,379 missed, and 85.941378%
+  total coverage.
+- Exact-head GitHub CI run `30709466348`: all eight required Linux, macOS,
+  Windows, geometry, fallback, static-analysis, generated-artifact, and native
+  bridge jobs passed; its Python 3.12.13 coverage result was 991 passed,
+  4 skipped, 16,922 statements, 2,375 missed, and 85.9650% total.
+- Wheel/sdist audit, direct-wheel versus sdist-rebuilt-wheel comparison,
+  clean-wheel installation, CLI and MCP stdio smoke, exact-CI Windows bridge
+  provenance, plug-in ZIP/settings validation, checksums, and public-download
+  verification passed.
+- All ten expected GitHub Release assets were present exactly once, and the
+  publicly downloaded files passed `sha256sum -c SHA256SUMS.txt`.
 
 ## 0.1.1 - 2026-08-01 [Withdrawn]
 
@@ -48,7 +60,7 @@ that a critical runtime vulnerability existed is made. It is superseded by
 
 - Preserve Windows-native live exchange paths in session metadata and derive WSL
   drive-mount paths only in memory, preventing false `applied` results against a
-  phantom `C:\mnt\c\...` target.
+  phantom `C:\\mnt\\c\\...` target.
 - Ignore the intentional stdout-close race used to unblock a Windows output-reader
   thread after the root process exits while a descendant inherited the pipe.
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -4,10 +4,12 @@
 
 Audited repository state: 2026-08-01.
 
-**Status: development release only under explicit exception.** The repository has an OSI-approved project-wide license (Apache-2.0, committed as `LICENSE`), private vulnerability reporting published as `SECURITY.md`, a v0.1.2 development-stage release path with an unsigned-binary disclosure, and a completed 2026-07-31 live acceptance matrix. It still has no verified conduct channel, approved contribution terms, signed release artifact, or independent release reviewer, so it must not be represented as independently reviewed, signed, or production-ready.
+**Status: v0.1.2 is a verified development-stage release under an explicit solo-maintainer exception.** The repository has an OSI-approved project-wide license (Apache-2.0, committed as `LICENSE`), private vulnerability reporting published as `SECURITY.md`, an unsigned-binary disclosure, a completed 2026-07-31 live acceptance matrix, green exact-head CI, and verified public release assets. It still has no verified conduct channel, approved contribution terms, signed release artifact, dependency/bundled-content legal review, or independent release reviewer, so it must not be represented as independently reviewed, signed, or production-ready.
 
-Checked boxes below describe repository facts in the audited state. Unchecked
-boxes are release blockers, not publication claims.
+Checked boxes below describe repository or release facts in the audited state.
+Unchecked boxes are blockers for stronger publication, redistribution, governance,
+or production-readiness claims; they do not negate the verified alpha/development-
+stage status of v0.1.2.
 
 ## Legal, ownership, and redistribution
 
@@ -28,7 +30,7 @@ boxes are release blockers, not publication claims.
       provenance and redistribution permission.
 - [ ] Trademark and non-affiliation wording is approved.
 
-Until the remaining redistribution and review items are complete, do not claim every bundled asset has independent clearance and do not publish a release as independently reviewed, signed, or production-ready. Development-stage publication requires the explicit exception and disclosures described in [RELEASE_PROCESS.md](RELEASE_PROCESS.md).
+Until the remaining redistribution and review items are complete, do not claim every bundled asset has independent clearance and do not publish a release as independently reviewed, signed, or production-ready. Development-stage publication uses the explicit exception and disclosures described in [RELEASE_PROCESS.md](RELEASE_PROCESS.md).
 
 ## Maintainers, governance, and community safety
 
@@ -60,7 +62,7 @@ in [SECURITY.md](../SECURITY.md).
 - [x] Missing native library mutation and manufacturing output remain
       explicit.
 - [x] Open compatibility questions and human-only experiments are documented.
-- [x] Both READMEs state the license and public-release blocker.
+- [x] Both READMEs state the license and public-release limitations.
 - [x] Citation metadata records the Apache-2.0 license and the 0.1.2 release
       date.
 - [x] The changelog and release provenance distinguish the withdrawn `0.1.1`
@@ -68,8 +70,10 @@ in [SECURITY.md](../SECURITY.md).
 - [ ] Package-index rendering of README links is verified or made independent
       of repository-relative link resolution.
 - [x] Windows plug-in settings, installer, and bridge-binary delivery are documented separately from the Python wheel; clean build, four-target install hash checks, and live PCB/Schematic acceptance were completed on 2026-07-31.
-- [ ] Final installation instructions are tested from release artifacts.
-- [ ] Announcement text is reviewed only after public URLs and license exist.
+- [x] Final installation instructions were tested from the publicly downloaded
+      v0.1.2 release artifacts.
+- [x] English and Russian announcement drafts were reviewed after the public
+      release URLs, license, limitations, and checksums were verified.
 
 ## Quality and compatibility
 
@@ -81,13 +85,18 @@ in [SECURITY.md](../SECURITY.md).
 - [x] Specification inventory and format coverage have reproducibility gates.
 - [x] Acceptance seed audit fails closed and reports zero accepted seeds.
 - [x] Windows DipTrace 5.2.0.4 ↔ WSL MCP live acceptance covers the tested PCB/Schematic apply, cancel, and wrong-SHA matrix, with GUI/save/re-export checks and no phantom path.
-- [ ] Release commit passes every required CI job.
-- [ ] Coverage figures in public docs are regenerated from the release commit.
-- [ ] Release candidate is installed and smoke-tested from v0.1.2 built artifacts
-      (procedure in [TESTING.md](TESTING.md)).
-- [ ] Supported Python, OS, DipTrace, transport, and bridge ranges are
-      approved.
-- [ ] Known limitations are copied into release notes without overclaiming.
+- [x] The exact final PR head `759234f209927e3c033e44d63494d3ca3cfae150`
+      passed all eight required jobs in CI run `30709466348`; the ordinary merge
+      commit preserved that tested release tree.
+- [x] Public documentation distinguishes the frozen candidate coverage result
+      from the exact-head GitHub CI coverage result.
+- [x] The release candidate and publicly downloaded wheel were installed and
+      smoke-tested from v0.1.2 artifacts using the procedure in
+      [TESTING.md](TESTING.md).
+- [ ] Supported Python, OS, DipTrace, transport, and bridge ranges receive an
+      independent compatibility approval.
+- [x] Known limitations are copied into release notes and announcements without
+      production-ready or universal-compatibility claims.
 
 ## Artifact and supply-chain controls
 
@@ -96,35 +105,39 @@ in [SECURITY.md](../SECURITY.md).
       or unexpected archive members.
 - [x] CI checks wheel entry points, eight packaged skills, project URLs,
       archive bounds, and every wheel `RECORD` hash and size.
-- [ ] A wheel rebuilt from the frozen source distribution is compared with the
-      direct release wheel in the release environment.
-- [ ] The frozen release wheel is installed and smoke-tested with only its
-      declared dependencies.
-- [ ] Windows bridge contents and runtime dependencies are inspected.
-- [ ] Artifact SHA-256 manifest is generated for the v0.1.2 release assets
-      (`SHA256SUMS.txt`; see [releases/v0.1.2.md](releases/v0.1.2.md)).
+- [x] A wheel rebuilt from the frozen source distribution was compared with the
+      direct release wheel by member set and per-member SHA-256.
+- [x] The frozen and publicly downloaded release wheels were installed and
+      smoke-tested with only their declared dependencies.
+- [x] Windows bridge contents and bundled runtime dependencies were inspected;
+      PowerShell `--help`, plug-in ZIP, and all four settings profiles passed.
+- [x] `SHA256SUMS.txt` covers all ten v0.1.2 release assets, and a fresh public
+      download passed `sha256sum -c`.
 - [x] A reviewed unsigned policy is disclosed for the unsigned 0.1.2
       artifacts; no signing identity is configured yet.
-- [ ] Publication accounts have multi-factor authentication and recovery
-      owners.
-- [ ] Immutable artifact host and retention policy are documented.
-- [ ] Tag, archive, wheel, binary, checksums, and release notes resolve to the
-      same commit and version.
+- [ ] Publication accounts have documented multi-factor-authentication and
+      recovery owners.
+- [ ] Immutable artifact-host retention and recovery policy is documented.
+- [x] Tag, wheel, source distribution, binary, plug-in ZIP, checksums, evidence
+      files, installation guide, announcements, and release notes resolve to
+      version 0.1.2 and the documented frozen release provenance.
 
 ## Release operation
 
-- [ ] Release manager and independent reviewer are named in the release record.
-- [ ] Version and frozen merge commit are approved (recorded in
-      [releases/v0.1.2.md](releases/v0.1.2.md)).
+- [x] Release manager is named in [releases/v0.1.2.md](releases/v0.1.2.md).
+- [ ] An independent release reviewer is named.
+- [x] Version and frozen merge commit are recorded in
+      [releases/v0.1.2.md](releases/v0.1.2.md).
 - [x] `CHANGELOG.md` is finalized for the approved version and date.
-- [ ] Staged v0.1.2 artifacts pass clean-environment installation and smoke
-      tests.
-- [ ] Security and conduct channels are monitored.
-- [ ] Tag and artifacts are published through
+- [x] Staged and publicly downloaded v0.1.2 artifacts passed clean-environment
+      installation and smoke tests.
+- [ ] Security and conduct channels have documented ongoing monitoring and
+      backup ownership.
+- [x] Tag and all ten artifacts are published through the process in
       [RELEASE_PROCESS.md](RELEASE_PROCESS.md).
-- [ ] English and Russian announcements are posted only after final public URLs
-      are verified.
-- [ ] Post-release support and incident processes are active.
+- [ ] English and Russian announcements are posted to their external forums;
+      the repository drafts are verified and ready for posting.
+- [ ] Post-release support and incident processes have documented active owners.
 
 ## Explicit non-evidence
 

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -4,7 +4,10 @@
 
 - Version: `0.1.2`; tag: `v0.1.2`.
 - Frozen release commit: `8ec5d26d4e4f63a56cf42dd37d0b305f519f79cc`.
-- `main` and annotated tag `v0.1.2` resolve to that same commit.
+- Annotated tag `v0.1.2` resolves to the frozen release commit. `main` resolved to
+  the same commit at publication; later `main` commits may contain
+  post-publication documentation only and do not alter the immutable release
+  tag or asset bytes.
 - Release pull request: [#38](https://github.com/fireostendere/mcp_diptrace/pull/38), merged with an ordinary merge commit so the explicit revert remains visible.
 - Original `v0.1.1` commit: `f799bc51fa350747a253563926fabbae0fe75c19`.
 - Explicit revert commit: `a0b6dd28bac41f60ccbff13ec23a250e5c8eea3e`.
@@ -27,7 +30,9 @@ All eight required jobs passed:
 - native Windows bridge build and `--help` smoke test; and
 - Ruff, strict Mypy, generated skills, MCP snapshot, artifact audit, format coverage, spec inventory, probe pack, trust-neutral ingest, and acceptance-seed audit.
 
-The non-squash merge commit contains the exact tested release tree. `main` and `v0.1.2` are identical at the frozen release commit.
+The ordinary merge commit contains the exact tested release tree, and tag
+`v0.1.2` remains fixed on that merge commit. Post-publication documentation
+commits on `main` do not change the tagged source or published assets.
 
 Two coverage measurements are retained because they describe different executions:
 

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -3,43 +3,39 @@
 ## Identity and scope
 
 - Version: `0.1.2`; tag: `v0.1.2`.
-- Frozen commit: the exact non-squash merge commit of the single release PR;
-  its SHA is the value returned by `git rev-parse 'v0.1.2^{}'` and is recorded
-  in the GitHub Release notes after merge. A self-referential SHA is not placed
-  in this file before the merge commit exists.
-- Release manager: [@fireostendere](https://github.com/fireostendere), the
-  repository owner.
+- Frozen release commit: `8ec5d26d4e4f63a56cf42dd37d0b305f519f79cc`.
+- `main` and annotated tag `v0.1.2` resolve to that same commit.
+- Release pull request: [#38](https://github.com/fireostendere/mcp_diptrace/pull/38), merged with an ordinary merge commit so the explicit revert remains visible.
+- Original `v0.1.1` commit: `f799bc51fa350747a253563926fabbae0fe75c19`.
+- Explicit revert commit: `a0b6dd28bac41f60ccbff13ec23a250e5c8eea3e`.
+- Release manager: [@fireostendere](https://github.com/fireostendere), the repository owner.
 - Independent reviewer: none.
-- Exception: solo-maintainer development-release exception, with the limits and
-  evidence boundaries below.
-- This is an alpha/development-stage release. It is not production-ready and
-  is not published to PyPI or another package index.
-- The predecessor [v0.1.1 is withdrawn](v0.1.1.md); its tag remains on the
-  original commit for audit.
+- Exception: solo-maintainer development-release exception, with the limits and evidence boundaries below.
+- This is an alpha/development-stage release. It is not production-ready and is not published to PyPI or another package index.
+- The predecessor [v0.1.1 is withdrawn](v0.1.1.md); its tag and original asset bytes remain unchanged for audit.
 
-## Required validation
+## CI and validation
 
-The exact final PR head must pass the complete required CI matrix before merge:
+The exact final PR head `759234f209927e3c033e44d63494d3ca3cfae150` passed GitHub Actions run
+[30709466348](https://github.com/fireostendere/mcp_diptrace/actions/runs/30709466348).
+All eight required jobs passed:
 
 - Linux Python 3.10 and 3.13;
 - Linux Python 3.12 with Shapely/GEOS, coverage, and headless bridge tests;
 - Linux Python 3.12 no-Shapely fallback;
 - macOS and Windows Python 3.12;
-- native Windows bridge build and `--help` smoke test;
-- Ruff, strict Mypy, generated skills, MCP snapshot, artifact audit, format
-  coverage, spec inventory, probe pack, trust-neutral ingest, and
-  acceptance-seed audit.
+- native Windows bridge build and `--help` smoke test; and
+- Ruff, strict Mypy, generated skills, MCP snapshot, artifact audit, format coverage, spec inventory, probe pack, trust-neutral ingest, and acceptance-seed audit.
 
-The release procedure also requires a fresh exact coverage run, a clean-wheel
-smoke test, a real MCP stdio `initialize`/`tools/list` handshake, a
-`get_capabilities` response, and one read-only tool call. The direct wheel and
-the wheel rebuilt from the sdist are compared by member set, member SHA-256,
-entry points, packaged skills, `METADATA`, and `RECORD` hashes/sizes.
+The non-squash merge commit contains the exact tested release tree. `main` and `v0.1.2` are identical at the frozen release commit.
 
-The fresh candidate run on 2026-08-01 completed with 991 passed and 4 skipped
-on Python 3.12.3, Shapely 2.1.2, and GEOS 3.13.1. Total coverage was
-85.941378% (16,922 statements, 2,379 missed); `bridge.py` was 264/83
-(68.560606%), `xml_document.py` 808/86 (89.356436%),
+Two coverage measurements are retained because they describe different executions:
+
+- frozen candidate/local release run: Python 3.12.3, Shapely 2.1.2, GEOS 3.13.1, 991 passed, 4 skipped, 16,922 statements, 2,379 missed, 85.941378% total;
+- exact-head GitHub CI run: Python 3.12.13, 991 passed, 4 skipped, 16,922 statements, 2,375 missed, 85.9650% total.
+
+The enforced per-file floors passed. In the frozen candidate measurement,
+`bridge.py` was 264/83 (68.560606%), `xml_document.py` 808/86 (89.356436%),
 `semantic_compiler.py` 1,349/159 (88.2135%), and `routing_compiler.py` 561/75
 (86.631016%).
 
@@ -47,10 +43,44 @@ The candidate wheel/sdist audit passed with 79 wheel files and 280 sdist files.
 The direct wheel and wheel rebuilt from the sdist had identical member sets and
 per-member SHA-256 values. The clean wheel passed CLI `--help` and a real stdio
 handshake: `initialize`, `tools/list` with 159 tools, `get_capabilities`, and
-read-only `summarize_design` all succeeded. The local headless bridge smoke test
-also passed. The exact final PR-head CI matrix, merge commit, CI run, Windows
-bridge provenance, SHA256SUMS, and public-download smoke evidence remain
-publication gates and are recorded only after those checks complete.
+read-only `summarize_design` all succeeded.
+
+The public MCP snapshot contains 159 registered tools. Its canonical descriptor
+is 140,831 bytes with SHA-256
+`384f8355475f158faec06218d931f3b2f433fdaede6fabf68813d3ba3b4222d2`.
+Compact discovery is 128,466 bytes, 5.8771% above the 121,335-byte baseline.
+Format coverage records 19 written-only, 22 mentioned-only, and 171 passthrough
+entries.
+
+## Windows bridge and public-asset verification
+
+The Windows bridge was taken from the successful exact-head CI artifact. Its
+PowerShell `--help` smoke test passed, bundled runtime dependencies were
+validated, and the plug-in ZIP and all four settings profiles passed package
+validation. The executable and plug-in package are unsigned; CI success is not
+a code signature.
+
+All ten expected files are present exactly once in the public
+[GitHub Release v0.1.2](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.1.2).
+They were downloaded again from the public release, and `sha256sum -c
+SHA256SUMS.txt` passed. The publicly downloaded wheel also passed clean-install,
+CLI, and MCP stdio smoke tests.
+
+`SHA256SUMS.txt` is authoritative for the complete digests. The table below
+records public sizes and short digest prefixes for convenient identification:
+
+| Asset | Size | SHA-256 prefix |
+| --- | ---: | --- |
+| `diptrace_mcp-0.1.2-py3-none-any.whl` | 396,758 bytes | `5c1c6698…` |
+| `diptrace_mcp-0.1.2.tar.gz` | 878,213 bytes | `edcd7d45…` |
+| `diptrace_mcp_bridge.exe` | 17,645,043 bytes | `65242e72…` |
+| `diptrace_mcp_windows_plugin-0.1.2.zip` | 17,367,697 bytes | `fe963e5d…` |
+| `SHA256SUMS.txt` | 836 bytes | `f4709d86…` |
+| `LIVE_ACCEPTANCE_2026-07-31.md` | 2,936 bytes | `a7f525dc…` |
+| `CODE_REVIEW_2026-07-31.md` | 4,508 bytes | `8ffed2f5…` |
+| `INSTALL_FROM_RELEASE.md` | 4,016 bytes | `0a7d77a0…` |
+| `v0.1.2-forum-ru.md` | 4,656 bytes | `9f104f8b…` |
+| `v0.1.2-forum-en.md` | 3,498 bytes | `38593b37…` |
 
 ## Live evidence boundary
 
@@ -60,43 +90,19 @@ save/re-export, path-platform metadata, and connectivity/count checks. It does
 not prove every registered tool, every DipTrace version, every XML object,
 native library mutation, external solver path, or manufacturing sign-off.
 
-The Windows bridge provenance must identify the successful exact-head CI run,
-its artifact, source commit, non-empty executable, `--help` result, bundled
-runtime dependencies, and SHA-256. The executable and plugin package are
-unsigned; CI success is not a signature.
-
-## Release assets
-
-The published asset set is:
-
-- `diptrace_mcp-0.1.2.tar.gz`;
-- `diptrace_mcp-0.1.2-py3-none-any.whl`;
-- `diptrace_mcp_bridge.exe`;
-- `diptrace_mcp_windows_plugin-0.1.2.zip`;
-- `LIVE_ACCEPTANCE_2026-07-31.md`;
-- `CODE_REVIEW_2026-07-31.md`;
-- `INSTALL_FROM_RELEASE.md`;
-- `v0.1.2-forum-ru.md`;
-- `v0.1.2-forum-en.md`; and
-- `SHA256SUMS.txt` covering every file above.
-
-All assets are unsigned. The release does not publish to PyPI. Users must
-download from GitHub, verify SHA-256, and retain the release URL and commit
-metadata when reporting an issue.
+The public workflow invokes 63 distinct tools. That is not evidence of real GUI
+round trips for all 159 registered tools. Runtime `get_capabilities` remains the
+authoritative source for a particular document and installation.
 
 ## Supported environments and limitations
 
 - Python 3.10–3.13 on Linux, macOS, Windows, and offline WSL server use;
-- live bridge integration on Windows 10/11 with a DipTrace build supporting
-  executable XML plug-ins;
+- live bridge integration on Windows 10/11 with a DipTrace build supporting executable XML plug-ins;
 - Component and Pattern Editor bridge profiles remain read-only;
-- broad DipTrace writer compatibility, native library mutation, manufacturing
-  output, external-solver evidence, and complete trust invalidation remain
-  explicitly incomplete;
-- the runtime `get_capabilities` response is authoritative for a particular
-  document and installation; and
-- no production-ready, signed-binary, vendor-endorsement, independent-audit,
-  or complete-manufacturing-sign-off claim is made.
+- broad DipTrace writer compatibility, native library mutation, manufacturing output, external-solver evidence, and complete trust invalidation remain explicitly incomplete;
+- all release assets are unsigned;
+- no package-index publication is performed; and
+- no production-ready, signed-binary, vendor-endorsement, independent-audit, community-adoption, or complete-manufacturing-sign-off claim is made.
 
 ## Rollback and withdrawal
 
@@ -104,5 +110,5 @@ Release assets are immutable and are never replaced under an existing version.
 If a material defect or documentation inconsistency is found, preserve the tag
 and asset bytes, publish a replacement version, and mark this release withdrawn
 with the reason and replacement link. Security reports use the private channel
-in [SECURITY.md](../../SECURITY.md). The `v0.1.1` withdrawal record documents
-the same procedure and the explicit Git revert that preserved history.
+in [SECURITY.md](../../SECURITY.md). The [v0.1.1 withdrawal record](v0.1.1.md)
+documents the same procedure and the explicit Git revert that preserved history.


### PR DESCRIPTION
## Scope

Finalize the post-publication documentation for the already published `v0.1.2` release without moving the tag or replacing any release asset.

- records frozen release commit `8ec5d26d4e4f63a56cf42dd37d0b305f519f79cc`;
- records exact-head CI run `30709466348` and its eight successful jobs;
- distinguishes the frozen local coverage result from the exact-head GitHub CI result;
- records public-download, checksum, clean-wheel, stdio, bridge, plug-in ZIP, and settings verification;
- records all ten public assets by name, size, and digest prefix while retaining `SHA256SUMS.txt` as the authoritative full-digest manifest;
- reconciles `CHANGELOG.md` and the public release checklist with the completed publication work;
- preserves the existing alpha/development-stage, unsigned-binary, evidence-boundary, and no-PyPI claims.

This is a documentation-only follow-up. The immutable `v0.1.2` tag and published asset bytes remain unchanged.