### PR TITLE
Fix DipTrace PCB roundtrip serialization

### DIFF
--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -166,3 +166,4 @@ does not make undocumented children safe.
 Any operation listed above can discard matching passthrough children rather than
 preserve their original bytes. Unlisted dynamic removal sites remain unavailable
 to this static detector and must not be assumed safe.
+

--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -11,8 +11,8 @@
 | Documented parent/child relationships | 143 across 61 parents |
 | Normalized (reader produces typed field) | 72 |
 | Written only (writer can create/modify) | 18 |
-| Mentioned only (literal, not an XML call) | 6 |
-| Passthrough (unknown XML, kept byte-for-byte) | 11 |
+| Mentioned only (literal, not an XML call) | 7 |
+| Passthrough (unknown XML, kept byte-for-byte) | 10 |
 | **Coverage** | **84.1%** |
 
 ## Inventory Provenance
@@ -131,6 +131,7 @@ the current reader/writer call sites; it is not a normative DipTrace format spec
 - `NegPoints`
 - `PosPoint`
 - `PosPoints`
+- `RefDesMarking`
 - `Silk`
 
 ## Passthrough Elements
@@ -145,7 +146,6 @@ the current reader/writer call sites; it is not a normative DipTrace format spec
 - `Manufacturer`
 - `Note`
 - `PadNumber`
-- `RefDesMarking`
 
 ## What Passthrough Means
 
@@ -161,10 +161,8 @@ does not make undocumented children safe.
 - `semantic_compiler.py::_apply_remove_testpoints` may remove `<Item>` from `<Pads>`; known passthrough children: none.
 - `semantic_compiler.py::_apply_remove_testpoints` may remove `<Pattern>` from `<Patterns>`; known passthrough children: none.
 - `semantic_compiler.py::_apply_sync_schematic_to_pcb` may remove `<Item>` from `<Pads>`; known passthrough children: none.
-- `semantic_compiler.py::_apply_sync_schematic_to_pcb` may remove `<Ratline>` from `<Ratlines>`; known passthrough children: none.
 - `semantic_compiler.py::_apply_ungroup_components` may remove `<Group>` from `<Groups>`; known passthrough children: none.
 
 Any operation listed above can discard matching passthrough children rather than
 preserve their original bytes. Unlisted dynamic removal sites remain unavailable
 to this static detector and must not be assumed safe.
-

