### PR TITLE
release: publish unsigned v0.2.0 prerelease

### DIFF
--- a/.github/workflows/windows-signing.yml
+++ b/.github/workflows/windows-signing.yml
@@ -1,6 +1,18 @@
-name: Windows signing preparation
+name: Windows signing preparation and v0.2.0 publication
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-signing.yml"
+      - ".release-v0.2.0.trigger"
+      - "pyproject.toml"
+      - "scripts/build_windows_installer.ps1"
+      - "docs/releases/v0.2.0.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".release-v0.2.0.trigger"
   workflow_dispatch:
     inputs:
       signing_required:
@@ -16,9 +28,16 @@ on:
 permissions:
   contents: read
 
+env:
+  RELEASE_VERSION: "0.2.0"
+  RELEASE_TAG: "v0.2.0"
+  INNO_SETUP_URL: https://github.com/jrsoftware/issrc/releases/download/is-6_4_2/innosetup-6.4.2.exe
+  INNO_SETUP_SHA256: 238e2cf82c212a3879a050e02d787283c54bcb72d5cb6070830942de56627d5b
+
 jobs:
   build-test-package:
     name: Build, test, and package bridge
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: windows-latest
     steps:
       - name: Require a protected ref for signing
@@ -72,7 +91,7 @@ jobs:
 
   protected-signing-handoff:
     name: Protected SignPath handoff
-    if: ${{ inputs.signing_required == true && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.signing_required == true && github.ref == 'refs/heads/main' }}
     needs: build-test-package
     runs-on: windows-latest
     environment: windows-signing
@@ -94,3 +113,286 @@ jobs:
             throw "HUMAN ACTION REQUIRED: configure the protected SignPath integration before requesting signing"
           }
           throw "HUMAN ACTION REQUIRED: replace this reviewed handoff with the approved pinned SignPath action"
