### PR TITLE
fix: close post-merge clearance and MCP error gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - add a centralized service-to-MCP error boundary with stable public error codes and safe details;
 - remove verbatim external reference extracts and source-derived inventory from public surfaces;
 - add a clean-room factual inventory generator and a pending DipTrace 5.3 fixture-pack manifest;
+- make unresolved trace-clearance pairs explicit and publish their structured
+  skip reasons and effective clearance rule sources;
+- verify the service-to-MCP error contract through connected
+  `session.call_tool` calls and prevent nested typed-result error wrapping;
+- refresh the dated external GitHub ruleset evidence without changing the
+  ruleset;
 - document the remaining live-evidence, provenance, and partial-clearance limitations.
 
 This file records user-visible project changes. Version `0.1.0` was the first
@@ -18,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Documentation
 
 - Activated and verified the main-branch GitHub ruleset; pull requests require
-  DCO plus the eight technical CI contexts.
+  DCO plus nine unique technical CI contexts (eleven API status records).
 - Completed a post-merge security and compliance audit of the current tree and
   reachable Git history.
 - Added reproducible deep secret-scanning, dependency-audit, and clean-room

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,7 +29,8 @@ No release may bypass a blocker in
 repository owner is responsible for deciding whether a blocker is resolved and
 for preserving the evidence behind that decision.
 
-As checked on 2026-08-02, `main` is covered by the active GitHub ruleset
+As checked on 2026-08-03 at main SHA
+`3f06ffc084154f59a116540694f071c513323215`, `main` is covered by the active GitHub ruleset
 documented in [BRANCH_PROTECTION_STATUS.md](docs/compliance/BRANCH_PROTECTION_STATUS.md).
 Changes are required to come through pull requests with conversation resolution,
 DCO, and the required technical CI checks; force-pushes and branch deletion are
@@ -37,8 +38,9 @@ blocked. Required approvals are `0` for the current solo-maintainer mode. The
 ruleset is an administrative GitHub setting, not a second reviewer: the owner
 retains the administrative ability to change it, and this document does not
 claim independent review or a second maintainer. The API also reports strict
-up-to-date checks and all three merge methods; those facts are retained in the
-dated status record rather than silently changed here.
+up-to-date checks, all three merge methods, and a repository-role pull-request
+bypass; those facts are retained in the dated status record and are not
+immutability claims.
 
 ## Missing governance functions
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Native Component/Pattern Library mutation and native manufacturing output genera
 Current evidence limits are explicit: live Component Angle GUI/re-export validation
 is still pending, so rotation results carry a structured warning. Routing and
 offline trace-to-trace review resolve board defaults and affected NetClass rules;
-trace-to-object and placement clearance remain partial. The public XML inventory
+unresolved owning nets, unknown classes, or unavailable rules make the trace
+review explicitly partial and are counted in its structured result; trace-to-object
+and placement clearance remain partial. The public XML inventory
 contains project-authored observations only; it is not a normative DipTrace
 specification and does not claim Novarm permission or universal DipTrace 5.3
 compatibility.

--- a/README_RU.md
+++ b/README_RU.md
@@ -16,7 +16,9 @@ DipTrace MCP — локальный Model Context Protocol сервер для �
 Ограничения evidence явно раскрыты: live GUI/re-export проверка Component Angle
 ещё не выполнена, поэтому результаты rotation содержат structured warning.
 Routing и offline trace-to-trace review учитывают board defaults и NetClass
-правила затронутых сетей; trace-to-object и placement clearance пока частичны.
+правила затронутых сетей; unresolved owning net, неизвестный класс или
+отсутствующее правило делают trace review явно partial и попадают в structured
+счётчики результата; trace-to-object и placement clearance пока частичны.
 Публичный XML inventory содержит только project-authored observations, не является
 нормативной спецификацией DipTrace и не заявляет разрешение Novarm или universal
 совместимость с DipTrace 5.3.

--- a/docs/API_ERRORS.md
+++ b/docs/API_ERRORS.md
@@ -26,6 +26,16 @@ Pydantic `ValidationError` or the typed `InvalidArgumentError`. On the wire,
 failures also set MCP's native `isError` flag; `structuredContent` and the text
 content carry the same stable envelope.
 
+The transport contract is tested through an in-memory connected MCP session
+using `session.call_tool`, not only by calling a registered Python function.
+Those tests assert one outer `CallToolResult`, one JSON error envelope, matching
+text and `structuredContent`, and no nested or stringified `CallToolResult`.
+They cover a missing document, schema failures (including missing, wrong-type,
+extra-field, and non-finite numeric inputs), typed domain errors, raw
+`ValueError`, `KeyError`, `AssertionError`, `OSError`, and a representative
+external-adapter failure. No registered public tool is asynchronous at present;
+the async wrapper itself remains covered by the boundary unit tests.
+
 The stable public taxonomy is:
 
 | Code | Meaning | Retryable default |
@@ -46,11 +56,11 @@ safe. Mutations still require the existing transaction and SHA-256 gates.
 
 The registered-tool surface is generated in `src/diptrace_mcp/server.py`; every
 registered callable is wrapped by `error_boundary.wrap_tool_callable`, and the
-argument-validation and tool-run hooks use the same boundary. The contract tests
-exercise typed errors, raw `ValueError`, `KeyError`, `AssertionError`, `OSError`,
-async calls, redaction, transport `isError`, and JSON serializability. The
-project service layer also validates the same high-risk unit and numeric inputs
-before mutation.
+argument-validation and tool-run hooks use the same boundary. A registry
+traversal test proves that all 159 snapshot tools carry all three boundary
+markers; end-to-end tests cover representative groups rather than invoking all
+159 tools with every possible invalid input. The project service layer also
+validates the same high-risk unit and numeric inputs before mutation.
 
 ## Boundary audit matrix
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -36,6 +36,10 @@ The repository provides a stricter two-component control/probe
 [operator capture recipe](evidence_capture/q1-component-angle.recipe.json). It records the literal
 values and UI observations without treating either convention as the expected answer.
 
+The post-merge review keeps this question at `NOT RUN`: no live GUI edit and
+independent DipTrace re-export were available. The rotate tool therefore keeps
+its caveat and structured `component_angle_live_validation_pending` warning.
+
 **Who can perform:** Human with a licensed DipTrace installation. HUMAN ACTION REQUIRED:
 follow
 [`q1-component-angle.HUMAN_ACTION_REQUIRED.md`](evidence_capture/q1-component-angle.HUMAN_ACTION_REQUIRED.md).

--- a/docs/PROBE_PACK.md
+++ b/docs/PROBE_PACK.md
@@ -54,6 +54,10 @@ The repository provides a stricter two-component control/probe
 [operator capture recipe](evidence_capture/q1-component-angle.recipe.json). It records the literal
 values and UI observations without treating either convention as the expected answer.
 
+The post-merge review keeps this question at `NOT RUN`: no live GUI edit and
+independent DipTrace re-export were available. The rotate tool therefore keeps
+its caveat and structured `component_angle_live_validation_pending` warning.
+
 **Operator required:** Human with a licensed DipTrace installation. HUMAN ACTION REQUIRED:
 follow
 [`q1-component-angle.HUMAN_ACTION_REQUIRED.md`](evidence_capture/q1-component-angle.HUMAN_ACTION_REQUIRED.md).

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -2,7 +2,8 @@
 
 ## Snapshot status
 
-Audited repository state: 2026-08-02.
+Audited repository state: 2026-08-03 (main SHA
+`3f06ffc084154f59a116540694f071c513323215`).
 
 **Status: v0.1.2 is a verified development-stage release under an explicit solo-maintainer exception.** The repository has an OSI-approved project-wide license (Apache-2.0, committed as `LICENSE`), open DCO 1.1 contribution intake, private vulnerability reporting published as `SECURITY.md`, an active main-branch ruleset, an unsigned-binary disclosure, a completed 2026-07-31 live acceptance matrix, green exact-head CI, and verified public release assets. It still has no verified conduct channel, signed release artifact, dependency/bundled-content legal review, or independent release reviewer, so it must not be represented as independently reviewed, signed, or production-ready.
 
@@ -44,9 +45,12 @@ Until the remaining redistribution and review items are complete, do not claim e
 - [x] Current GitHub repository authority is documented in
       [GOVERNANCE.md](../GOVERNANCE.md).
 - [x] The default `main` branch has an active ruleset requiring pull requests,
