### PR TITLE
Fix Windows external-process timeout race

### DIFF
--- a/src/diptrace_mcp/external_process.py
+++ b/src/diptrace_mcp/external_process.py
@@ -196,6 +196,17 @@ class ExternalProcessRunner:
                     on_progress(elapsed)
                 cancel.wait(self.poll_interval_seconds)
 
+            # The process can exit between the loop condition and the next
+            # deadline check. Preserve timeout/cancellation precedence instead
+            # of misclassifying that boundary race as an external-tool failure.
+            elapsed = time.monotonic() - started
+            if cancel.is_set():
+                self._stop_remaining_descendants(process)
+                raise JobCancelledError(cancellation_message, jobid=jobid)
+            if elapsed > timeout_seconds:
+                self._stop_remaining_descendants(process)
+                raise JobTimeoutError(timeout_message, jobid=jobid)
+
             return_code = process.wait()
             self._stop_remaining_descendants(process)
             if cancel.is_set():


### PR DESCRIPTION
## What changed

- re-check cancellation and timeout immediately after the child process leaves the polling loop;
- keep timeout/cancellation typed errors authoritative when the process exits on the deadline boundary;
- preserve existing descendant cleanup and public contracts.

## Root cause

`ExternalProcessRunner.run()` checked the deadline only while `process.poll()` returned `None`. If the process exited between the loop condition and the next deadline check, the timeout path could be skipped and the higher-level openEMS job could be reported as `external_tool_failed` instead of `job_timeout`. This was observed once in the Windows CI job after PR #59 merged; rerunning the same job passed, confirming the boundary race was flaky.

## Validation

The existing `test_openems_job_timeout_is_bounded` is the regression coverage that exposed the issue. CI should additionally cover Windows, macOS, Linux, strict Mypy, Ruff, architecture and contract checks.