+
+  release-source:
+    name: Build and audit v0.2.0 Python artifacts
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Verify release identity
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib, tomllib
+          data = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))
+          actual = data['project']['version']
+          expected = '0.2.0'
+          if actual != expected:
+              raise SystemExit(f'project version {actual!r} does not match {expected!r}')
+          PY
+      - name: Build and audit wheel and source distribution
+        shell: bash
+        run: |
+          python -m pip install -e ".[dev]"
+          rm -rf release-dist
+          python -m hatchling build -d release-dist
+          python scripts/audit_release_artifacts.py --dist-dir release-dist --check-allowlist
+          test -f release-dist/diptrace_mcp-0.2.0-py3-none-any.whl
+          test -f release-dist/diptrace_mcp-0.2.0.tar.gz
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v0.2.0-python-artifacts
+          path: release-dist
+          if-no-files-found: error
+
+  release-server:
+    name: Build v0.2.0 standalone Windows server
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Build server
+        shell: pwsh
+        run: .\scripts\build_windows_server.ps1 -PythonCommand python -OutputDir dist\windows-server -Clean
+      - name: Verify server version
+        shell: pwsh
+        run: |
+          & .\dist\windows-server\diptrace_mcp_server\diptrace_mcp_server.exe --version
+          if ($LASTEXITCODE -ne 0) { throw "server --version failed" }
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v0.2.0-server-onedir
+          path: dist/windows-server/diptrace_mcp_server
+          if-no-files-found: error
+
+  release-bridge:
+    name: Build v0.2.0 Windows bridge
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Build bridge
+        shell: pwsh
+        run: .\plugin\build_bridge.ps1 -PythonCommand python -Clean
+      - name: Verify unsigned bridge
+        shell: pwsh
+        run: |
+          & .\plugin\dist\diptrace_mcp_bridge.exe --help
+          if ($LASTEXITCODE -ne 0) { throw "bridge --help failed" }
+          .\plugin\verify_signature.ps1 -Path .\plugin\dist\diptrace_mcp_bridge.exe
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v0.2.0-bridge-exe
+          path: plugin/dist/diptrace_mcp_bridge.exe
+          if-no-files-found: error
+
+  release-windows-assets:
+    name: Build and smoke v0.2.0 installer and portable assets
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    needs: [release-server, release-bridge]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.2.0-server-onedir
+          path: dist/windows-server/diptrace_mcp_server
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.2.0-bridge-exe
+          path: plugin/dist
+      - name: Build configurator
+        shell: pwsh
+        run: .\scripts\build_windows_configurator.ps1 -PythonCommand python -OutputDir dist\windows-configurator -Clean
+      - name: Install pinned Inno Setup compiler
+        shell: pwsh
+        run: |
+          $package = Join-Path $env:RUNNER_TEMP 'innosetup-6.4.2.exe'
+          Invoke-WebRequest -Uri $env:INNO_SETUP_URL -OutFile $package
+          $actual = (Get-FileHash -LiteralPath $package -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $env:INNO_SETUP_SHA256) { throw "Inno Setup prerequisite hash mismatch" }
+          $process = Start-Process -FilePath $package -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "Inno Setup prerequisite installation failed" }
+          $iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
+          if (-not (Test-Path -LiteralPath $iscc)) { throw "Pinned ISCC.exe was not installed" }
+          "ISCC_PATH=$iscc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build exact v0.2.0 assets
+        shell: pwsh
+        run: |
+          .\scripts\build_windows_installer.ps1 `
+            -Version 0.2.0 `
+            -PythonCommand python `
+            -BridgePath .\plugin\dist\diptrace_mcp_bridge.exe `
+            -IsccPath "$env:ISCC_PATH" `
+            -OutputDir dist\windows-artifacts `
+            -SkipBuild
+          if (-not (Test-Path .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-0.2.0.exe)) { throw "installer missing" }
+          if (-not (Test-Path .\dist\windows-artifacts\portable\DipTrace-MCP-Portable-0.2.0.zip)) { throw "portable archive missing" }
+      - name: Portable and installer smoke
+        shell: pwsh
+        run: |
+          $portable = '.\dist\windows-artifacts\portable\DipTrace-MCP-Portable-0.2.0.zip'
+          $portableRoot = Join-Path $env:RUNNER_TEMP 'release-portable'
+          Expand-Archive -LiteralPath $portable -DestinationPath $portableRoot -Force
+          python scripts/audit_windows_bundle.py --root $portableRoot --sha256 (Join-Path $portableRoot 'SHA256SUMS.txt') --json
+          & (Join-Path $portableRoot 'app\diptrace_mcp_server.exe') --version
+          if ($LASTEXITCODE -ne 0) { throw "portable server --version failed" }
+
+          $setup = '.\dist\windows-artifacts\installer\DipTrace-MCP-Setup-0.2.0.exe'
+          $install = Join-Path $env:RUNNER_TEMP 'release-install'
+          $workspace = Join-Path $env:RUNNER_TEMP 'release-workspace'
+          $state = Join-Path $env:RUNNER_TEMP 'release-state'
+          New-Item -ItemType Directory -Force -Path $workspace | Out-Null
+          $arguments = @('/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/TYPE=server','/SERVERONLY','/CLIENT=none',"/DIR=`"$install`"","/WORKSPACE=`"$workspace`"","/STATEDIR=`"$state`"")
+          $process = Start-Process -FilePath $setup -ArgumentList $arguments -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "release installer smoke failed" }
+          & (Join-Path $install 'app\diptrace_mcp_server.exe') --version
+          if ($LASTEXITCODE -ne 0) { throw "installed server --version failed" }
+          $uninstall = Start-Process -FilePath (Join-Path $install 'unins000.exe') -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait -PassThru
+          if ($uninstall.ExitCode -ne 0) { throw "release uninstall smoke failed" }
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v0.2.0-windows-release-assets
+          path: |
+            dist/windows-artifacts/installer/DipTrace-MCP-Setup-0.2.0.exe
+            dist/windows-artifacts/portable/DipTrace-MCP-Portable-0.2.0.zip
+          if-no-files-found: error
+
+  release-publish:
+    name: Tag, publish, and verify v0.2.0 prerelease
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: [release-source, release-windows-assets]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.2.0-python-artifacts
+          path: downloaded/python
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.2.0-windows-release-assets
+          path: downloaded/windows
+      - name: Assemble immutable release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          for name in \
+            diptrace_mcp-0.2.0-py3-none-any.whl \
+            diptrace_mcp-0.2.0.tar.gz \
+            DipTrace-MCP-Setup-0.2.0.exe \
+            DipTrace-MCP-Portable-0.2.0.zip; do
+            mapfile -t matches < <(find downloaded -type f -name "$name")
+            test "${#matches[@]}" -eq 1
+            cp "${matches[0]}" "release-assets/$name"
+          done
+          cp docs/compliance/sbom.cdx.json release-assets/diptrace-mcp-0.2.0-sbom.cdx.json
+          cp docs/compliance/dependency-inventory.json release-assets/diptrace-mcp-0.2.0-dependency-inventory.json
+          cp docs/compliance/THIRD_PARTY_NOTICES.md release-assets/THIRD_PARTY_NOTICES.md
+          cp docs/compliance/PROVENANCE_INVENTORY.csv release-assets/PROVENANCE_INVENTORY.csv
+          cp docs/compliance/WINDOWS_BUNDLE_INVENTORY.md release-assets/WINDOWS_BUNDLE_INVENTORY.md
+          cp docs/releases/v0.2.0.md release-assets/RELEASE_RECORD-v0.2.0.md
+          cp LICENSE release-assets/LICENSE
+          (
+            cd release-assets
+            find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -printf '%f\n' | LC_ALL=C sort | while read -r name; do
+              sha256sum "$name"
+            done > SHA256SUMS.txt
+          )
+          test "$(wc -l < release-assets/SHA256SUMS.txt)" -eq 11
+      - name: Prepare release notes
+        shell: bash
+        run: |
+          cat > release-notes.md <<'EOF'
+          # DipTrace MCP 0.2.0
+
+          Unsigned alpha/development prerelease of the DipTrace Model Context Protocol server and Windows live XML bridge.
+
+          ## Highlights
+
+          - Windows one-click installer, standalone server, portable bundle, and Codex/Claude configurator.
+          - Service-Facade decomposition with the public contract preserved at 159 MCP tools.
+          - Guarded transactions, SHA-bound previews and commits, backups, rollback, live apply/cancel, and explicit policy limits.
+          - Expanded review, routing, placement, synchronization, evidence, provenance, and release auditing.
+          - Exact release assets include wheel, source distribution, installer, portable bundle, checksums, SBOM, dependency inventory, notices, and provenance records.
+
+          ## Important limitations
+
+          - Windows executables are unsigned. SHA-256 checks establish byte identity, not publisher trust.
+          - This is not production-ready manufacturing sign-off software and is not endorsed by Novarm/DipTrace.
+          - Runtime `get_capabilities` is authoritative for each installation and document.
+          - Universal DipTrace 5.x compatibility is not claimed.
+          - Q1 Component Angle GUI/re-export evidence remains `NOT_RUN`.
+          - Some real Windows 11, current DipTrace 5, Codex, Claude Desktop, elevated-install, and custom-state acceptance items remain uncompleted and are disclosed in the bundled release record.
+          EOF
+      - name: Create annotated tag and GitHub prerelease
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "fireostendere"
+          git config user.email "87851878+fireostendere@users.noreply.github.com"
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            target="$(git rev-list -n 1 "$RELEASE_TAG")"
+            test "$target" = "$GITHUB_SHA"
+          else
+            git tag -a "$RELEASE_TAG" "$GITHUB_SHA" -m "DipTrace MCP $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release already exists; refusing to replace published bytes."
+          else
+            gh release create "$RELEASE_TAG" release-assets/* \
+              --verify-tag \
+              --prerelease \
+              --title "DipTrace MCP $RELEASE_TAG" \
+              --notes-file release-notes.md
+          fi
+      - name: Verify public downloads and wheel installation
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf public-release verify-venv
+          mkdir public-release
+          gh release download "$RELEASE_TAG" --dir public-release
+          (cd public-release && sha256sum -c SHA256SUMS.txt)
+          python -m venv verify-venv
+          verify-venv/bin/python -m pip install public-release/diptrace_mcp-0.2.0-py3-none-any.whl
+          verify-venv/bin/diptrace-mcp --help
+          gh release view "$RELEASE_TAG" --json tagName,isPrerelease,url,targetCommitish

--- a/.release-v0.2.0.trigger
+++ b/.release-v0.2.0.trigger
@@ -1,0 +1,1 @@
+Publish unsigned development prerelease v0.2.0 from the exact merged release-finalisation commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,71 +2,67 @@
 
 ## Unreleased
 
-- complete the first service-facade decomposition pass with typed shared context,
-  a single document gateway, and explicit in-process domain services;
-- extract document/read models, BOM/component metadata, review/findings and
-  signal-integrity analysis, discovery, exports, jobs, external adapters,
-  routing, placement, semantic operations, synchronization, XML writes,
-  scaffolding, transactions, evidence/trust, and live sessions while preserving
-  the 159-tool MCP surface;
-- preserve singleton store ownership, explicit Facade signatures, stable error
-  contracts, SHA/policy/atomic-write boundaries, live-session leases, and the
-  server-owned thread-offload boundary;
-- document the remaining Facade assembly/callback responsibilities and the
-  follow-on plan-application/capability candidates;
-- disclose pending live component-angle evidence and expose structured evidence warnings;
-- resolve routing and trace-to-trace review clearances from board defaults plus affected NetClasses;
-- add a centralized service-to-MCP error boundary with stable public error codes and safe details;
-- remove verbatim external reference extracts and source-derived inventory from public surfaces;
-- add a clean-room factual inventory generator and a pending DipTrace 5.3 fixture-pack manifest;
-- make unresolved trace-clearance pairs explicit and publish their structured
-  skip reasons and effective clearance rule sources;
-- bound partial trace-clearance detail output, avoid quadratic pair enumeration
-  when rules are unavailable, and separate partial-review status from actual
-  NetClass-rule omission;
-- verify the service-to-MCP error contract through connected
-  `session.call_tool` calls and prevent nested typed-result error wrapping;
-- refresh the dated external GitHub ruleset evidence without changing the
-  ruleset;
-- document the remaining live-evidence, provenance, and partial-clearance limitations.
-- add a Windows onedir server bundle, safe Codex/Claude configurator, Inno Setup
-  installer, portable fallback, install manifest, and fail-closed upgrade/uninstall
-  behavior;
-- add Windows CI smoke/audit coverage for no-Python installation, settings
-  profiles, Unicode paths, client-config backups, checksums, and unsigned status;
-- audit the FastMCP synchronous worker-thread boundary and add connected
-  responsiveness probes for blocking I/O and CPU-heavy work;
-- publish CI status and deterministic coverage-gate badges whose threshold is
-  generated from the enforced workflow value;
-- harden 0.2.0 release preparation with state ownership markers, compensating
-  plug-in rollback, working portable paths, final-asset checksums, and complete
-  executable-signature gates.
+No unreleased user-visible changes are recorded after the `v0.2.0`
+finalisation candidate.
+
+## 0.2.0 - 2026-08-04
+
+### Added
+
+- Windows onedir server, Inno Setup installer, portable bundle, and guarded
+  Codex/Claude Desktop configurator.
+- Typed in-process domain services for document reads, BOM and component
+  metadata, review, discovery, exports, jobs, external adapters, routing,
+  placement, semantic operations, synchronization, XML writes, scaffolding,
+  transactions, evidence, and live sessions.
+- Central service-to-MCP error boundary with stable public error codes and
+  bounded safe details.
+- NetClass-aware routing and trace-to-trace review-clearance resolution with
+  structured partial-review and skip reporting.
+- Clean-room factual inventory generation, pending current-version fixture
+  manifests, evidence warnings, SBOM, dependency inventory, provenance records,
+  and deterministic release-artifact auditing.
+- Project-owned AnyIO worker-thread boundary and connected responsiveness probes
+  for all registered MCP tools.
+
+### Changed
+
+- Completed the first service-Facade decomposition pass while preserving the
+  159-tool MCP surface, all 157 public `DipTraceService` signatures, and 148
+  explicit delegations.
+- Preserved singleton store ownership, stable error contracts,
+  SHA/policy/atomic-write boundaries, live-session leases, and the server-owned
+  thread-offload boundary.
+- Removed verbatim external reference extracts and source-derived inventory from
+  public surfaces.
+- Hardened installer ownership, compensating plug-in rollback, uninstall/state
+  preservation, portable paths, final-asset checksums, and executable-signature
+  gates.
+- Published CI status and deterministic coverage-gate metadata generated from
+  the enforced workflow threshold.
+
+### Validation and limitations
+
+- Exact PR #48 implementation head passed CI run `30933874564`, Windows
+  installer run `30933874350`, `1074 passed, 4 skipped` on the geometry-enabled
+  Linux coverage job, and `1062 passed, 16 skipped` on Windows.
+- Exact PR #49 release-preparation head passed CI run `30940972328` and Windows
+  installer run `30940972331` across Linux 3.10/3.12/3.13, macOS, Windows,
+  geometry, fallback, static analysis, DCO, MCP contract, decomposition,
+  provenance, and artifact audits.
+- The release is an explicitly unsigned alpha/development prerelease. SHA-256
+  checks establish byte identity, not publisher trust.
+- Universal DipTrace 5.x compatibility, production readiness, independent
+  review, Novarm/DipTrace endorsement, and complete manufacturing sign-off are
+  not claimed.
+- Q1 Component Angle GUI/re-export evidence remains `NOT_RUN`; runtime
+  `get_capabilities` remains authoritative for each installation and document.
 
 This file records user-visible project changes. Version `0.1.0` was the first
 tagged release; the withdrawn `0.1.1` release and the corrected `0.1.2`
 development release are retained as separate historical records.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-
-### Documentation
-
-- Activated and verified the main-branch GitHub ruleset; pull requests require
-  DCO plus nine unique technical CI contexts (eleven API status records).
-- Completed a post-merge security and compliance audit of the current tree and
-  reachable Git history.
-- Added reproducible deep secret-scanning, dependency-audit, and clean-room
-  audit tools; their raw reports remain owner-private.
-- Finalized the post-publication `v0.1.2` provenance with the immutable release
-  commit, exact-head CI run, public asset inventory, checksum verification, and
-  public-download smoke results.
-- Distinguished the frozen candidate coverage measurement from the exact-head
-  GitHub CI coverage measurement.
-- Reconciled the public release checklist with the verification work that was
-  completed during publication.
-- Opened contribution intake under DCO 1.1, added provenance/privacy checks,
-  and added reproducible dependency, SBOM, and signing-preparation records.
-- Removed forum-announcement drafts from the public tree; external announcement
-  materials are maintained privately by the repository owner.
 
 ## 0.1.2 - 2026-08-01
 
@@ -81,16 +77,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Added the release installation guide.
 - Added the withdrawn `v0.1.1` record and the `v0.1.2` release record.
+- Activated and verified the main-branch GitHub ruleset; pull requests require
+  DCO plus nine unique technical CI contexts.
+- Completed a post-merge security and compliance audit of the current tree and
+  reachable Git history.
+- Added reproducible deep secret-scanning, dependency-audit, and clean-room
+  audit tools; raw reports remain owner-private.
+- Finalized the post-publication `v0.1.2` provenance with the immutable release
+  commit, exact-head CI run, public asset inventory, checksum verification, and
+  public-download smoke results.
+- Opened contribution intake under DCO 1.1 and added provenance/privacy checks.
 
 ### Validation
 
 - Frozen candidate/local run: Python 3.12.3, Shapely 2.1.2, GEOS 3.13.1,
   991 passed, 4 skipped, 16,922 statements, 2,379 missed, and 85.941378%
   total coverage.
-- Exact-head GitHub CI run `30709466348`: all eight required Linux, macOS,
-  Windows, geometry, fallback, static-analysis, generated-artifact, and native
-  bridge jobs passed; its Python 3.12.13 coverage result was 991 passed,
-  4 skipped, 16,922 statements, 2,375 missed, and 85.9650% total.
+- Exact-head GitHub CI run `30709466348`: all required Linux, macOS, Windows,
+  geometry, fallback, static-analysis, generated-artifact, and native bridge
+  jobs passed; its Python 3.12.13 coverage result was 991 passed, 4 skipped,
+  16,922 statements, 2,375 missed, and 85.9650% total.
 - Wheel/sdist audit, direct-wheel versus sdist-rebuilt-wheel comparison,
   clean-wheel installation, CLI and MCP stdio smoke, exact-CI Windows bridge
   provenance, plug-in ZIP/settings validation, checksums, and public-download
@@ -117,14 +123,16 @@ that a critical runtime vulnerability existed is made. It is superseded by
 
 - Completed Windows DipTrace 5.2.0.4 ↔ WSL MCP live acceptance for PCB and
   Schematic apply/cancel/wrong-SHA paths, including GUI checks, independent
-  save/re-export comparisons, path invariants, and connectivity/count preservation.
-- Added focused unit coverage for non-WSL Windows-path refusal, relative WSL mount
-  roots, POSIX-path refusal on Windows, and invalid path-platform metadata.
+  save/re-export comparisons, path invariants, and connectivity/count
+  preservation.
+- Added focused unit coverage for non-WSL Windows-path refusal, relative WSL
+  mount roots, POSIX-path refusal on Windows, and invalid path-platform metadata.
 
 ### Documentation
 
-- Reconciled English and Russian readiness, testing, architecture, compatibility,
-  usage, roadmap, and release-policy documentation with the 2026-07-31 evidence.
+- Reconciled English and Russian readiness, testing, architecture,
+  compatibility, usage, roadmap, and release-policy documentation with the
+  2026-07-31 evidence.
 - Added a dated code-review record and live-acceptance record.
 
 ## 0.1.0 - 2026-07-30
@@ -144,8 +152,8 @@ that a critical runtime vulnerability existed is made. It is superseded by
 - Citation metadata for the repository's current development state.
 - An exact, versioned release-file allowlist and CI audit for Python source
   distributions and wheels.
-- Public package metadata for repository, documentation, and issue links,
-  plus EDA-focused classifiers without a premature license classifier.
+- Public package metadata for repository, documentation, and issue links, plus
+  EDA-focused classifiers without a premature license classifier.
 
 ### Fixed
 
@@ -162,12 +170,14 @@ that a critical runtime vulnerability existed is made. It is superseded by
   remain open for a fully verified release line.
 - No community size, adoption, sponsorship, vendor endorsement, signed binary,
   package-index release, or support-program acceptance is asserted.
-- Python wheels intentionally contain the MCP server and eight packaged
-  skills, while Windows bridge installation scripts and settings remain
-  separate source/release assets.
+- Python wheels intentionally contain the MCP server and eight packaged skills,
+  while Windows bridge installation scripts and settings remain separate
+  source/release assets.
 
 Version `0.1.0` is published as tag `v0.1.0`; its provenance record is
 [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) and the release assets on
 GitHub.
 
+[0.2.0]: https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.2.0
+[0.1.2]: https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.1.2
 [0.1.0]: https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@ cff-version: 1.2.0
 message: Cite the repository URL and commit used in your work.
 title: DipTrace MCP
 type: software
-version: 0.1.2
+version: 0.2.0
 license: Apache-2.0
-date-released: 2026-08-01
+date-released: 2026-08-04
 abstract: >-
   A local Model Context Protocol server and live XML bridge for reading,
   reviewing, and performing guarded edits on DipTrace designs.

--- a/docs/RELEASE_0_2_0_CHECKLIST.md
+++ b/docs/RELEASE_0_2_0_CHECKLIST.md
@@ -1,147 +1,128 @@
 # DipTrace MCP 0.2.0 Release Checklist
 
-This checklist separates completed repository automation from actions that
-require the repository owner, a real Windows profile, a real DipTrace
-installation, signing credentials, or external review.
+This checklist separates completed repository automation from actions requiring
+a real Windows profile, current DipTrace installation, external clients,
+signing credentials, or independent review.
 
-Do not create tag `v0.2.0` until every blocking item is complete or an explicit
-reviewed exception is recorded without weakening the stated evidence limits.
-
-## Current candidate identity
+## Publication decision
 
 - Version: `0.2.0`.
-- Latest published release: `v0.1.2`.
-- Publication status: **NOT TAGGED / NOT PUBLISHED**.
+- Release manager: [@fireostendere](https://github.com/fireostendere), repository
+  owner.
+- Approval date: `2026-08-04`.
+- Publication class: **unsigned alpha/development GitHub prerelease**.
+- Independent reviewer: none.
+- PyPI publication: not configured and not planned for this release.
+- Signing claim: prohibited; all Windows executables remain explicitly unsigned.
+
+The repository owner explicitly approved publication under the documented
+solo-maintainer exception while the manual acceptance items below remain open.
+Those items are not represented as completed. They are release limitations and
+must remain visible in the release notes, release record, README, and runtime
+capability reporting.
+
+## Reviewed lineage
+
 - Service-refactor PR: `#48`.
-- Reviewed implementation head: `ceafb30725783f66ab83071ed7e98a478ac76618`.
-- PR #48 squash commit on `main`:
+- Reviewed implementation head:
+  `ceafb30725783f66ab83071ed7e98a478ac76618`.
+- PR #48 squash commit:
   `a4c9023cdbc982e5bc8e1867945105c18f49f3f5`.
 - Release-preparation PR: `#49`.
-- Exact PR #49 head: `946fc121806af532e431fcc1bdad3d85b217cd30`.
-- PR #49 merge commit on `main`:
+- Exact PR #49 head:
+  `946fc121806af532e431fcc1bdad3d85b217cd30`.
+- PR #49 merge commit:
   `4fdefcd5464d57fa7bef2aa7391eb5b0507798f6`.
+- Documentation-synchronisation PR: `#50`.
+- PR #50 merge commit:
+  `9c31fe51b31e5aece66b085021d4cf2a6171ce31`.
 - Exact PR #49 CI run: `30940972328`, successful.
 - Exact PR #49 Windows installer run: `30940972331`, successful.
-- Intended publication class: unsigned alpha/development-stage GitHub
-  prerelease under the documented solo-maintainer exception.
+- Exact PR #50 CI run: `30945046315`, successful.
+- Exact PR #50 Windows installer run: `30945046584`, successful.
 
-The merged commit above is the current documentation/release-preparation
-baseline. It is not automatically the final release commit; final human
-acceptance may require another reviewed release-finalisation PR.
+The final release-finalisation PR must pass its complete exact-head matrix. Its
+merged commit becomes the immutable annotated-tag target.
 
-## Automated preparation
+## Completed automated preparation
 
-- [x] Project and Windows artifact version is `0.2.0`.
-- [x] PR #48 is merged with the public MCP contract preserved.
-- [x] PR #49 release-candidate documentation is merged.
-- [x] The public MCP surface remains 159 tools.
+- [x] Project/package version is `0.2.0`.
+- [x] Public MCP surface remains 159 tools.
 - [x] All 157 public Facade signatures and 148 explicit delegations are checked.
 - [x] All 195 Facade methods are covered by the decomposition inventory.
-- [x] Persistent write-capability classification includes internal delegation
-      and lazy preview-store construction.
-- [x] Ruff passes.
-- [x] Strict Mypy passes.
-- [x] DCO passes.
-- [x] Linux Python 3.10/3.12/3.13 tests pass.
-- [x] macOS and Windows tests pass.
+- [x] Persistent-write classification includes internal delegation and lazy
+      preview-store construction.
+- [x] Ruff, strict Mypy, and DCO pass.
+- [x] Linux Python 3.10/3.12/3.13, macOS, and Windows tests pass.
 - [x] Shapely/GEOS and explicit no-Shapely fallback paths pass.
-- [x] Public `tools/list` snapshot is regenerated and checked.
-- [x] Service-Facade contract and decomposition safety checks pass.
-- [x] Event-loop audit covers all registered tools.
+- [x] Public `tools/list`, service-Facade contract, decomposition safety, and
+      event-loop audits pass.
 - [x] Python wheel/source archives build from the exact allowlist and pass audit.
 - [x] Standalone server, bridge, configurator, installer, and portable bundle
-      build in the Windows workflow.
-- [x] Installer/portable smoke includes frozen stdio, `tools/list`,
-      `get_capabilities`, XML, checksums, provenance, and unsigned status.
-- [x] State deletion requires matching installation ownership metadata.
-- [x] Installer rollback covers plug-in changes when a later configuration step
-      fails.
-- [x] Signed-required verification covers installer, bridge, server, and
-      configurator executables.
-- [x] Regular wheel/source stdio remains on the public FastMCP path; the private
-      fallback is frozen-only.
-- [x] The reviewed implementation head passed `1074 passed, 4 skipped` in the
-      geometry-enabled Linux coverage run.
-- [x] The reviewed implementation head passed `1062 passed, 16 skipped` on
-      Windows.
-- [x] Reviewed implementation coverage is `85.9367%`; total and per-file gates
-      passed.
+      build in Windows CI.
+- [x] Installer ownership, rollback, state preservation, checksums, unsigned
+      verification, frozen stdio, XML, and provenance paths are covered by CI.
+- [x] Reviewed implementation head passed `1074 passed, 4 skipped` at
+      `85.9367%` geometry-enabled Linux coverage.
+- [x] Reviewed implementation head passed `1062 passed, 16 skipped` on Windows.
+- [x] Changelog and citation metadata are finalised for `0.2.0` dated
+      `2026-08-04`.
+- [x] A guarded publication workflow builds exact `0.2.0` assets, creates an
+      annotated tag, publishes a prerelease, redownloads all public assets,
+      verifies `SHA256SUMS.txt`, installs the public wheel, and runs CLI smoke.
 
-## Human release blockers
+## Manual acceptance not completed
 
-- [ ] Test install, repair, and uninstall on a clean Windows 11 VM.
-- [ ] Test a current real DipTrace 5 installation across PCB, Schematic,
-      Component, and Pattern modules.
-- [ ] Confirm the installer does not remove pre-existing user files from a
-      custom state location.
-- [ ] Test real Codex configuration, restart Codex, and call
-      `get_capabilities`.
-- [ ] Test real Claude Desktop configuration, restart Claude, and call
-      `get_capabilities`.
-- [ ] Test an elevated plug-in installation under Program Files while MCP client
-      configuration remains in the original user profile.
-- [ ] Record exact Windows, DipTrace, Codex, and Claude versions/builds used for
-      acceptance.
-- [ ] Obtain and record any required external legal review. No Novarm/DipTrace
-      permission, affiliation, or endorsement is implied.
-- [ ] Freeze the exact final release commit after acceptance.
-- [ ] Build final release assets from that exact commit.
-- [ ] Produce and verify final per-file `SHA256SUMS.txt`.
-- [ ] Download the public assets and repeat checksum, install, MCP stdio, and
-      uninstall smoke tests after publication.
+- [ ] Clean Windows 11 install, repair, and uninstall acceptance.
+- [ ] Current real DipTrace 5 across PCB, Schematic, Component, and Pattern
+      modules.
+- [ ] Preservation of pre-existing files in a custom state location.
+- [ ] Real Codex configuration, restart, and `get_capabilities`.
+- [ ] Real Claude Desktop configuration, restart, and `get_capabilities`.
+- [ ] Elevated Program Files plug-in installation while client configuration
+      remains in the original user profile.
+- [ ] Exact Windows, DipTrace, Codex, and Claude versions/builds for the above
+      acceptance matrix.
+- [ ] Any required external legal review or Novarm/DipTrace permission.
+- [ ] Q1 Component Angle GUI/re-export evidence; status remains `NOT_RUN`.
 
-## Explicit decisions already recorded
+These unchecked items prohibit stronger claims but do not block the explicitly
+approved unsigned prerelease. They must not be silently converted into passes.
 
-- [x] Publish 0.2.0, if approved, as explicitly unsigned development-stage
-      software unless a real protected signing run is completed.
-- [x] Do not describe CI success or SHA-256 verification as a code signature.
-- [x] Keep Q1 Component Angle validation marked `NOT_RUN` unless live evidence
-      is captured and independently reviewed.
-- [x] Keep the remaining trust-invalidation gaps visible for `plan_apply`,
-      `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`.
-- [x] Do not claim universal DipTrace 5.x compatibility, production readiness,
-      independent review, native library mutation, or native manufacturing
-      output.
+## Final automated sequence
 
-## Final release sequence
+1. Merge the release-finalisation PR only after exact-head CI and exact
+   `0.2.0` release-asset builds pass.
+2. Build wheel, source distribution, standalone server, bridge, configurator,
+   installer, and portable bundle from the merged commit.
+3. Smoke the exact installer and portable bundle.
+4. Assemble the release files and deterministic per-file `SHA256SUMS.txt`.
+5. Create annotated tag `v0.2.0` at the exact merged commit.
+6. Publish the files as an explicitly unsigned GitHub prerelease.
+7. Redownload the public assets, verify all checksums, install the public wheel,
+   and run `diptrace-mcp --help`.
+8. Reconcile public documentation with the immutable tag, release URL, asset
+   hashes, and verification result in a post-release PR.
 
-1. Complete and record the human acceptance matrix.
-2. Open a final release-finalisation PR from current `main`.
-3. Record the exact candidate commit and acceptance evidence.
-4. Move user-visible entries from `Unreleased` into `0.2.0 - <date>` in
-   `CHANGELOG.md`.
-5. Update `CITATION.cff` to 0.2.0 and the approved release date.
-6. Reconcile `README.md`, `README_RU.md`, release records, and installation docs
-   with the final immutable state.
-7. Regenerate compliance outputs against the exact final commit.
-8. Run the complete release and clean-room commands from
-   `docs/RELEASE_PROCESS.md`.
-9. Build final assets from that exact commit.
-10. Verify every entry in `SHA256SUMS.txt` from a clean directory.
-11. Verify Authenticode only when a signed release is claimed.
-12. Create annotated tag `v0.2.0` from the approved commit.
-13. Publish the exact audited assets as a GitHub development/prerelease.
-14. Download the public files and repeat checksum/install/stdio/uninstall smoke.
-15. Replace candidate placeholders in `docs/releases/v0.2.0.md` with immutable
-    tag, asset, date, and public-download evidence.
-
-## Intended release assets
+## Release assets
 
 - `DipTrace-MCP-Setup-0.2.0.exe`
 - `DipTrace-MCP-Portable-0.2.0.zip`
 - `diptrace_mcp-0.2.0-py3-none-any.whl`
 - `diptrace_mcp-0.2.0.tar.gz`
 - `SHA256SUMS.txt`
-- current SBOM
+- SBOM
 - dependency inventory
 - third-party notices
-- provenance/release records
+- provenance inventory
+- Windows bundle inventory
+- release record
+- Apache-2.0 license
 
 ## Claims prohibited without additional evidence
 
 - production-ready;
-- signed, unless every distributed executable verifies under the approved
-  identity;
+- signed or trusted-publisher verified;
 - independently reviewed;
 - universally compatible with DipTrace 5.x;
 - validated for every registered tool or XML object;
@@ -149,4 +130,5 @@ acceptance may require another reviewed release-finalisation PR.
 - native Component/Pattern Library mutation;
 - native Gerber/NC Drill/manufacturing generation;
 - Novarm/DipTrace endorsement, affiliation, approval, or redistribution
-  permission.
+  permission;
+- complete manufacturing, fabrication, assembly, or regulatory sign-off.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,183 +1,156 @@
-# Release Candidate Record: v0.2.0
+# Release Record: v0.2.0
 
-## Status
+## Status and authority
 
 - Version: `0.2.0`.
-- Publication status: **NOT TAGGED / NOT PUBLISHED**.
-- Latest published release: `v0.1.2`.
-- Release manager: [@fireostendere](https://github.com/fireostendere), the
-  repository owner.
+- Approval date: `2026-08-04`.
+- Release manager: [@fireostendere](https://github.com/fireostendere), repository
+  owner.
+- Publication class: unsigned alpha/development GitHub prerelease.
 - Independent reviewer: none.
-- Intended publication class: unsigned alpha/development-stage GitHub
-  prerelease under the documented solo-maintainer exception.
+- Signing status: unsigned; no trusted-publisher claim is permitted.
+- Package index: not published to PyPI.
 
-This is a candidate record, not a completed release record. It must be updated
-with the final immutable tag SHA, publication date, asset sizes and hashes, and
-public-download verification before `v0.2.0` can be described as published.
+The repository owner explicitly approved publication under the documented
+solo-maintainer exception. Manual acceptance items listed below remain open and
+are not represented as completed.
 
-## Candidate lineage
+The guarded publication workflow creates annotated tag `v0.2.0` at the exact
+merged release-finalisation commit, publishes immutable assets, redownloads the
+public files, verifies `SHA256SUMS.txt`, installs the public wheel, and runs CLI
+smoke. The GitHub release page is authoritative for the final tag target, asset
+sizes, and uploaded bytes. A post-release documentation PR records those exact
+values back into the repository.
+
+## Lineage
 
 ### Service decomposition
 
-- PR: `#48`.
-- Reviewed implementation head:
+- PR `#48` reviewed head:
   `ceafb30725783f66ab83071ed7e98a478ac76618`.
-- Squash commit on `main`:
+- PR `#48` squash commit:
   `a4c9023cdbc982e5bc8e1867945105c18f49f3f5`.
 
 ### Release preparation
 
-- PR: `#49`.
-- Exact reviewed PR head:
+- PR `#49` reviewed head:
   `946fc121806af532e431fcc1bdad3d85b217cd30`.
-- Merge commit on `main`:
+- PR `#49` merge commit:
   `4fdefcd5464d57fa7bef2aa7391eb5b0507798f6`.
-- Exact-head CI run: `30940972328`, successful.
-- Exact-head Windows installer run: `30940972331`, successful.
+- Exact-head CI run `30940972328`: success.
+- Exact-head Windows installer run `30940972331`: success.
 
-The merge commit above is the current documentation/release-preparation
-baseline. It is not yet frozen as the final tag target because human acceptance
-and final asset verification remain open.
+### Documentation synchronisation
+
+- PR `#50` merge commit:
+  `9c31fe51b31e5aece66b085021d4cf2a6171ce31`.
+- Exact-head CI run `30945046315`: success.
+- Exact-head Windows installer run `30945046584`: success.
+
+The final release-finalisation PR must pass its own exact-head source and
+Windows release-asset matrix before merge. Its merged commit is the tag target.
 
 ## Scope since v0.1.2
 
-The 0.2.0 line is a substantial development release rather than a correction
-release. It includes:
+Version 0.2.0 is a substantial development release. It includes:
 
-- a Windows Inno Setup installer, standalone onedir server, portable bundle,
-  and safe Codex/Claude configurator;
-- fail-closed installation ownership, rollback, uninstall, checksums,
-  unsigned/signed verification gates, SBOM, and provenance auditing;
-- a central MCP error boundary with stable public codes and bounded safe
-  details;
-- a project-owned AnyIO worker-thread boundary for all registered MCP tools;
+- Windows Inno Setup installer, standalone onedir server, portable bundle, and
+  guarded Codex/Claude Desktop configurator;
+- installer ownership markers, rollback, conservative uninstall/state handling,
+  checksums, explicit unsigned verification, SBOM, and provenance auditing;
+- central service-to-MCP error handling with stable public codes and bounded
+  safe details;
+- project-owned AnyIO worker-thread execution for all registered MCP tools;
 - NetClass-aware routing and trace-to-trace clearance resolution with explicit
   partial-review reporting;
-- removal of verbatim external reference extracts from public surfaces and a
-  project-authored factual inventory path;
-- explicit pending current-version fixture and Component Angle evidence status;
-- the first full service-Facade decomposition pass, with explicit typed domain
-  services and a stable public Facade;
-- reproducible Facade signature/delegation and write-capability checks.
+- clean-room factual inventory and pending current-version evidence manifests;
+- complete first-pass service-Facade decomposition into typed domain services;
+- exact Facade signature/delegation and write-capability validation;
+- expanded guarded transactions, reviews, routing, placement, synchronization,
+  evidence, exports, jobs, and live-session handling.
 
-## Public contract evidence
+## Public contract
 
-The reviewed code preserves:
+The release preserves:
 
 - 159 registered MCP tools;
 - 157 public `DipTraceService` methods;
 - 148 explicit Facade-to-domain-service delegations;
 - nine intentionally Facade-owned public methods;
-- all existing transaction, SHA, policy, backup, atomic-write, evidence,
-  live-session, plan-application, and external-process boundaries;
+- transaction, SHA, policy, backup, atomic-write, evidence, live-session,
+  plan-application, and external-process boundaries;
 - one server-owned thread-offload boundary for every registered tool.
 
-The complete current MCP snapshot contains 142,746 canonical UTF-8 bytes and
-has SHA-256
+The MCP snapshot contains 142,746 canonical UTF-8 bytes with SHA-256
 `073f53681306fd13c5f3f29d61baed9a83fc9eb5c1ed14883846005a39d812db`.
+Runtime `get_capabilities` remains authoritative for a specific installation,
+document, policy, and optional-adapter configuration.
 
-The service contract manifest records parameter names, kinds, defaults,
-annotations, return annotations, sync/async kind, decorators, and delegation
-targets. The decomposition validator audits all 195 Facade methods and all known
-persistent writers, including internal delegation and lazy raw-preview-store
-construction.
+## Automated evidence
 
-## Reviewed automated evidence
-
-### Implementation head
-
-The exact reviewed PR #48 head
-`ceafb30725783f66ab83071ed7e98a478ac76618` passed:
+The reviewed implementation head passed:
 
 - CI run `30933874564`;
 - Windows one-click installer run `30933874350`;
 - geometry-enabled Linux coverage: `1074 passed, 4 skipped`, `85.9367%`;
 - Windows pytest: `1062 passed, 16 skipped`.
 
-The retained workflow artifacts from that implementation head were:
+The release-preparation and documentation heads additionally passed Linux
+Python 3.10/3.12/3.13, macOS, Windows, Shapely/GEOS, no-Shapely fallback, Ruff,
+strict Mypy, DCO, MCP snapshot, service contract, decomposition safety,
+event-loop, release-artifact, provenance, installer, portable, frozen stdio,
+XML, checksum, and unsigned-status checks.
 
-| Workflow artifact | Artifact ID | GitHub Actions archive digest |
-| --- | ---: | --- |
-| `diptrace-windows-artifacts` | `8902338281` | `sha256:7e735e197f7a905e71544faa9a2dcd7a59da079dde0aa106a65f74c1c3820645` |
-| `diptrace-server-onedir` | `8902290859` | `sha256:e62054aa81cffba18eaa7aed78ceace545261ab916d5f48967c3215d8809b24c` |
-| `diptrace-bridge-exe` | `8902283647` | `sha256:962ad8c2af50a2ccea3131bc7587abbe9afbe0e39ab1d794faf7b02fcf8a3bf1` |
+The final publication workflow additionally builds and smokes the exact
+`0.2.0` wheel, source distribution, installer, and portable bundle from the
+merged tag target before publication.
 
-These are GitHub Actions ZIP archive digests, not final per-file release
-checksums.
+## Manual acceptance not completed
 
-### Release-preparation head
-
-The exact PR #49 head
-`946fc121806af532e431fcc1bdad3d85b217cd30` passed:
-
-- CI run `30940972328`;
-- Windows installer run `30940972331`;
-- Linux Python 3.10/3.12/3.13;
-- macOS and Windows Python 3.12;
-- Shapely/GEOS and explicit no-Shapely fallback;
-- Ruff and strict Mypy;
-- DCO;
-- MCP snapshot, service contract, decomposition safety, and event-loop audits;
-- Python release-artifact allowlist/audit;
-- bridge, standalone server, configurator, installer, portable, frozen stdio,
-  XML, provenance, checksum, and unsigned-status smoke paths.
-
-## Human acceptance still required
-
-The candidate is not publication-ready until the blocking items in
-[`RELEASE_0_2_0_CHECKLIST.md`](../RELEASE_0_2_0_CHECKLIST.md) are completed.
-Current evidence does not yet include:
+The following are disclosed limitations, not completed checks:
 
 - clean Windows 11 install/repair/uninstall acceptance;
-- a current real DipTrace 5 installation exercised across PCB, Schematic,
-  Component, and Pattern modules;
-- real Codex and Claude Desktop profile configuration and restart verification;
-- elevated Program Files plug-in installation while preserving the original
-  user profile for client configuration;
-- confirmation that custom-state uninstall preserves pre-existing user files;
-- final frozen per-file checksums;
-- public-download installation verification for 0.2.0;
-- any required external legal review or Novarm/DipTrace permission.
+- a current real DipTrace 5 installation across PCB, Schematic, Component, and
+  Pattern modules;
+- preservation of pre-existing files in a custom state directory;
+- real Codex configuration, restart, and `get_capabilities`;
+- real Claude Desktop configuration, restart, and `get_capabilities`;
+- elevated Program Files plug-in installation with client configuration kept in
+  the original user profile;
+- external legal review or Novarm/DipTrace permission;
+- Q1 Component Angle GUI/re-export evidence, which remains `NOT_RUN`.
 
-Q1 Component Angle GUI/re-export evidence remains `NOT_RUN`. Rotation output
-must retain its warning and must not be described as live-validated.
+The capability report also keeps trust-invalidation work visible for
+`plan_apply`, `ses_import`, `schematic_to_pcb_sync`, and `live_session_apply`.
 
-The capability report also keeps trust-invalidation work explicit for:
+## Release assets
 
-- `plan_apply`;
-- `ses_import`;
-- `schematic_to_pcb_sync`;
-- `live_session_apply`.
-
-## Signing and distribution
-
-The intended 0.2.0 development release is explicitly unsigned unless a real
-protected signing run is completed and every distributed executable verifies.
-CI success and SHA-256 verification are not code signatures. Test certificates,
-self-signed certificates, or an unexecuted signing configuration must not be
-represented as trusted signing.
-
-The project is not published to PyPI. The intended GitHub asset set is:
+The publication set contains:
 
 - `DipTrace-MCP-Setup-0.2.0.exe`;
 - `DipTrace-MCP-Portable-0.2.0.zip`;
 - `diptrace_mcp-0.2.0-py3-none-any.whl`;
 - `diptrace_mcp-0.2.0.tar.gz`;
 - `SHA256SUMS.txt`;
-- current SBOM, dependency inventory, notices, and provenance records.
+- SBOM and dependency inventory;
+- third-party notices;
+- provenance and Windows bundle inventories;
+- this release record;
+- Apache-2.0 license.
 
-These filenames describe intended final assets, not current public downloads.
+`SHA256SUMS.txt` establishes byte identity only. It is not an Authenticode or
+trusted-publisher signature.
 
 ## Supported claims and limitations
 
-The candidate may be described as an alpha/development-stage MCP server with an
-unsigned Windows installer path and guarded DipTrace XML workflows.
+The release may be described as an unsigned alpha/development MCP server with a
+Windows installer path and guarded DipTrace XML workflows.
 
 It must not be described as:
 
 - production-ready;
+- signed or trusted-publisher verified;
 - independently reviewed;
-- signed;
 - universally compatible with DipTrace 5.x;
 - validated for every registered tool or XML object;
 - safe for component rotation without the pending Q1 evidence;
@@ -185,35 +158,11 @@ It must not be described as:
 - capable of native Component/Pattern Library mutation;
 - capable of native Gerber/NC Drill/manufacturing generation;
 - endorsed by, affiliated with, or approved by Novarm/DipTrace;
-- complete manufacturing or fabrication sign-off software.
-
-Runtime `get_capabilities` remains authoritative for a specific installation
-and document.
-
-## Finalisation procedure
-
-1. Complete and record every human blocker in
-   `docs/RELEASE_0_2_0_CHECKLIST.md`.
-2. Open and review a final release-finalisation PR.
-3. Freeze the exact release commit.
-4. Move `CHANGELOG.md` entries from `Unreleased` to a dated `0.2.0` section.
-5. Update `CITATION.cff` to the approved version/date.
-6. Regenerate compliance outputs against the exact commit.
-7. Run the complete release and clean-room commands from
-   `docs/RELEASE_PROCESS.md`.
-8. Build final assets and per-file `SHA256SUMS.txt` from the same commit.
-9. Create annotated tag `v0.2.0` only after all gates pass.
-10. Publish the exact audited assets as a GitHub development/prerelease.
-11. Download the public files and repeat checksum, install, MCP stdio, and
-    uninstall smoke tests.
-12. Replace this candidate status with immutable tag, release URL, final asset
-    sizes/hashes, publication date, and public-download evidence.
+- complete manufacturing, fabrication, assembly, or regulatory sign-off.
 
 ## Rollback and withdrawal
 
-Before publication, abandon the candidate by closing or reverting the relevant
-release-finalisation PR. Do not rewrite history or move an existing tag.
-
-After publication, preserve the tag and asset bytes. If a material problem is
-discovered, withdraw the release and publish a replacement version with an
-explicit incident record. Never replace an asset under an existing version.
+Tag and asset bytes must never be replaced. If a material problem is found,
+preserve the original tag and files, mark the release withdrawn when
+appropriate, publish a corrected version, and record affected hashes and user
+action. Do not rewrite `main` history or move an existing tag.


### PR DESCRIPTION
## Summary

Finalize and publish DipTrace MCP `v0.2.0` as an explicitly unsigned alpha/development GitHub prerelease.

## Changes

- finalize `CHANGELOG.md` and `CITATION.cff` for 2026-08-04;
- record the repository-owner solo-maintainer publication exception without marking incomplete manual acceptance as passed;
- finalize the `v0.2.0` release record and limitations;
- add a one-shot guarded publication path to the existing protected signing workflow;
- build and audit the exact `0.2.0` wheel and source distribution;
- build and smoke the exact `0.2.0` standalone Windows server, bridge, installer, and portable bundle;
- create an annotated `v0.2.0` tag from the merged finalisation commit;
- publish immutable assets as a GitHub prerelease;
- redownload the public files, verify `SHA256SUMS.txt`, install the public wheel, and run CLI smoke.

## Exact identity

- base: `9c31fe51b31e5aece66b085021d4cf2a6171ce31`;
- head: `4d8829d14d9cf19a54ae01aa533f1f4db35b5f2c`;
- branch: `release/finalize-v0.2.0`.

## Exact-head validation

- CI run `30946506994`: success;
- Windows one-click installer run `30946506419`: success;
- v0.2.0 publication dry-run workflow `30946506846`: success;
- exact wheel/sdist build and release-artifact audit: success;
- exact standalone server and bridge builds: success;
- exact `DipTrace-MCP-Setup-0.2.0.exe` and `DipTrace-MCP-Portable-0.2.0.zip` build: success;
- portable audit, installed-server smoke, and uninstall smoke: success;
- DCO, Ruff, strict Mypy, Linux 3.10/3.12/3.13, macOS, Windows, geometry, fallback, MCP snapshot, Facade contract, decomposition, event-loop, provenance, and compliance checks: success.

## Release boundary

The release is unsigned and must not be described as production-ready, independently reviewed, universally compatible with DipTrace 5.x, endorsed by Novarm/DipTrace, or complete manufacturing sign-off software. Q1 Component Angle evidence remains `NOT_RUN`. Several real Windows/DipTrace/client acceptance items remain explicitly open and are disclosed as limitations.

## Merge behavior

The root `.release-v0.2.0.trigger` causes the publication workflow to run only when this PR is merged to `main`. The publication job was skipped on the pull request; the PR run built and smoked the exact release assets. After merge, the push workflow tags the exact merge commit, publishes the prerelease, redownloads the public files, verifies checksums, installs the public wheel, and runs CLI smoke.

## Prior reviewed lineage

- PR #48 squash commit: `a4c9023cdbc982e5bc8e1867945105c18f49f3f5`;
- PR #49 merge commit: `4fdefcd5464d57fa7bef2aa7391eb5b0507798f6`;
- PR #50 merge commit: `9c31fe51b31e5aece66b085021d4cf2a6171ce31`.