-      conversation resolution, DCO, and the eight technical CI contexts;
-      force-push and deletion are blocked and approvals are `0` for the
-      solo-maintainer mode. Evidence is in
+      conversation resolution, DCO, and nine unique technical CI contexts
+      (eleven API status records); force-push and deletion are blocked and
+      approvals are `0` for the solo-maintainer mode. The API also reports
+      strict up-to-date checks, all three merge methods, and a repository-role
+      pull-request bypass. These are external, owner-changeable settings;
+      evidence is in
       [BRANCH_PROTECTION_STATUS.md](compliance/BRANCH_PROTECTION_STATUS.md).
 - [x] The ruleset was exercised by test PR #41, which was closed without merge;
       its one-file test branch is not present in `main`.

--- a/docs/REVIEW_ENGINE.md
+++ b/docs/REVIEW_ENGINE.md
@@ -36,6 +36,30 @@ clearance still use their DRC/geometry-specific rules and do not apply NetClass
 clearance; their results expose `netclass_rules_ignored: true`. Board-edge
 clearance is a separate geometry rule.
 
+### Trace-to-trace completeness
+
+`pcb.trace_clearance` does not treat a trace with an absent or unresolved
+owning net as compliant. Each candidate pair is counted in
+`candidate_pairs_checked` and then in exactly one of `evaluated_pairs`,
+`skipped_unresolved_net_pairs`, or `skipped_clearance_resolution_pairs`.
+Unresolved pairs produce no violation finding because no safe effective rule was
+calculated, but they set `clearance_review_complete: false`, add a stable
+`warning_codes` value, and appear in report-level `skipped_reasons` with the
+pair segment ids and safe unresolved-net/class details. A missing rule set is
+also a partial result; when possible, all same-layer unlike-net candidates are
+counted before the resolver reports the rule as unavailable. A skipped pair is
+never counted as evaluated or compliant.
+
+Trace-clearance findings publish the compact `rule_source` label plus the
+project-authored `rule_sources` records from the shared resolver. The records
+contain only source kind, layer/net/class identifiers, normalized millimetres,
+and a stable project rule path. `clearance_rule_status.effective_rule_source`
+and the resolution's requested/required/effective values explain whether the
+effective result came from board defaults, NetClass rules, or an explicit
+request. The router and review use the same resolution object and expose the
+same effective source label; this remains an offline structural review, not a
+DipTrace DRC sign-off.
+
 Affected routing, planning, congestion, and review results contain
 `requested_clearance_mm`, `required_clearance_mm`, `effective_clearance_mm`,
 `clearance_sources`, `netclass_rules_applied`, `netclass_rules_ignored`, and
@@ -101,10 +125,14 @@ Tools aggregate registry checks by category: `run_drc`, `run_erc`, `run_board_re
 
 A finding contains ID, check, category, severity, confidence, explanation, object and net
 references, layer, location, bounding box, measured and required values, delta, rule
-source, suggested actions, and suppression state. A report contains metrics, assumptions,
-skipped checks, registry completeness, and a resource URI. `completeness` is only the
-fraction of selected registered checks that did not return a whole-check skip; it does
-not include missing rows from the matrix and is not manufacturing completeness.
+source, structured rule sources, requested/required/effective clearance values where
+applicable, suggested actions, and suppression state. A report contains metrics,
+assumptions, skipped checks, report-level `skipped_reasons`, registry completeness, and
+a resource URI. `completeness` is only the fraction of selected registered checks that
+did not return a whole-check skip; it does not include unresolved pairs or missing rows
+from the matrix and is not manufacturing completeness. Consumers must inspect the
+trace-clearance counters and `clearance_review_complete` before treating the report as
+complete.
 
 ## Heuristic Analyses
 

--- a/docs/ROUTING_ENGINE.md
+++ b/docs/ROUTING_ENGINE.md
@@ -35,11 +35,17 @@ normalized pad coordinates; the grid is not used to move or reinterpret a pad. T
 coupled differential-pair centerline still requires on-grid center anchors because
 arbitrary uncoupled pair escapes are not implemented.
 
-Route `clearance` is an explicit override. When omitted, the router reads
-`DRC/LayClearances/LayClearance/@TraceToTrace` for every requested routing layer and
-uses the maximum applicable value. If any requested layer lacks that rule, routing
-fails with `capability_unavailable`; it does not fall back to the former hardcoded
-`0.2 mm` value or silently use zero.
+Route `clearance` is an explicit requested value, not a lowering override. The
+shared resolver reads `DRC/LayClearances/LayClearance/@TraceToTrace` for every
+requested routing layer and the applicable
+`NetClasses/NetClass/LayProperties/LayProperty/@Clearance` for every affected
+net. It applies `effective = max(board defaults, affected NetClass rules,
+explicit request)`, and publishes the requested, required, effective, source
+records, and `clearance_rule_status` in route metrics. If any requested layer
+lacks both a board rule and an applicable NetClass rule while no explicit value
+was supplied, routing fails with `capability_unavailable`; it does not fall back
+to the former hardcoded `0.2 mm` value or silently use zero. Unknown NetClass
+references fail closed rather than being guessed.
 
 Legacy `layer="Top", max_vias=0` preserves single-layer behavior. Multi-layer routing is
 enabled only with explicit `preferred_layers`, `via_style`, and `max_vias>0`; an unknown

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,6 +20,21 @@ python benchmarks/benchmark_core.py --repeat 5 --patch-count 1000
 python -m benchmarks.benchmark_large_board --components 500
 ```
 
+The MCP error boundary has a separate protocol-level contract suite. It uses
+`create_connected_server_and_client_session` and `session.call_tool` to verify
+schema, typed-domain, external, unexpected, and typed-result failures. It also
+asserts one outer `CallToolResult`, matching text/structured envelopes, safe
+details, and registry coverage for all 159 registered tools:
+
+```bash
+pytest -q tests/test_mcp_error_contracts.py
+```
+
+The declared development constraint remains `pytest>=8.4,<9`. Pytest 9 is
+checked only in a separate clean environment against the same project and MCP
+SDK versions; a successful probe does not by itself change the supported CI
+matrix or dependency constraint.
+
 ## Deep compliance and clean-room audit
 
 The following commands are manual or release-audit checks, not replacements

--- a/docs/compliance/BRANCH_PROTECTION_STATUS.md
+++ b/docs/compliance/BRANCH_PROTECTION_STATUS.md
@@ -1,10 +1,10 @@
 # Main branch protection status
 
-Checked: 2026-08-02
+Checked: 2026-08-03
 
 The checked default branch was `main` at