--- a/src/diptrace_mcp/semantic_compiler.py
+++ b/src/diptrace_mcp/semantic_compiler.py
@@ -1384,18 +1384,54 @@ def _apply_sync_schematic_to_pcb(
     patch_count = 0
     before: list[dict[str, Any]] = []
     after: list[dict[str, Any]] = []
+    connectivity_mutated = False
 
-    pattern_library = document.root.find("./Library[@Type='DipTrace-PatternLibrary']")
-    if pattern_library is None:
-        pattern_library = ET.Element(
+    # PCB Layout stores its footprint cache inside the embedded component library.
+    # Older project-authored fixtures used a sibling PatternLibrary; normalize that
+    # legacy shape before copying any synchronized patterns.
+    component_library = document.root.find(
+        "./Library[@Type='DipTrace-ComponentLibrary']"
+    )
+    if component_library is None:
+        component_library = ET.Element(
             "Library",
-            {
-                "Type": "DipTrace-PatternLibrary",
-                "Version": document.version,
-                "Units": document.units,
-            },
+            {"Type": "DipTrace-ComponentLibrary", "Units": document.units},
         )
-        document.root.insert(0, pattern_library)
+        document.root.insert(0, component_library)
+        patch_count += 1
+    if component_library.get("Version") is not None:
+        component_library.attrib.pop("Version", None)
+        patch_count += 1
+    if component_library.get("Units") is None:
+        component_library.set("Units", document.units)
+        patch_count += 1
+
+    pattern_library = component_library.find(
+        "./Library[@Type='DipTrace-PatternLibrary']"
+    )
+    if pattern_library is None:
+        legacy_pattern_library = document.root.find(
+            "./Library[@Type='DipTrace-PatternLibrary']"
+        )
+        if legacy_pattern_library is not None:
+            pattern_library = ET.fromstring(
+                ET.tostring(legacy_pattern_library, encoding="unicode")
+            )
+            document.root.remove(legacy_pattern_library)
+            component_library.insert(0, pattern_library)
+            patch_count += 1
+        else:
+            pattern_library = ET.SubElement(
+                component_library,
+                "Library",
+                {"Type": "DipTrace-PatternLibrary", "Units": document.units},
+            )
+            patch_count += 1
+    if pattern_library.get("Version") is not None:
+        pattern_library.attrib.pop("Version", None)
+        patch_count += 1
+    if pattern_library.get("Units") is None:
+        pattern_library.set("Units", document.units)
         patch_count += 1
     patterns = pattern_library.find("./Patterns")
     if patterns is None:
@@ -1413,6 +1449,23 @@ def _apply_sync_schematic_to_pcb(
     existing_pad_styles = {
         (item.get("Name") or "").casefold() for item in pad_styles.findall("./PadStyle")
     }
+    for pattern_index, pattern in enumerate(patterns.findall("./Pattern")):
+        expected_id = str(pattern_index)
+        if pattern.get("Id") != expected_id:
+            pattern.set("Id", expected_id)
+            patch_count += 1
+        for attribute, default in (
+            ("LockTypeChange", "N"),
+            ("Float1", "0"),
+            ("Float2", "0"),
+            ("Float3", "0"),
+            ("Int1", "0"),
+            ("Int2", "0"),
+        ):
+            if pattern.get(attribute) is None:
+                pattern.set(attribute, default)
+                patch_count += 1
+    next_pattern_id = len(patterns.findall("./Pattern"))
     for raw in operation.pad_style_xml:
         element = parse_xml_definition(raw)
         if element.tag != "PadStyle" or not element.get("Name"):
@@ -1429,6 +1482,17 @@ def _apply_sync_schematic_to_pcb(
             raise EditError("Schematic sync contains an invalid Pattern definition")
         key = style.casefold()
         if key not in existing_pattern_styles:
+            element.set("Id", str(next_pattern_id))
+            next_pattern_id += 1
+            for attribute, default in (
+                ("LockTypeChange", "N"),
+                ("Float1", "0"),
+                ("Float2", "0"),
+                ("Float3", "0"),
+                ("Int1", "0"),
+                ("Int2", "0"),
+            ):
+                element.attrib.setdefault(attribute, default)
             patterns.append(element)
             existing_pattern_styles.add(key)
             patch_count += 1
@@ -1471,6 +1535,9 @@ def _apply_sync_schematic_to_pcb(
                     "X": f"{from_mm(spec.x, document.units):.9g}",
                     "Y": f"{from_mm(spec.y, document.units):.9g}",
                     "Side": spec.side,
+                    "MarkingFontSize": "10",
+                    "MarkingFontSizeFloat": "10",
+                    "GridAlign": "Pad",
                     "Locked": "N",
                     "Selected": "N",
                 },
@@ -1479,6 +1546,26 @@ def _apply_sync_schematic_to_pcb(
             ET.SubElement(target_component, "RefDes").text = spec.refdes
             ET.SubElement(target_component, "Name").text = spec.name
             ET.SubElement(target_component, "Value").text = spec.value
+            for tag, align in (
+                ("RefDesMarking", "Top"),
+                ("NameMarking", "Left"),
+                ("ValueMarking", "Bottom"),
+            ):
+                marking = ET.SubElement(target_component, tag)
+                for surface in ("Silk", "Assy"):
+                    ET.SubElement(
+                        marking,
+                        surface,
+                        {
+                            "Show": "Show",
+                            "Align": align,
+                            "Horz": "Center",
+                            "Vert": "Center",
+                            "X": "0",
+                            "Y": "0",
+                            "Angle": "0",
+                        },
+                    )
             _, field_patches = _set_additional_fields(target_component, spec.fields)
             component_pads = ET.SubElement(target_component, "Pads")
             for pad_index, number in enumerate(spec.pad_numbers):
@@ -1506,6 +1593,7 @@ def _apply_sync_schematic_to_pcb(
                 }
             )
             patch_count += 1 + field_patches
+            connectivity_mutated = True
         else:
             stable = _element_stable_id(
                 snapshot,
@@ -1589,6 +1677,7 @@ def _apply_sync_schematic_to_pcb(
             components.remove(extra_component)
             del existing_components[key]
             patch_count += 1
+            connectivity_mutated = True
 
     nets_container = document.container.find("./Nets")
     if nets_container is None:
@@ -1645,6 +1734,7 @@ def _apply_sync_schematic_to_pcb(
             nets_container.remove(extra_net)
             del existing_nets[key]
             patch_count += 1
+            connectivity_mutated = True
 
         for key, target_net in existing_nets.items():
             desired_endpoints = desired_endpoints_by_net.get(key)
@@ -1696,32 +1786,20 @@ def _apply_sync_schematic_to_pcb(
                 }
             )
 
-        desired_ratline_pairs = {
-            frozenset({first, second})
-            for endpoints in desired_endpoints_by_net.values()
-            for first, second in zip(endpoints, endpoints[1:], strict=False)
-            if first != second
-        }
-        ratlines = document.container.find("./Ratlines")
-        if ratlines is not None:
-            for ratline in list(ratlines.findall("./Ratline")):
-                pair = frozenset(
-                    {
-                        (ratline.get("Comp1", ""), ratline.get("Pad1", "")),
-                        (ratline.get("Comp2", ""), ratline.get("Pad2", "")),
-                    }
-                )
-                if not operation.create_ratlines or pair not in desired_ratline_pairs:
-                    ratlines.remove(ratline)
-                    patch_count += 1
+        connectivity_mutated = True
 
     next_net_id = int(_next_numeric_id(nets_container.findall("./Net")))
+    hidden_ids = [
+        int(value)
+        for item in nets_container.findall("./Net")
+        if (value := item.get("HiddenId", "")).isdigit()
+    ]
+    next_hidden_net_id = max(hidden_ids, default=-1) + 1
     endpoint_nets: dict[tuple[str, str], ET.Element] = {}
     for existing_net in nets_container.findall("./Net"):
         for item in existing_net.findall("./Pads/Item"):
             endpoint_nets[(item.get("Comp", ""), item.get("Pad", ""))] = existing_net
 
-    requested_ratlines: list[tuple[str, list[tuple[str, str]]]] = []
     for net_spec in operation.nets:
         sync_net = existing_nets.get(net_spec.name.casefold())
         net_was_created = sync_net is None
@@ -1731,8 +1809,14 @@ def _apply_sync_schematic_to_pcb(
             sync_net = ET.SubElement(
                 nets_container,
                 "Net",
-                {"Id": net_id, "NetClass": "0", "Locked": "N"},
+                {
+                    "Id": net_id,
+                    "HiddenId": str(next_hidden_net_id),
+                    "NetClass": "0",
+                    "Locked": "N",
+                },
             )
+            next_hidden_net_id += 1
             ET.SubElement(sync_net, "Name").text = net_spec.name
             ET.SubElement(sync_net, "Pads")
             ET.SubElement(sync_net, "Traces")
@@ -1747,16 +1831,20 @@ def _apply_sync_schematic_to_pcb(
             "net", document.source_type, f"xml:{sync_net.get('Id', '')}"
         )
         net_changed = net_was_created
+        if sync_net.get("HiddenId") is None:
+            sync_net.set("HiddenId", str(next_hidden_net_id))
+            next_hidden_net_id += 1
+            patch_count += 1
+            net_changed = True
+        if not operation.create_ratlines and sync_net.get("HideRatlines") != "Y":
+            sync_net.set("HideRatlines", "Y")
+            patch_count += 1
+            net_changed = True
         pads_container = sync_net.find("./Pads")
         if pads_container is None:
             pads_container = ET.SubElement(sync_net, "Pads")
             patch_count += 1
             net_changed = True
-        preexisting_endpoints = [
-            (item.get("Comp", ""), item.get("Pad", ""))
-            for item in pads_container.findall("./Item")
-        ]
-        added_endpoints: list[tuple[str, str]] = []
         for endpoint in net_spec.endpoints:
             endpoint_key, component_pad = _sync_endpoint(
                 component_by_refdes,
@@ -1782,6 +1870,7 @@ def _apply_sync_schematic_to_pcb(
                             old_pads.remove(item)
                             patch_count += 1
                             net_changed = True
+                            connectivity_mutated = True
                 endpoint_nets.pop(endpoint_key, None)
             if endpoint_key not in endpoint_nets:
                 ET.SubElement(
@@ -1792,27 +1881,17 @@ def _apply_sync_schematic_to_pcb(
                 endpoint_nets[endpoint_key] = sync_net
                 patch_count += 1
                 net_changed = True
-                added_endpoints.append(endpoint_key)
+                connectivity_mutated = True
             net_id = sync_net.get("Id", "")
             if component_pad.get("NetId") != net_id:
                 component_pad.set("NetId", net_id)
                 patch_count += 1
                 net_changed = True
+                connectivity_mutated = True
             if component_pad.get("InternalConnection") is None:
                 component_pad.set("InternalConnection", "-1")
                 patch_count += 1
                 net_changed = True
-        if operation.reconciliation_mode == "exact":
-            requested_ratlines.append(
-                (net_spec.name, desired_endpoints_by_net[net_spec.name.casefold()])
-            )
-        elif added_endpoints:
-            ratline_endpoints = (
-                added_endpoints
-                if not preexisting_endpoints
-                else [preexisting_endpoints[0], *added_endpoints]
-            )
-            requested_ratlines.append((net_spec.name, ratline_endpoints))
         if net_changed and net_stable not in changed_ids:
             changed_ids.append(net_stable)
             if not net_was_created:
@@ -1839,86 +1918,19 @@ def _apply_sync_schematic_to_pcb(
             if pad.get("NetId") != expected_net_id:
                 pad.set("NetId", expected_net_id)
                 patch_count += 1
+                connectivity_mutated = True
             if pad.get("InternalConnection") is None:
                 pad.set("InternalConnection", "-1")
                 patch_count += 1
 
-    if operation.create_ratlines:
+    # Ratlines are a derived DipTrace cache. Pad@NetId is authoritative; keeping
+    # hand-authored ratlines after a connectivity edit can make DipTrace reject the
+    # cache and show a reinitialization warning. Drop it and let DipTrace rebuild.
+    if connectivity_mutated:
         ratlines = document.container.find("./Ratlines")
-        if ratlines is None:
-            ratlines = ET.SubElement(document.container, "Ratlines")
+        if ratlines is not None:
+            document.container.remove(ratlines)
             patch_count += 1
-        existing_pairs = {
-            frozenset(
-                {
-                    (item.get("Comp1", ""), item.get("Pad1", "")),
-                    (item.get("Comp2", ""), item.get("Pad2", "")),
-                }
-            )
-            for item in ratlines.findall("./Ratline")
-        }
-        next_ratline_id = int(_next_numeric_id(ratlines.findall("./Ratline")))
-        positioned_snapshot = build_snapshot(document)
-        pad_positions: dict[tuple[str, str], Point] = {}
-        for component_record in positioned_snapshot.objects.values():
-            if (
-                component_record.kind not in {"component", "testpoint"}
-                or not component_record.xml_id
-            ):
-                continue
-            for pad_stable in component_record.relationships.get("pads", []):
-                pad_record: ObjectRecord | None = positioned_snapshot.objects.get(pad_stable)
-                if pad_record is None or not pad_record.xml_id:
-                    continue
-                position = pad_record.position or component_record.position
-                if position is not None:
-                    pad_positions[(component_record.xml_id, pad_record.xml_id)] = Point(**position)
-        for _net_name, endpoints in requested_ratlines:
-            for first, second in zip(endpoints, endpoints[1:], strict=False):
-                pair = frozenset({first, second})
-                if first == second or pair in existing_pairs:
-                    continue
-                first_component = component_by_refdes[
-                    next(
-                        spec.refdes.casefold()
-                        for spec in operation.components
-                        if component_by_refdes[spec.refdes.casefold()].get("Id") == first[0]
-                    )
-                ]
-                second_component = component_by_refdes[
-                    next(
-                        spec.refdes.casefold()
-                        for spec in operation.components
-                        if component_by_refdes[spec.refdes.casefold()].get("Id") == second[0]
-                    )
-                ]
-                first_position = pad_positions.get(first) or Point(
-                    to_mm(float(first_component.get("X", "0")), document.units),
-                    to_mm(float(first_component.get("Y", "0")), document.units),
-                )
-                second_position = pad_positions.get(second) or Point(
-                    to_mm(float(second_component.get("X", "0")), document.units),
-                    to_mm(float(second_component.get("Y", "0")), document.units),
-                )
-                ET.SubElement(
-                    ratlines,
-                    "Ratline",
-                    {
-                        "Id": str(next_ratline_id),
-                        "Hidden": "N",
-                        "X1": f"{from_mm(first_position.x, document.units):.9g}",
-                        "Y1": f"{from_mm(first_position.y, document.units):.9g}",
-                        "X2": f"{from_mm(second_position.x, document.units):.9g}",
-                        "Y2": f"{from_mm(second_position.y, document.units):.9g}",
-                        "Comp1": first[0],
-                        "Pad1": first[1],
-                        "Comp2": second[0],
-                        "Pad2": second[1],
-                    },
-                )
-                next_ratline_id += 1
-                existing_pairs.add(pair)
-                patch_count += 1
 
     final_snapshot = build_snapshot(document)
     targets = [

--- a/src/diptrace_mcp/synchronization.py
+++ b/src/diptrace_mcp/synchronization.py
@@ -454,13 +454,18 @@ def build_sync_plan(
         limitations=[
             "Multi-part components require explicit part-id/pin to pad-number mappings.",
             (
-                "Exact reconciliation covers components, net endpoint sets, traces on changed "
-                "nets, and ratlines; unrelated board geometry remains outside its scope."
+                "Exact reconciliation covers components, net endpoint sets, and traces on "
+                "changed nets; derived ratline cache is invalidated when connectivity changes. "
+                "Unrelated board geometry remains outside its scope."
                 if reconciliation_mode == "exact"
                 else "Synchronization is additive; extra PCB components, nets and traces "
                 "are preserved."
             ),
             "New components use deterministic grid placement and should be legalized "
             "before routing.",
+            (
+                "Ratline geometry is derived by DipTrace from pad NetId membership; "
+                "create_ratlines=false hides the derived guides on synchronized nets."
+            ),
         ],
     )

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -166,6 +166,47 @@ def test_sync_bootstraps_missing_embedded_libraries() -> None:
     ] == ["PatType0", "PatType1"]
 
 
+def test_sync_restores_missing_embedded_library_units() -> None:
+    schematic = _load("schematic.xml")
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    initial_plan = build_sync_plan(
+        schematic,
+        pcb,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+    )
+    initial = apply_semantic_operations(pcb, [initial_plan.operation])
+    root = ET.fromstring(initial.raw_bytes)
+    component_library = root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert component_library is not None
+    pattern_library = component_library.find("./Library[@Type='DipTrace-PatternLibrary']")
+    assert pattern_library is not None
+    component_library.attrib.pop("Units", None)
+    pattern_library.attrib.pop("Units", None)
+    missing_units = DipTraceDocument.from_bytes(
+        Path("board.dip"), ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    )
+    repair_plan = build_sync_plan(
+        schematic,
+        missing_units,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+    )
+
+    repaired = apply_semantic_operations(missing_units, [repair_plan.operation])
+    repaired_root = ET.fromstring(repaired.raw_bytes)
+    repaired_component_library = repaired_root.find(
+        "./Library[@Type='DipTrace-ComponentLibrary']"
+    )
+    assert repaired_component_library is not None
+    repaired_pattern_library = repaired_component_library.find(
+        "./Library[@Type='DipTrace-PatternLibrary']"
+    )
+    assert repaired_pattern_library is not None
+    assert repaired_component_library.get("Units") == missing_units.units
+    assert repaired_pattern_library.get("Units") == missing_units.units
+
+
 def test_sync_operation_is_idempotent() -> None:
     schematic = _load("schematic.xml")
     pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -69,18 +69,35 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
     components = root.findall("./Board/Components/Component")
     assert [item.findtext("./RefDes") for item in components] == ["R1", "U1"]
     assert [item.get("PatternStyle") for item in components] == ["PatType0", "PatType1"]
-    assert [
-        item.get("PatternStyle")
-        for item in root.findall(
-            "./Library[@Type='DipTrace-PatternLibrary']/Patterns/Pattern"
-        )
-    ] == ["PatType0", "PatType1"]
+    embedded_patterns = root.findall(
+        "./Library[@Type='DipTrace-ComponentLibrary']/"
+        "Library[@Type='DipTrace-PatternLibrary']/Patterns/Pattern"
+    )
+    assert [item.get("PatternStyle") for item in embedded_patterns] == [
+        "PatType0",
+        "PatType1",
+    ]
+    assert [item.get("Id") for item in embedded_patterns] == ["0", "1"]
+    assert all(item.get("LockTypeChange") == "N" for item in embedded_patterns)
+    assert all(item.get("Float1") == "0" for item in embedded_patterns)
+    assert all(item.get("Float2") == "0" for item in embedded_patterns)
+    assert all(item.get("Float3") == "0" for item in embedded_patterns)
+    assert all(item.get("Int1") == "0" for item in embedded_patterns)
+    assert all(item.get("Int2") == "0" for item in embedded_patterns)
     assert {
         item.get("Name")
         for item in root.findall(
-            "./Library[@Type='DipTrace-PatternLibrary']/PadStyles/PadStyle"
+            "./Library[@Type='DipTrace-ComponentLibrary']/"
+            "Library[@Type='DipTrace-PatternLibrary']/PadStyles/PadStyle"
         )
     } == {"SMD_0603", "THT_1MM"}
+    outer_library = root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert outer_library is not None
+    assert outer_library.get("Version") is None
+    pattern_library = outer_library.find("./Library[@Type='DipTrace-PatternLibrary']")
+    assert pattern_library is not None
+    assert pattern_library.get("Version") is None
+    assert root.find("./Library[@Type='DipTrace-PatternLibrary']") is None
     nets = {
         net.findtext("./Name"): {
             (item.get("Comp"), item.get("Pad"))
@@ -105,7 +122,21 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         ("1", "0"): ("0", "-1"),
         ("1", "1"): ("1", "-1"),
     }
-    assert len(root.findall("./Board/Ratlines/Ratline")) == 2
+    assert root.find("./Board/Ratlines") is None
+    assert [net.get("HiddenId") for net in root.findall("./Board/Nets/Net")] == [
+        "0",
+        "1",
+    ]
+    for component in components:
+        assert component.get("MarkingFontSize") == "10"
+        assert component.get("MarkingFontSizeFloat") == "10"
+        assert component.get("GridAlign") == "Pad"
+        refdes_silk = component.find("./RefDesMarking/Silk")
+        name_silk = component.find("./NameMarking/Silk")
+        value_silk = component.find("./ValueMarking/Silk")
+        assert refdes_silk is not None and refdes_silk.get("Align") == "Top"
+        assert name_silk is not None and name_silk.get("Align") == "Left"
+        assert value_silk is not None and value_silk.get("Align") == "Bottom"
 
 
 def test_sync_operation_is_idempotent() -> None:
@@ -127,6 +158,25 @@ def test_sync_operation_is_idempotent() -> None:
     second = apply_semantic_operations(first.document, [second_plan.operation])
     assert second.patch_count == 0
     assert second.raw_bytes == first.raw_bytes
+
+
+def test_sync_without_ratlines_hides_derived_guides() -> None:
+    schematic = _load("schematic.xml")
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    plan = build_sync_plan(
+        schematic,
+        pcb,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+        create_ratlines=False,
+    )
+
+    result = apply_semantic_operations(pcb, [plan.operation])
+    root = ET.fromstring(result.raw_bytes)
+    assert root.find("./Board/Ratlines") is None
+    assert {
+        net.get("HideRatlines") for net in root.findall("./Board/Nets/Net")
+    } == {"Y"}
 
 
 def _synced_pcb_with_extras(*, locked_extra: bool = False) -> DipTraceDocument:
@@ -178,14 +228,17 @@ def _synced_pcb_with_extras(*, locked_extra: bool = False) -> DipTraceDocument:
     extra_net = ET.SubElement(
         nets,
         "Net",
-        {"Id": "2", "NetClass": "0", "Locked": "N"},
+        {"Id": "2", "HiddenId": "2", "NetClass": "0", "Locked": "N"},
     )
     ET.SubElement(extra_net, "Name").text = "EXTRA"
     ET.SubElement(extra_net, "Pads")
     ET.SubElement(extra_net, "Traces")
 
+    board = root.find("./Board")
+    assert board is not None
     ratlines = root.find("./Board/Ratlines")
-    assert ratlines is not None
+    if ratlines is None:
+        ratlines = ET.SubElement(board, "Ratlines")
     ET.SubElement(
         ratlines,
         "Ratline",
@@ -228,7 +281,7 @@ def test_exact_sync_removes_unmatched_objects_and_changed_net_traces() -> None:
         item.findtext("./Name") for item in root.findall("./Board/Nets/Net")
     } == {"VCC", "SIGNAL"}
     assert root.findall("./Board/Nets/Net/Traces/Trace") == []
-    assert len(root.findall("./Board/Ratlines/Ratline")) == 2
+    assert root.find("./Board/Ratlines") is None
 
     second_plan = build_sync_plan(
         schematic,

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -139,6 +139,33 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         assert value_silk is not None and value_silk.get("Align") == "Bottom"
 
 
+def test_sync_bootstraps_missing_embedded_libraries() -> None:
+    schematic = _load("schematic.xml")
+    root = ET.fromstring(build_pcb_document())
+    for library in list(root.findall("./Library")):
+        root.remove(library)
+    pcb = DipTraceDocument.from_bytes(
+        Path("board.dip"), ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    )
+    plan = build_sync_plan(
+        schematic,
+        pcb,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+    )
+
+    result = apply_semantic_operations(pcb, [plan.operation])
+    result_root = ET.fromstring(result.raw_bytes)
+    component_library = result_root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert component_library is not None
+    pattern_library = component_library.find("./Library[@Type='DipTrace-PatternLibrary']")
+    assert pattern_library is not None
+    assert pattern_library.find("./PadStyles") is not None
+    assert [
+        item.get("PatternStyle") for item in pattern_library.findall("./Patterns/Pattern")
+    ] == ["PatType0", "PatType1"]
+
+
 def test_sync_operation_is_idempotent() -> None:
     schematic = _load("schematic.xml")
     pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())


### PR DESCRIPTION
## Summary

Fixes the real DipTrace 5.3.0.2 acceptance failure in `diptrace_current_pcb_roundtrip`.

The generated synchronized PCB XML previously diverged from the current DipTrace serializer contract in several related ways: the embedded pattern cache used a sibling `PatternLibrary`, copied patterns lacked dense IDs/current bookkeeping attributes, synchronized nets lacked `HiddenId`, MCP serialized a hand-built ratline cache, and newly created components omitted explicit marking placement.

This change:

- normalizes the PCB embedded pattern cache under `DipTrace-ComponentLibrary`;
- assigns dense pattern IDs and required pattern bookkeeping defaults;
- assigns `HiddenId` to synchronized nets;
- treats `Component/Pad@NetId` as authoritative connectivity and invalidates stale `<Ratlines>` after connectivity edits so DipTrace can rebuild derived guides;
- maps `create_ratlines=false` to `HideRatlines=Y` on synchronized nets;
- gives newly synchronized RefDes/Name/Value explicit non-overlapping marking positions;
- updates regression tests for the current serialized shape and idempotence.

## Acceptance evidence

Triggered by real DipTrace 5.3.0.2 import evidence showing `Ratline structure was reinitialized because of connection issue!` plus overlapping component text on commit `51ad37c4d9dec2550cccd87a625ab707c03f6f85`.

The mistaken direct `File/Open` attempt on XML bytes renamed to `.dip` is not treated as a product defect; the blocker is the real XML import path.

## Validation

Local targeted validation before push:

- `tests/test_schematic_pcb_sync.py`: 8 passed
- sync/write-path regression subset: 33 passed
- `py_compile` for changed Python files: passed

Full repository CI is intentionally delegated to this PR because the local sdist environment does not include all dev dependencies.

## Manual retest required

Do not mark the acceptance gate PASS from automated checks alone. After CI is green, Work must regenerate the representative PCB XML from this commit, import it through DipTrace 5.3.0.2 XML import, confirm there is no ratline-reinitialization warning, inspect RefDes/Name/Value placement, save, re-export XML, and record fresh evidence.