-`f4ea60352a560d03f0cee45d500c186530e6f5f6` (the ordinary merge commit for PR
-#40). The active ruleset is named **Protect main** and targets the default
+`3f06ffc084154f59a116540694f071c513323215` (the merge commit for PR #43). The
+active ruleset is named **Protect main** (id `20233687`) and targets the default
 branch through GitHub's `~DEFAULT_BRANCH` ref condition.
 
 ## Rules observed through GitHub API
@@ -15,30 +15,29 @@ branch through GitHub's `~DEFAULT_BRANCH` ref condition.
 - required conversation/thread resolution is enabled;
 - code-owner, last-push approval, and required reviewer rules are not enabled;
 - deletion and non-fast-forward updates are blocked;
-- nine unique required status contexts are present:
+- GitHub returned eleven required-status records, representing nine unique
+  contexts:
   `DCO`, `static-analysis`, `test-linux (3.10)`, `test-linux (3.13)`,
   `test-linux geometry + coverage (3.12)`,
   `test-linux no-Shapely fallback (3.12)`, `test-macos`, `test-windows`, and
   `build-windows-bridge`;
-- GitHub returned duplicate entries for `test-linux (3.10)` and
-  `build-windows-bridge` with and without an integration identifier; they are
-  recorded as one context each above and were not changed automatically;
+- duplicate records for `test-linux (3.10)` and `build-windows-bridge` differ
+  only by the GitHub Actions integration identifier; they are recorded as one
+  unique context each above and were not changed automatically;
 - the API reports `strict_required_status_checks_policy: true`, so branches
-  must be up to date before merging. This differs from the earlier intended
-  setting and requires an owner decision if that policy is not wanted;
+  must be up to date before merging;
 - the API reports all three merge methods (`merge`, `squash`, and `rebase`)
-  as allowed. This differs from the earlier ordinary-merge-only expectation
-  and requires an owner decision if ordinary merge is the intended policy;
-- no bypass actor was exposed in the unauthenticated ruleset response. This
-  record therefore does not claim that bypass is impossible or that the
-  administrator cannot change the ruleset.
+  as allowed;
+- a repository-role bypass actor with id `5` is present for pull requests, and
+  the authenticated audit identity reports `current_user_can_bypass:
+  pull_requests_only`. This is an observed GitHub setting, not an assertion
+  about the human identity behind that role or about immutable administration.
 
-The ruleset was queried with the repository ruleset REST endpoints and checked
-against the public PR #41 test record. PR #41 (`test: verify branch protection`)
-was closed without merge, had one changed file (`branch-protection-test.txt`),
-and its remote head branch was absent at the audit check. The file is absent
-from `main`. No status contexts were returned for the short-lived test head,
-so this document does not claim that a complete CI run was recorded for PR #41.
+The ruleset was queried read-only with the repository ruleset REST endpoints on
+2026-08-03. Classic branch-protection lookup returned no protected-branch
+record; the active ruleset is the observed enforcement mechanism. This audit
+does not change the ruleset, infer owner intent, or claim that the settings
+cannot be changed externally.
 
 Settings link: [GitHub branch rules](https://github.com/fireostendere/mcp_diptrace/settings/rules).
 

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -262,6 +262,7 @@ tests/test_large_synthetic_board.py
 tests/test_libraries.py
 tests/test_live_apply_binding.py
 tests/test_live_session_lifecycle.py
+tests/test_mcp_error_contracts.py
 tests/test_mcp_tool_chain.py
 tests/test_mcp_tools_snapshot.py
 tests/test_model_cache.py

--- a/src/diptrace_mcp/clearance.py
+++ b/src/diptrace_mcp/clearance.py
@@ -9,6 +9,7 @@ document so malformed numeric values retain the existing byte-location errors.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -41,6 +42,69 @@ class ClearanceResolution:
             "netclass_rules_ignored": self.netclass_rules_ignored,
             "clearance_rule_status": dict(self.clearance_rule_status),
         }
+
+
+def clearance_source_label(
+    sources: Iterable[dict[str, Any]],
+    *,
+    required_clearance_mm: float | None = None,
+    effective_clearance_mm: float | None = None,
+    requested_clearance_mm: float | None = None,
+) -> str:
+    """Return a stable summary of the rule kinds represented by ``sources``.
+
+    The source records themselves remain the authoritative explanation.  This
+    label is only a compact finding/report discriminator and never contains XML
+    objects or source text.
+    """
+
+    source_list = [dict(item) for item in sources]
+    kinds = {str(item.get("kind", "")) for item in source_list}
+    if (
+        required_clearance_mm is not None
+        and effective_clearance_mm is not None
+        and requested_clearance_mm is not None
+    ):
+        board_values = [
+            float(item["value_mm"])
+            for item in source_list
+            if item.get("kind") == "board_default"
+        ]
+        netclass_values = [
+            float(item["value_mm"])
+            for item in source_list
+            if item.get("kind") == "netclass"
+        ]
+        board_max = max(board_values, default=0.0)
+        netclass_max = max(netclass_values, default=0.0)
+        # A requested value is part of the effective rule explanation only
+        # when it raises the mandatory document rules.  A NetClass is part of
+        # that compact label when it raises the board default (or is the only
+        # document rule); all detailed source records remain in the result.
+        kinds = set()
+        if board_values:
+            kinds.add("board_default")
+        if netclass_values and (
+            not board_values or netclass_max > board_max + 1e-12
+        ):
+            kinds.add("netclass")
+        if requested_clearance_mm > required_clearance_mm + 1e-12 or not (
+            board_values or netclass_values
+        ):
+            kinds.add("explicit_requested")
+    labels = {
+        "netclass": "netclass",
+        "board_default": "board",
+        "explicit_requested": "explicit",
+    }
+    ordered = [
+        labels[kind]
+        for kind in ("netclass", "board_default", "explicit_requested")
+        if kind in kinds
+    ]
+    if ordered == ["board"]:
+        return "board_default"
+    return "_and_".join(ordered) if ordered else "unresolved"
 
 
 def _layer_name_map(snapshot: DocumentSnapshot) -> dict[str, str]:
@@ -264,6 +328,12 @@ def resolve_clearance(
         ),
         "warning_code": None,
         "clearance_source": source_label,
+        "effective_rule_source": clearance_source_label(
+            sources,
+            required_clearance_mm=required,
+            effective_clearance_mm=effective,
+            requested_clearance_mm=requested,
+        ),
         "unknown_class_references": [],
     }
     return ClearanceResolution(

--- a/src/diptrace_mcp/error_boundary.py
+++ b/src/diptrace_mcp/error_boundary.py
@@ -232,7 +232,7 @@ def invoke_with_error_boundary(
     try:
         return function(*args, **kwargs)
     except Exception as exc:
-        if not isinstance(exc, (DipTraceMcpError, ValueError, ValidationError)):
+        if not isinstance(exc, (DipTraceMcpError, ValidationError)):
             logger.exception("Unexpected failure in MCP tool %s", tool_name)
         result = exception_to_error_result(exc)
         return error_result_to_mcp_result(result) if mcp_result else result
@@ -253,12 +253,14 @@ def wrap_tool_callable(
             try:
                 return await cast(Awaitable[Any], function(*args, **kwargs))
             except Exception as exc:
-                if not isinstance(exc, (DipTraceMcpError, ValueError, ValidationError)):
+                if not isinstance(exc, (DipTraceMcpError, ValidationError)):
                     logger.exception("Unexpected failure in MCP tool %s", tool_name)
                 result = exception_to_error_result(exc)
                 return error_result_to_mcp_result(result) if mcp_result else result
 
-        return cast(_F, async_wrapper)
+        wrapped = cast(_F, async_wrapper)
+        cast(Any, wrapped).__diptrace_mcp_error_boundary__ = True
+        return wrapped
 
     @wraps(function)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -270,4 +272,6 @@ def wrap_tool_callable(
             **kwargs,
         )
 
-    return cast(_F, wrapper)
+    wrapped = cast(_F, wrapper)
+    cast(Any, wrapped).__diptrace_mcp_error_boundary__ = True
+    return wrapped

--- a/src/diptrace_mcp/findings.py
+++ b/src/diptrace_mcp/findings.py
@@ -48,6 +48,11 @@ class Finding(StrictModel):
     delta: float | None = None
     units: str | None = None
     rule_source: str | None = None
+    rule_sources: list[dict[str, Any]] = Field(default_factory=list)
+    clearance_rule_status: dict[str, Any] | None = None
+    required_clearance_mm: float | None = None
+    requested_clearance_mm: float | None = None
+    effective_clearance_mm: float | None = None
     pour_geometry: Literal["boundary_only"] | None = None
     geometry_accuracy: Literal["exact", "approximate"] | None = None
     suggested_actions: list[str] = Field(default_factory=list)
@@ -65,6 +70,7 @@ class ReviewReport(StrictModel):
     metrics: dict[str, Any] = Field(default_factory=dict)
     assumptions: list[str] = Field(default_factory=list)
     skipped_checks: list[dict[str, str]] = Field(default_factory=list)
+    skipped_reasons: list[dict[str, Any]] = Field(default_factory=list)
     completeness: float = Field(ge=0.0, le=1.0)
 
     def summary(self) -> dict[str, Any]:
@@ -79,6 +85,7 @@ class ReviewReport(StrictModel):
             "by_severity": counts,
             "completeness": self.completeness,
             "skipped_check_count": len(self.skipped_checks),
+            "skipped_reason_count": len(self.skipped_reasons),
         }
 
 
@@ -104,6 +111,11 @@ def make_finding(
     required: float | None = None,
     units: str | None = None,
     rule_source: str | None = None,
+    rule_sources: list[dict[str, Any]] | None = None,
+    clearance_rule_status: dict[str, Any] | None = None,
+    required_clearance_mm: float | None = None,
+    requested_clearance_mm: float | None = None,
+    effective_clearance_mm: float | None = None,
     pour_geometry: Literal["boundary_only"] | None = None,
     geometry_accuracy: Literal["exact", "approximate"] | None = None,
     suggested_actions: list[str] | None = None,
@@ -131,6 +143,13 @@ def make_finding(
         delta=delta,
         units=units,
         rule_source=rule_source,
+        rule_sources=[dict(item) for item in (rule_sources or [])],
+        clearance_rule_status=(
+            dict(clearance_rule_status) if clearance_rule_status is not None else None
+        ),
+        required_clearance_mm=required_clearance_mm,
+        requested_clearance_mm=requested_clearance_mm,
+        effective_clearance_mm=effective_clearance_mm,
         pour_geometry=pour_geometry,
         geometry_accuracy=geometry_accuracy,
         suggested_actions=list(suggested_actions or []),
@@ -264,6 +283,18 @@ class FindingStore(RecordStore):
         report_id = deterministic_id("report", document_id, source_sha256, profile)
         completed = max(0, registered_check_count - len(skipped_checks))
         completeness = completed / registered_check_count if registered_check_count else 1.0
+        skipped_reasons: list[dict[str, Any]] = []
+        for check_id, check_metrics in metrics.items():
+            if not isinstance(check_metrics, dict):
+                continue
+            reasons = check_metrics.get("skipped_pair_reasons", [])
+            if not isinstance(reasons, list):
+                continue
+            for reason in reasons:
+                if isinstance(reason, dict):
+                    skipped_reasons.append(
+                        {"check_id": str(check_id), "reason": dict(reason)}
+                    )
         report = ReviewReport(
             report_id=report_id,
             document_id=document_id,
@@ -277,6 +308,7 @@ class FindingStore(RecordStore):
             metrics=metrics,
             assumptions=assumptions,
             skipped_checks=skipped_checks,
+            skipped_reasons=skipped_reasons,
             completeness=completeness,
         )
         self.store(report)

--- a/src/diptrace_mcp/review.py
+++ b/src/diptrace_mcp/review.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from .adapters import DocumentSnapshot
 from .advanced_review import register_advanced_checks
-from .clearance import clearance_rule_status, resolve_clearance
+from .clearance import clearance_rule_status, clearance_source_label, resolve_clearance
 from .domain import ObjectRecord
 from .errors import CapabilityUnavailableError, NetClassResolutionError
 from .findings import Finding, make_finding
@@ -214,13 +214,8 @@ def check_trace_clearance(snapshot: DocumentSnapshot) -> tuple[list[Finding], di
         for item in net_class.findall("./LayProperties/LayProperty")
         if item.get("Clearance") is not None
     ]
-    if not clearance_by_layer and not netclass_clearances:
-        return [], {
-            "skipped": "trace_clearance_rules_unavailable",
-            "clearance_rule_status": clearance_rule_status(
-                snapshot, operation="offline_clearance_review"
-            ),
-        }
+    base_status = clearance_rule_status(snapshot, operation="offline_clearance_review")
+    rules_available = bool(clearance_by_layer or netclass_clearances)
     maximum_clearance = max([*clearance_by_layer.values(), *netclass_clearances], default=0.0)
     segment_records: list[ObjectRecord] = []
     segment_geometry: dict[str, tuple[Point, Point, float, str, str]] = {}
@@ -250,30 +245,78 @@ def check_trace_clearance(snapshot: DocumentSnapshot) -> tuple[list[Finding], di
     index = SpatialIndex.build(segment_records, cell_size_mm=5.0)
     findings: list[Finding] = []
     seen: set[tuple[str, str]] = set()
-    skipped_netclass_pairs = 0
+    net_by_id = {
+        item.xml_id: item
+        for item in snapshot.board.nets
+        if item.xml_id is not None
+    }
+    candidate_pairs_checked = 0
+    evaluated_pairs = 0
+    skipped_unresolved_net_pairs = 0
+    skipped_clearance_resolution_pairs = 0
+    skipped_pair_reasons: list[dict[str, Any]] = []
+    warning_codes: set[str] = set()
+    if not rules_available:
+        warning_codes.add("trace_clearance_rules_unavailable")
+        skipped_pair_reasons.append(
+            {
+                "reason_code": "trace_clearance_rules_unavailable",
+                "scope": "check",
+            }
+        )
     for segment in segment_records:
         assert segment.bbox is not None
-        for other in index.query(BBox(**segment.bbox), layers={segment.layer or ""}):
-            if segment.stable_id == other.stable_id or segment.net_id == other.net_id:
+        candidates = (
+            index.query(BBox(**segment.bbox), layers={segment.layer or ""})
+            if rules_available
+            else (
+                item
+                for item in segment_records
+                if item.layer == segment.layer
+            )
+        )
+        for other in candidates:
+            if segment.stable_id == other.stable_id:
+                continue
+            if (
+                segment.net_id is not None
+                and other.net_id is not None
+                and segment.net_id == other.net_id
+                and segment.net_id in net_by_id
+            ):
                 continue
             first, second = sorted((segment.stable_id, other.stable_id))
             pair = (first, second)
             if pair in seen:
                 continue
             seen.add(pair)
+            candidate_pairs_checked += 1
             a1, a2, width_a, trace_a, layer = segment_geometry[segment.stable_id]
             b1, b2, width_b, trace_b, _ = segment_geometry[other.stable_id]
-            net_a = next(
-                (item for item in snapshot.board.nets if item.xml_id == segment.net_id),
-                None,
-            )
-            net_b = next(
-                (item for item in snapshot.board.nets if item.xml_id == other.net_id),
-                None,
-            )
+            net_a = net_by_id.get(segment.net_id or "")
+            net_b = net_by_id.get(other.net_id or "")
             if net_a is None or net_b is None:
-                # A trace without a resolvable owning net is not safe to
-                # evaluate as a class-aware result.
+                unresolved_sides = [
+                    {
+                        "side": side,
+                        "segment_id": item.stable_id,
+                        "net_id": item.net_id,
+                    }
+                    for side, item, net in (
+                        ("a", segment, net_a),
+                        ("b", other, net_b),
+                    )
+                    if net is None
+                ]
+                skipped_unresolved_net_pairs += 1
+                warning_codes.add("trace_net_unresolved")
+                skipped_pair_reasons.append(
+                    {
+                        "reason_code": "trace_net_unresolved",
+                        "pair_segment_ids": [first, second],
+                        "unresolved_sides": unresolved_sides,
+                    }
+                )
                 continue
             try:
                 resolution = resolve_clearance(
@@ -282,16 +325,51 @@ def check_trace_clearance(snapshot: DocumentSnapshot) -> tuple[list[Finding], di
                     None,
                     nets=[net_a, net_b],
                 )
-            except (CapabilityUnavailableError, NetClassResolutionError):
-                # The report-level disclosure remains visible; this pair is
-                # deliberately not treated as compliant or non-compliant.
-                skipped_netclass_pairs += 1
+            except NetClassResolutionError as exc:
+                skipped_clearance_resolution_pairs += 1
+                warning_codes.add("trace_netclass_unresolved")
+                skipped_pair_reasons.append(
+                    {
+                        "reason_code": "trace_netclass_unresolved",
+                        "pair_segment_ids": [first, second],
+                        "details": {
+                            "net_ids": [
+                                value for value in (segment.net_id, other.net_id) if value
+                            ],
+                            "unresolved_class_reference": str(
+                                exc.details.get("unresolved_class_reference", "unknown")
+                            ),
+                        },
+                    }
+                )
+                continue
+            except CapabilityUnavailableError:
+                skipped_clearance_resolution_pairs += 1
+                unavailable_code = (
+                    "trace_clearance_rules_unavailable"
+                    if not rules_available
+                    else "trace_clearance_resolution_unavailable"
+                )
+                warning_codes.add(unavailable_code)
+                skipped_pair_reasons.append(
+                    {
+                        "reason_code": unavailable_code,
+                        "pair_segment_ids": [first, second],
+                        "details": {
+                            "layer_id": layer,
+                            "net_ids": [
+                                value for value in (segment.net_id, other.net_id) if value
+                            ],
+                        },
+                    }
+                )
                 continue
             required = resolution.effective_clearance_mm
             measured = max(
                 0.0,
                 segment_distance(a1, a2, b1, b2) - (width_a + width_b) / 2.0,
             )
+            evaluated_pairs += 1
             if measured + 1e-9 < required:
                 findings.append(
                     make_finding(
@@ -307,20 +385,59 @@ def check_trace_clearance(snapshot: DocumentSnapshot) -> tuple[list[Finding], di
                         measured=measured,
                         required=required,
                         units="mm",
-                        rule_source="DRC/LayClearances/LayClearance.TraceToTrace",
+                        rule_source=clearance_source_label(
+                            resolution.clearance_sources,
+                            required_clearance_mm=resolution.required_clearance_mm,
+                            effective_clearance_mm=resolution.effective_clearance_mm,
+                            requested_clearance_mm=resolution.requested_clearance_mm,
+                        ),
+                        rule_sources=list(resolution.clearance_sources),
+                        clearance_rule_status=dict(resolution.clearance_rule_status),
+                        required_clearance_mm=resolution.required_clearance_mm,
+                        requested_clearance_mm=resolution.requested_clearance_mm,
+                        effective_clearance_mm=resolution.effective_clearance_mm,
                         suggested_actions=[
                             "Reroute one segment or change the applicable rule explicitly."
                         ],
                     )
                 )
-    return findings, {
-        "segments_checked": len(segment_records),
-        "candidate_pairs_checked": len(seen),
-        "skipped_netclass_pairs": skipped_netclass_pairs,
-        "clearance_rule_status": clearance_rule_status(
-            snapshot, operation="offline_clearance_review"
-        ),
+    partial = bool(
+        not rules_available
+        or skipped_unresolved_net_pairs
+        or skipped_clearance_resolution_pairs
+    )
+    final_status = {
+        **base_status,
+        "clearance_review_complete": not partial,
     }
+    if partial:
+        final_status.update(
+            {
+                "netclass_rules_ignored": True,
+                "partial_review": True,
+                "warning_code": sorted(warning_codes)[0],
+                "warning_codes": sorted(warning_codes),
+            }
+        )
+    metrics = {
+        "segments_checked": len(segment_records),
+        "candidate_pairs_checked": candidate_pairs_checked,
+        "evaluated_pairs": evaluated_pairs,
+        "skipped_unresolved_net_pairs": skipped_unresolved_net_pairs,
+        "skipped_clearance_resolution_pairs": skipped_clearance_resolution_pairs,
+        "skipped_netclass_pairs": skipped_clearance_resolution_pairs,
+        "skipped_pair_reasons": skipped_pair_reasons,
+        "warning_codes": sorted(warning_codes),
+        "clearance_review_complete": not partial,
+        "clearance_rule_status": final_status,
+    }
+    if partial:
+        metrics["partial_skipped"] = (
+            "trace_clearance_rules_unavailable"
+            if not rules_available and candidate_pairs_checked == 0
+            else "trace_clearance_partial"
+        )
+    return findings, metrics
 
 
 @registry.register("pcb.trace_object_clearance", "clearance", "pcb")
@@ -574,6 +691,7 @@ def run_checks(
             snapshot, operation="offline_clearance_review"
         ),
         "netclass_rules_ignored": False,
+        "clearance_review_complete": True,
     }
     skipped: list[dict[str, str]] = []
     for check in checks:
@@ -590,6 +708,8 @@ def run_checks(
                 )
         metrics[check.check_id] = check_metrics
         check_status = check_metrics.get("clearance_rule_status")
+        if check_metrics.get("clearance_review_complete") is False:
+            metrics["clearance_review_complete"] = False
         if isinstance(check_status, dict) and check_status.get(
             "netclass_rules_ignored", False
         ):
@@ -597,8 +717,12 @@ def run_checks(
             metrics["clearance_rule_status"] = {
                 **metrics["clearance_rule_status"],
                 "netclass_rules_ignored": True,
+                "clearance_review_complete": metrics["clearance_review_complete"],
                 "warning_code": check_status.get(
                     "warning_code", "netclass_rules_ignored"
+                ),
+                "warning_codes": check_status.get(
+                    "warning_codes", [check_status.get("warning_code", "netclass_rules_ignored")]
                 ),
             }
     return findings, metrics, skipped, len(checks)

--- a/src/diptrace_mcp/routing.py
+++ b/src/diptrace_mcp/routing.py
@@ -434,6 +434,9 @@ def synthesize_route(
             "detour": detour,
             "clearance_mm": clearance,
             "clearance_source": clearance_source,
+            "effective_rule_source": clearance_resolution.clearance_rule_status[
+                "effective_rule_source"
+            ],
             **clearance_resolution.as_dict(),
             "elapsed_ms": (time.monotonic() - started) * 1_000.0,
             "obstacle_count": sum(len(items) for items in obstacles.values()),
@@ -718,6 +721,9 @@ def synthesize_differential_pair_route(
             "center_spacing_mm": spacing,
             "clearance_mm": clearance,
             "clearance_source": clearance_source,
+            "effective_rule_source": clearance_resolution.clearance_rule_status[
+                "effective_rule_source"
+            ],
             **clearance_resolution.as_dict(),
             "via_count_per_net": via_count,
             "symmetric_via_count": via_count * 2,

--- a/src/diptrace_mcp/server.py
+++ b/src/diptrace_mcp/server.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
+from mcp import types
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -15,7 +17,7 @@ from .error_boundary import (
     exception_to_error_result,
     wrap_tool_callable,
 )
-from .errors import ObjectNotFoundError
+from .errors import DipTraceMcpError, InternalStateError, ObjectNotFoundError
 from .operations import (
     AddTestpointOperation,
     PinEndpoint,
@@ -36,6 +38,8 @@ from .scaffolding import (
 from .service import DipTraceService
 from .synchronization import ComponentSyncMapping, SyncPlacement
 from .xml_document import XmlEdit
+
+logger = logging.getLogger(__name__)
 
 
 class XmlEditInput(BaseModel):
@@ -382,19 +386,38 @@ def _finalize_tool_descriptions(mcp: FastMCP) -> None:
             "call_fn_with_arg_validation",
             validate_with_boundary,
         )
+        cast(Any, validate_with_boundary).__diptrace_mcp_validation_boundary__ = True
 
         original_run = tool.run
 
         async def run_with_boundary(
             *args: Any,
             _original_run: Any = original_run,
+            _metadata: Any = tool.fn_metadata,
             **kwargs: Any,
         ) -> Any:
             try:
-                return await _original_run(*args, **kwargs)
+                # FastMCP's output conversion validates typed return models.  An
+                # error CallToolResult cannot satisfy a successful tool's output
+                # schema, so stop conversion at this boundary and pass transport
+                # errors through exactly once. Successful values are converted by
+                # the same SDK metadata after this check.
+                kwargs["convert_result"] = False
+                raw_result = await _original_run(*args, **kwargs)
+                if isinstance(raw_result, types.CallToolResult):
+                    return raw_result
+                return _metadata.convert_result(raw_result)
             except Exception as exc:
+                if not isinstance(exc, (DipTraceMcpError, ValidationError)):
+                    logger.exception("Unexpected MCP tool boundary failure")
+                if isinstance(exc, ValidationError):
+                    exc = InternalStateError(
+                        "MCP tool output conversion failed",
+                        cause=exc,
+                    )
                 return error_result_to_mcp_result(exception_to_error_result(exc))
 
+        cast(Any, run_with_boundary).__diptrace_mcp_run_boundary__ = True
         object.__setattr__(tool, "run", run_with_boundary)
 
 

--- a/src/diptrace_mcp/service.py
+++ b/src/diptrace_mcp/service.py
@@ -7381,16 +7381,23 @@ class DipTraceService:
                 "findings": [finding.model_dump() for finding in report.findings],
                 "metrics": report.metrics,
                 "clearance_rule_status": report.metrics.get("clearance_rule_status"),
+                "clearance_review_complete": report.metrics.get(
+                    "clearance_review_complete", True
+                ),
                 "netclass_rules_ignored": report.metrics.get(
                     "netclass_rules_ignored", False
                 ),
                 "assumptions": report.assumptions,
                 "skipped_checks": report.skipped_checks,
+                "skipped_reasons": report.skipped_reasons,
             },
             resources=resources,
         )
         response["clearance_rule_status"] = report.metrics.get(
             "clearance_rule_status"
+        )
+        response["clearance_review_complete"] = report.metrics.get(
+            "clearance_review_complete", True
         )
         response["netclass_rules_ignored"] = report.metrics.get(
             "netclass_rules_ignored", False

--- a/tests/test_clearance_resolution.py
+++ b/tests/test_clearance_resolution.py
@@ -46,6 +46,9 @@ def test_one_netclass_rule_is_required_and_explicit_cannot_lower_it() -> None:
     assert resolution.netclass_rules_applied is True
     assert resolution.netclass_rules_ignored is False
     assert resolution.clearance_rule_status["clearance_source"] == "netclass_promoted"
+    assert resolution.clearance_rule_status["effective_rule_source"] == (
+        "netclass_and_board"
+    )
 
 
 def test_two_nets_from_different_classes_use_the_maximum_rule() -> None:
@@ -94,6 +97,24 @@ def test_explicit_larger_than_required_wins_and_resolution_is_deterministic() ->
     assert first.required_clearance_mm == pytest.approx(0.2)
     assert first.effective_clearance_mm == pytest.approx(0.9)
     assert first.clearance_rule_status["clearance_source"] == "caller"
+    assert first.clearance_rule_status["effective_rule_source"] == "board_and_explicit"
+
+
+def test_netclass_only_rule_source_is_explicit() -> None:
+    def netclass_only(root: ET.Element) -> None:
+        for item in root.findall("./Board/DRC/LayClearances/LayClearance"):
+            item.attrib.pop("TraceToTrace", None)
+        property_element = root.find(
+            "./Board/NetClasses/NetClass/LayProperties/LayProperty"
+        )
+        assert property_element is not None
+        property_element.set("Clearance", "0.45")
+
+    snapshot = build_snapshot(_document(netclass_only))
+    resolution = resolve_clearance(snapshot, ["0"], None, nets=[_net(snapshot, "VCC")])
+
+    assert resolution.required_clearance_mm == pytest.approx(0.45)
+    assert resolution.clearance_rule_status["effective_rule_source"] == "netclass"
 
 
 def test_unassigned_net_uses_board_default_and_missing_rule_fails_closed() -> None:
@@ -106,6 +127,9 @@ def test_unassigned_net_uses_board_default_and_missing_rule_fails_closed() -> No
     assert resolve_clearance(
         snapshot, ["0"], None, nets=[_net(snapshot, "VCC")]
     ).effective_clearance_mm == pytest.approx(0.2)
+    assert resolve_clearance(
+        snapshot, ["0"], None, nets=[_net(snapshot, "VCC")]
+    ).clearance_rule_status["effective_rule_source"] == "board_default"
 
     def no_rules(root: ET.Element) -> None:
         root.find("./Board/DRC/LayClearances/LayClearance").attrib.pop("TraceToTrace")

--- a/tests/test_mcp_error_contracts.py
+++ b/tests/test_mcp_error_contracts.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import math
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import CallToolResult
+
+from diptrace_mcp.config import Settings
+from diptrace_mcp.server import create_server
+from diptrace_mcp.service import DipTraceService
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _settings(state_dir: Path) -> Settings:
+    return Settings(
+        workspace=FIXTURES,
+        allowed_roots=(FIXTURES,),
+        state_dir=state_dir,
+    )
+
+
+def _assert_wire_error(
+    result: CallToolResult,
+    expected_code: str,
+    *,
+    state_dir: Path,
+) -> None:
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert isinstance(result.structuredContent, dict)
+    assert result.structuredContent["ok"] is False
+    assert result.structuredContent["error"]["code"] == expected_code
+
+    text_items = [item for item in result.content if getattr(item, "type", None) == "text"]
+    assert len(text_items) == 1
+    decoded = json.loads(text_items[0].text)
+    assert decoded == result.structuredContent
+
+    serialized = json.dumps(result.model_dump(mode="json"), sort_keys=True)
+    assert "CallToolResult" not in serialized
+    assert "Traceback" not in serialized
+    assert str(state_dir) not in serialized
+    assert "/home/" not in serialized
+    assert "INTERNAL_SECRET_VALUE" not in serialized
+
+
+async def _call(
+    state_dir: Path,
+    name: str,
+    arguments: dict[str, Any],
+) -> CallToolResult:
+    server = create_server(_settings(state_dir))
+    async with create_connected_server_and_client_session(
+        server,
+        read_timeout_seconds=timedelta(seconds=10),
+    ) as session:
+        result = await session.call_tool(name, arguments)
+    assert isinstance(result, CallToolResult)
+    return result
+
+
+def test_missing_document_is_bounded_through_connected_mcp_session(tmp_path: Path) -> None:
+    async def verify() -> None:
+        result = await _call(
+            tmp_path / "missing-document-state",
+            "get_document_info",
+            {"path": "missing.xml"},
+        )
+        _assert_wire_error(
+            result,
+            "OBJECT_NOT_FOUND",
+            state_dir=tmp_path / "missing-document-state",
+        )
+
+    asyncio.run(verify())
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments"),
+    [
+        ("validate_impedance_constraints", {}),
+        (
+            "get_board_model",
+            {"path": "pcb.xml", "section": "traces", "limit": "bad"},
+        ),
+        (
+            "validate_impedance_constraints",
+            {
+                "constraints": [
+                    {
+                        "net": "N",
+                        "layer": "0",
+                        "target_ohm": math.nan,
+                    }
+                ]
+            },
+        ),
+        (
+            "validate_roundtrip_evidence",
+            {
+                "path": "pcb.xml",
+                "evidence": {
+                    "source": {
+                        "path": "source.xml",
+                        "sha256": "0" * 64,
+                        "extra": "forbidden",
+                    },
+                    "saved": {"path": "saved.xml", "sha256": "1" * 64},
+                },
+            },
+        ),
+    ],
+)
+def test_schema_failures_are_invalid_argument_through_connected_session(
+    name: str,
+    arguments: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    async def verify() -> None:
+        result = await _call(tmp_path / "schema-state", name, arguments)
+        _assert_wire_error(result, "INVALID_ARGUMENT", state_dir=tmp_path / "schema-state")
+
+    asyncio.run(verify())
+
+
+def test_typed_domain_value_error_and_oserror_are_bounded_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def verify() -> None:
+        typed = await _call(
+            tmp_path / "typed-state",
+            "get_document_info",
+            {"path": "missing.xml"},
+        )
+        _assert_wire_error(typed, "OBJECT_NOT_FOUND", state_dir=tmp_path / "typed-state")
+
+        def raise_value_error(self: DipTraceService, path: str | None = None) -> dict[str, Any]:
+            raise ValueError("INTERNAL_SECRET_VALUE")
+
+        monkeypatch.setattr(DipTraceService, "document_info", raise_value_error)
+        value_error = await _call(
+            tmp_path / "value-state",
+            "get_document_info",
+            {"path": "pcb.xml"},
+        )
+        _assert_wire_error(value_error, "INTERNAL_ERROR", state_dir=tmp_path / "value-state")
+
+        def raise_os_error(self: DipTraceService, path: str | None = None) -> dict[str, Any]:
+            raise OSError("/home/devil/SECRET_PATH")
+
+        monkeypatch.setattr(DipTraceService, "document_info", raise_os_error)
+        os_error = await _call(
+            tmp_path / "os-state",
+            "get_document_info",
+            {"path": "pcb.xml"},
+        )
+        _assert_wire_error(os_error, "EXTERNAL_TOOL_ERROR", state_dir=tmp_path / "os-state")
+
+        for exception, state_name in (
+            (KeyError("INTERNAL_SECRET_KEY"), "key-state"),
+            (AssertionError("INTERNAL_SECRET_ASSERTION"), "assert-state"),
+        ):
+            def raise_unexpected(
+                self: DipTraceService,
+                path: str | None = None,
+                *,
+                _exception: BaseException = exception,
+            ) -> dict[str, Any]:
+                raise _exception
+
+            monkeypatch.setattr(DipTraceService, "document_info", raise_unexpected)
+            result = await _call(
+                tmp_path / state_name,
+                "get_document_info",
+                {"path": "pcb.xml"},
+            )
+            _assert_wire_error(
+                result,
+                "INTERNAL_ERROR",
+                state_dir=tmp_path / state_name,
+            )
+
+    asyncio.run(verify())
+
+
+def test_successful_tool_result_is_not_nested_by_boundary(tmp_path: Path) -> None:
+    async def verify() -> None:
+        fixture_root = FIXTURES.resolve()
+        server = create_server(
+            Settings(
+                workspace=fixture_root,
+                allowed_roots=(fixture_root,),
+                state_dir=tmp_path / "success-state",
+            )
+        )
+        async with create_connected_server_and_client_session(
+            server,
+            read_timeout_seconds=timedelta(seconds=10),
+        ) as session:
+            result = await session.call_tool(
+                "get_document_info",
+                {"path": "pcb.xml"},
+            )
+        assert isinstance(result, CallToolResult)
+        assert result.isError is False
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent["ok"] is True
+        assert not any(
+            "CallToolResult" in str(item)
+            for item in result.structuredContent.values()
+        )
+
+    asyncio.run(verify())
+
+
+@pytest.mark.parametrize(
+    ("group", "name", "arguments", "expected_code"),
+    [
+        ("document lookup", "get_document_info", {"path": "missing.xml"}, "OBJECT_NOT_FOUND"),
+        (
+            "units/numeric",
+            "validate_impedance_constraints",
+            {"constraints": [{"net": "N", "layer": "0", "target_ohm": 0}]},
+            "INVALID_ARGUMENT",
+        ),
+        (
+            "transactions",
+            "commit_transaction",
+            {"txid": "transaction_" + "0" * 16},
+            "OBJECT_NOT_FOUND",
+        ),
+        (
+            "routing",
+            "route_connection",
+            {
+                "net": "VCC",
+                "start_object_id": "missing-start",
+                "end_object_id": "missing-end",
+                "layer": "0",
+                "width": 0.2,
+                "path": "missing.xml",
+            },
+            "OBJECT_NOT_FOUND",
+        ),
+        ("review", "run_board_review", {"path": "missing.xml"}, "OBJECT_NOT_FOUND"),
+        ("live-session", "finish_live_session", {"action": "cancel"}, "OBJECT_NOT_FOUND"),
+        (
+            "external adapter",
+            "run_ngspice_simulation",
+            {"netlist": ".end"},
+            "EXTERNAL_TOOL_ERROR",
+        ),
+    ],
+)
+def test_representative_tool_groups_use_one_error_contract(
+    group: str,
+    name: str,
+    arguments: dict[str, Any],
+    expected_code: str,
+    tmp_path: Path,
+) -> None:
+    async def verify() -> None:
+        result = await _call(tmp_path / f"{group.replace(' ', '-')}-state", name, arguments)
+        _assert_wire_error(
+            result,
+            expected_code,
+            state_dir=tmp_path / f"{group.replace(' ', '-')}-state",
+        )
+
+    asyncio.run(verify())
+
+
+def test_every_registered_tool_has_all_boundary_layers(tmp_path: Path) -> None:
+    server = create_server(_settings(tmp_path / "registry-state"))
+    tools = server._tool_manager._tools
+
+    assert len(tools) == 159
+    for tool in tools.values():
+        assert getattr(tool.fn, "__diptrace_mcp_error_boundary__", False), tool.name
+        assert getattr(
+            tool.fn_metadata.call_fn_with_arg_validation,
+            "__diptrace_mcp_validation_boundary__",
+            False,
+        ), tool.name
+        assert getattr(tool.run, "__diptrace_mcp_run_boundary__", False), tool.name
+        assert not inspect.iscoroutinefunction(inspect.unwrap(tool.fn)), tool.name

--- a/tests/test_mcp_error_contracts.py
+++ b/tests/test_mcp_error_contracts.py
@@ -48,7 +48,7 @@ def _assert_wire_error(
     assert "CallToolResult" not in serialized
     assert "Traceback" not in serialized
     assert str(state_dir) not in serialized
-    assert "/home/" not in serialized
+    assert "/tmp/fixture-secret/" not in serialized
     assert "INTERNAL_SECRET_VALUE" not in serialized
 
 
@@ -155,7 +155,7 @@ def test_typed_domain_value_error_and_oserror_are_bounded_end_to_end(
         _assert_wire_error(value_error, "INTERNAL_ERROR", state_dir=tmp_path / "value-state")
 
         def raise_os_error(self: DipTraceService, path: str | None = None) -> dict[str, Any]:
-            raise OSError("/home/devil/SECRET_PATH")
+            raise OSError("/tmp/fixture-secret/SECRET_PATH")
 
         monkeypatch.setattr(DipTraceService, "document_info", raise_os_error)
         os_error = await _call(

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -140,6 +140,192 @@ def test_trace_clearance_uses_segment_geometry_and_drc_rule() -> None:
     assert metrics["pcb.trace_clearance"]["candidate_pairs_checked"] >= 1
 
 
+def _trace_pair_snapshot(
+    *,
+    unresolved_net_id: str | None = "__keep__",
+    unknown_class: bool = False,
+    remove_rules: bool = False,
+    add_second_unresolved: bool = False,
+) -> object:
+    original = DipTraceDocument.load(FIXTURES / "pcb.xml", 10_000_000)
+    root = ET.fromstring(original.raw_bytes)
+    traces = root.find("./Board/Nets/Net[@Id='0']/Traces")
+    assert traces is not None
+
+    def add_trace(trace_id: str, y: str) -> None:
+        trace = ET.SubElement(traces, "Trace", {"Id": trace_id, "Selected": "N"})
+        points = ET.SubElement(trace, "Points")
+        ET.SubElement(
+            points,
+            "Point",
+            {"Id": "0", "X": "10", "Y": y, "Lay": "0", "Width": "0.25"},
+        )
+        ET.SubElement(
+            points,
+            "Point",
+            {"Id": "1", "X": "20", "Y": y, "Lay": "0", "Width": "0.25"},
+        )
+
+    add_trace("review-pair", "10.3")
+    if add_second_unresolved:
+        add_trace("review-unresolved", "10.6")
+    if unknown_class:
+        net = root.find("./Board/Nets/Net[@Id='0']")
+        assert net is not None
+        net.set("NetClass", "does-not-exist")
+    if remove_rules:
+        for item in root.findall("./Board/DRC/LayClearances/LayClearance"):
+            item.attrib.pop("TraceToTrace", None)
+        for item in root.findall("./Board/NetClasses/NetClass/LayProperties/LayProperty"):
+            item.attrib.pop("Clearance", None)
+
+    document = DipTraceDocument.from_bytes(
+        original.path,
+        ET.tostring(root, encoding="utf-8", xml_declaration=True),
+    )
+    snapshot = build_snapshot(document)
+    assert snapshot.board is not None
+    added = next(
+        item
+        for item in snapshot.board.traces
+        if item.attributes.get("Id") == "review-pair"
+    )
+    if unresolved_net_id != "__keep__":
+        added.net_id = unresolved_net_id
+    if add_second_unresolved:
+        extra = next(
+            item
+            for item in snapshot.board.traces
+            if item.attributes.get("Id") == "review-unresolved"
+        )
+        extra.net_id = None
+    return snapshot
+
+
+def _write_unresolved_trace_document(path: Path) -> None:
+    original = DipTraceDocument.load(FIXTURES / "pcb.xml", 10_000_000)
+    root = ET.fromstring(original.raw_bytes)
+    nets = root.find("./Board/Nets")
+    assert nets is not None
+    net = ET.SubElement(nets, "Net", {"Name": "UNRESOLVED"})
+    traces = ET.SubElement(net, "Traces")
+    trace = ET.SubElement(traces, "Trace", {"Id": "unresolved", "Selected": "N"})
+    points = ET.SubElement(trace, "Points")
+    for point_id, x in enumerate(("10", "20")):
+        ET.SubElement(
+            points,
+            "Point",
+            {
+                "Id": str(point_id),
+                "X": x,
+                "Y": "10.3",
+                "Lay": "0",
+                "Width": "0.25",
+            },
+        )
+    path.write_bytes(ET.tostring(root, encoding="utf-8", xml_declaration=True))
+
+
+def test_trace_clearance_partial_reason_reaches_review_report(tmp_path: Path) -> None:
+    path = tmp_path / "unresolved.xml"
+    _write_unresolved_trace_document(path)
+
+    result = _service(tmp_path, tmp_path / "state").run_review(
+        "unresolved.xml",
+        profile="drc_partial",
+        categories={"clearance"},
+    )
+
+    assert result["clearance_review_complete"] is False
+    assert result["netclass_rules_ignored"] is True
+    assert result["result"]["skipped_reasons"][0]["check_id"] == "pcb.trace_clearance"
+    assert result["result"]["skipped_reasons"][0]["reason"]["reason_code"] == (
+        "trace_net_unresolved"
+    )
+    assert result["result"]["metrics"]["pcb.trace_clearance"]["evaluated_pairs"] == 0
+
+
+@pytest.mark.parametrize("unresolved_net_id", [None, "does-not-exist"])
+def test_trace_clearance_discloses_unresolved_owning_net(
+    unresolved_net_id: str | None,
+) -> None:
+    snapshot = _trace_pair_snapshot(unresolved_net_id=unresolved_net_id)
+
+    findings, metrics, skipped, _ = run_checks(snapshot, categories={"clearance"})
+
+    trace_metrics = metrics["pcb.trace_clearance"]
+    assert findings == []
+    assert skipped == [
+        {"check_id": "pcb.trace_clearance", "reason": "trace_clearance_partial"}
+    ]
+    assert trace_metrics["candidate_pairs_checked"] == 1
+    assert trace_metrics["evaluated_pairs"] == 0
+    assert trace_metrics["skipped_unresolved_net_pairs"] == 1
+    assert trace_metrics["skipped_clearance_resolution_pairs"] == 0
+    assert trace_metrics["clearance_review_complete"] is False
+    assert trace_metrics["warning_codes"] == ["trace_net_unresolved"]
+    assert trace_metrics["skipped_pair_reasons"][0]["reason_code"] == (
+        "trace_net_unresolved"
+    )
+    assert metrics["clearance_review_complete"] is False
+    assert metrics["netclass_rules_ignored"] is True
+
+
+def test_trace_clearance_discloses_unknown_netclass_and_does_not_find_violation() -> None:
+    snapshot = _trace_pair_snapshot(unknown_class=True)
+
+    findings, metrics, skipped, _ = run_checks(snapshot, categories={"clearance"})
+
+    trace_metrics = metrics["pcb.trace_clearance"]
+    assert findings == []
+    assert skipped == [
+        {"check_id": "pcb.trace_clearance", "reason": "trace_clearance_partial"}
+    ]
+    assert trace_metrics["candidate_pairs_checked"] == 1
+    assert trace_metrics["evaluated_pairs"] == 0
+    assert trace_metrics["skipped_unresolved_net_pairs"] == 0
+    assert trace_metrics["skipped_clearance_resolution_pairs"] == 1
+    assert trace_metrics["warning_codes"] == ["trace_netclass_unresolved"]
+    assert trace_metrics["clearance_review_complete"] is False
+
+
+def test_trace_clearance_reports_whole_check_skip_when_rules_are_absent() -> None:
+    snapshot = _trace_pair_snapshot(remove_rules=True)
+
+    findings, metrics, skipped, _ = run_checks(snapshot, categories={"clearance"})
+
+    trace_metrics = metrics["pcb.trace_clearance"]
+    assert findings == []
+    assert skipped == [
+        {"check_id": "pcb.trace_clearance", "reason": "trace_clearance_partial"}
+    ]
+    assert trace_metrics["candidate_pairs_checked"] >= 1
+    assert trace_metrics["evaluated_pairs"] == 0
+    assert trace_metrics["skipped_clearance_resolution_pairs"] >= 1
+    assert trace_metrics["warning_codes"] == ["trace_clearance_rules_unavailable"]
+    assert any(
+        item["reason_code"] == "trace_clearance_rules_unavailable"
+        and item.get("scope") == "check"
+        for item in trace_metrics["skipped_pair_reasons"]
+    )
+
+
+def test_trace_clearance_reports_evaluated_and_skipped_pairs_together() -> None:
+    snapshot = _trace_pair_snapshot(add_second_unresolved=True)
+
+    findings, metrics, skipped, _ = run_checks(snapshot, categories={"clearance"})
+
+    trace_metrics = metrics["pcb.trace_clearance"]
+    assert any(item.check_id == "pcb.trace_clearance" for item in findings)
+    assert skipped == [
+        {"check_id": "pcb.trace_clearance", "reason": "trace_clearance_partial"}
+    ]
+    assert trace_metrics["candidate_pairs_checked"] >= 2
+    assert trace_metrics["evaluated_pairs"] >= 1
+    assert trace_metrics["skipped_unresolved_net_pairs"] >= 1
+    assert trace_metrics["clearance_review_complete"] is False
+
+
 def test_router_and_trace_review_use_the_same_netclass_clearance() -> None:
     original = DipTraceDocument.load(FIXTURES / "pcb.xml", 10_000_000)
     root = ET.fromstring(original.raw_bytes)
@@ -189,10 +375,22 @@ def test_router_and_trace_review_use_the_same_netclass_clearance() -> None:
 
     violation = next(item for item in findings if item.check_id == "pcb.trace_clearance")
     assert route.clearance_resolution["effective_clearance_mm"] == pytest.approx(0.45)
+    assert route.metrics["effective_rule_source"] == "netclass_and_board"
     assert violation.required == pytest.approx(0.45)
     assert metrics["pcb.trace_clearance"]["clearance_rule_status"][
         "netclass_rules_applied"
     ] is True
+    assert violation.rule_source == "netclass_and_board"
+    assert violation.required_clearance_mm == pytest.approx(0.45)
+    assert violation.requested_clearance_mm is None
+    assert violation.effective_clearance_mm == pytest.approx(0.45)
+    assert violation.clearance_rule_status is not None
+    assert violation.clearance_rule_status["effective_rule_source"] == (
+        "netclass_and_board"
+    )
+    assert {
+        item["kind"] for item in violation.rule_sources
+    } == {"board_default", "netclass"}
 
 
 @pytest.mark.skipif(not shapely_available(), reason="geometry extra is not installed")


### PR DESCRIPTION
## Scope

Post-merge review of PR #43.

- Base SHA: `3f06ffc084154f59a116540694f071c513323215`
- Head SHA: `e4f519380d0afc39d200178eaab6b1a4a03d6d9e`

### Confirmed defects and fixes

- Confirmed `pcb.trace_clearance` silently skipped candidate pairs when an owning net was absent or unresolved. Results now count `candidate_pairs_checked`, `evaluated_pairs`, `skipped_unresolved_net_pairs`, and `skipped_clearance_resolution_pairs`; emit structured `skipped_pair_reasons`/report `skipped_reasons`; and set `clearance_review_complete=false` for any skipped pair. Skipped pairs are neither compliant nor violations.
- Confirmed trace-clearance findings always used the fixed DRC rule path even when NetClass clearance determined the effective value. Findings and route metrics now expose safe `rule_sources`, `clearance_rule_status.effective_rule_source`, and requested/required/effective millimetres. Router and review use the same resolver.
- Confirmed a typed-result boundary failure through a real connected MCP session: `finish_live_session` became `INTERNAL_ERROR` because FastMCP output conversion tried to validate an error `CallToolResult` against the success schema. The boundary now passes one native error result through exactly once and preserves successful output conversion.

### MCP error contract

Added `session.call_tool` tests for missing documents, schema validation (missing/wrong/extra/non-finite inputs), typed domain errors, raw `ValueError`, `KeyError`, `AssertionError`, `OSError`, external adapter failure, and a successful typed result. Assertions cover `isError`, one outer `CallToolResult`, matching JSON text and `structuredContent`, stable codes/retryability, JSON serializability, and redaction of paths/usernames/secrets/tracebacks. A registry traversal proves all 159 registered tools carry the three boundary layers; representative groups are tested end-to-end.

### Evidence and provenance

- Q1 Component Angle remains `NOT_RUN`; no live DipTrace PCB Layout was available. The descriptor, capability metadata, preview, and commit warning remain unchanged and rotations are not claimed safe.
- The current tree and release artifacts contain no `reference/diptrace-xml/extracted_text/` or source PDFs. The factual inventory remains project-authored/synthetic-only. Git history was not rewritten.
- No Novarm/DipTrace permission, endorsement, or legal clearance is claimed.
- DipTrace 5.3 fixture pack remains a plan with `HUMAN_ACTION_REQUIRED`; no fake real exports were created.

### External ruleset audit

Read-only audit on 2026-08-03 at the base SHA found active ruleset **Protect main** (id `20233687`) targeting `~DEFAULT_BRANCH`: PRs required, 0 approvals, conversation resolution enabled, strict up-to-date checks, deletion and non-fast-forward protection, all `merge`/`squash`/`rebase` methods allowed, 11 status records representing 9 unique contexts, and repository-role pull-request bypass actor id 5. Documentation now states these are external owner-changeable settings. No ruleset changes were made.

### Pytest 9

Tested separately with pytest `9.1.1` and MCP SDK `1.29.0` in a clean Python 3.12.3 environment. Full geometry-enabled suite: `1018 passed, 4 skipped`; coverage `86.17%` (threshold 85%). The declared `pytest>=8.4,<9` constraint was intentionally not changed because the supported CI/dependency decision is separate.

### Validation

- Baseline on main: Python 3.12.3, Linux WSL2, MCP SDK 1.29.0, pytest 8.4.2; `993 passed, 7 skipped`; Ruff, strict Mypy, tools/list snapshot, privacy, and provenance passed.
- Final local suite: `1015 passed, 7 skipped` without Shapely.
- Ruff and strict Mypy pass; generated skill and tools/list snapshot pass (159 tools, 142746 canonical bytes).
- Privacy, provenance, compliance inventory, spec inventory, format coverage, acceptance-seed audit, and release allowlist pass.
- Clean-room artifact audit passes: wheel/sdist have no blocked/private members, direct and sdist-rebuilt wheels have identical members and SHA-256, clean install, CLI help, and MCP stdio smoke pass.
- DCO passes for all commits.
- All 9 GitHub Actions checks for PR #44 passed (Linux 3.10/3.13, geometry+coverage, no-Shapely, static-analysis, macOS, Windows, bridge, and DCO).

### HUMAN ACTION REQUIRED

1. A human with DipTrace PCB Layout must perform the Q1 GUI edit/re-export recipe and capture exact version/build, hashes, and semantic comparison.
2. A maintainer must perform the DipTrace 5.3 fixture capture/acceptance and decide any redistribution basis.
3. The repository owner must review the externally mutable ruleset/bypass configuration and any legal/provenance blockers.
4. Decide separately whether pytest 9 should become a supported dependency/matrix change.

### Rollback

Close this draft PR without merging, or revert its signed-off commits in a new reviewable commit. No history rewrite, merge, release, tag, or ruleset mutation is required.