### PR TITLE
Fix PCB ratlines and marking placement after real DipTrace roundtrip

### DIFF
--- a/src/diptrace_mcp/semantic_compiler.py
+++ b/src/diptrace_mcp/semantic_compiler.py
@@ -1373,6 +1373,134 @@ def _sync_endpoint(
     return (component.get("Id", ""), pad.get("Id", "")), pad
 
 
+def _normalize_sync_pattern_for_pcb_cache(
+    pattern: ET.Element,
+    *,
+    units: str,
+) -> None:
+    """Normalize a copied footprint to the current PCB design-cache shape."""
+    pad_id_map: dict[str, str] = {}
+    seen_numbers: set[str] = set()
+    for pad_index, pad in enumerate(pattern.findall("./Pads/Pad"), start=1):
+        old_id = pad.get("Id", "")
+        new_id = str(pad_index)
+        if old_id:
+            pad_id_map[old_id] = new_id
+        pad.set("Id", new_id)
+        number = (pad.findtext("./Number") or "").strip()
+        if not number:
+            raise EditError("Schematic sync pattern pad has no Number")
+        key = number.casefold()
+        if key in seen_numbers:
+            raise EditError(
+                f"Schematic sync pattern has duplicate pad number: {number}"
+            )
+        seen_numbers.add(key)
+    for shape in pattern.findall("./Shapes/Shape"):
+        old_pad_id = shape.get("PadId")
+        if old_pad_id is not None and old_pad_id in pad_id_map:
+            shape.set("PadId", pad_id_map[old_pad_id])
+
+    model = pattern.find("./Model3D")
+    if model is None:
+        return
+    for attribute, default in (
+        ("Mirror", "N"),
+        ("NoSearch", "N"),
+        ("Units", units),
+        ("IPC_XOff", "0"),
+        ("IPC_YOff", "0"),
+        ("AutoHeight", "0"),
+        ("AutoColor", "0"),
+        ("Type", "File"),
+        ("KeepPins", "N"),
+    ):
+        model.attrib.setdefault(attribute, default)
+    filename = model.find("./Filename")
+    if filename is not None:
+        legacy_filename = (filename.text or "").strip()
+        filename_path = filename.find("./Path")
+        filename_var = filename.find("./Var")
+        if filename_path is None and legacy_filename:
+            filename.text = None
+            filename_path = ET.SubElement(filename, "Path")
+            filename_path.text = legacy_filename
+        if filename_var is None:
+            ET.SubElement(filename, "Var")
+    for tag, default in (("Rotate", "0"), ("Offset", "0"), ("Zoom", "1")):
+        transform = model.find(f"./{tag}")
+        if transform is None:
+            transform = ET.SubElement(model, tag)
+        for axis in ("X", "Y", "Z"):
+            transform.attrib.setdefault(axis, default)
+
+
+def _sync_pattern_pad_ids(pattern: ET.Element) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for pad in pattern.findall("./Pads/Pad"):
+        number = (pad.findtext("./Number") or "").strip()
+        pad_id = (pad.get("Id") or "").strip()
+        if not number or not pad_id:
+            continue
+        key = number.casefold()
+        if key in result:
+            raise EditError(f"Embedded pattern has duplicate pad number: {number}")
+        result[key] = pad_id
+    return result
+
+
+def _append_sync_component_markings(
+    component: ET.Element,
+    pattern: ET.Element,
+    *,
+    units: str,
+) -> None:
+    try:
+        pattern_height = abs(float(pattern.get("Height", "0")))
+    except ValueError:
+        pattern_height = 0.0
+    gap = from_mm(0.7, units)
+    line_step = from_mm(1.5, units)
+    base_offset = max(pattern_height / 2.0 + gap, line_step)
+    positions = {
+        "RefDesMarking": -base_offset,
+        "NameMarking": base_offset,
+        "ValueMarking": base_offset + line_step,
+    }
+    for tag, y in positions.items():
+        marking = ET.SubElement(component, tag)
+        for surface in ("Silk", "Assy"):
+            ET.SubElement(
+                marking,
+                surface,
+                {
+                    "Show": "Show",
+                    "Align": "Position",
+                    "Horz": "Center",
+                    "Vert": "Center",
+                    "X": "0",
+                    "Y": f"{y:.9g}",
+                    "Angle": "0",
+                },
+            )
+    for tag in ("PatternMarking", "ManufacturerMarking", "DatasheetMarking"):
+        marking = ET.SubElement(component, tag)
+        for surface in ("Silk", "Assy"):
+            ET.SubElement(
+                marking,
+                surface,
+                {
+                    "Show": "Hide",
+                    "Align": "Position",
+                    "Horz": "Center",
+                    "Vert": "Center",
+                    "X": "0",
+                    "Y": "0",
+                    "Angle": "0",
+                },
+            )
+
+
 def _apply_sync_schematic_to_pcb(
     index: int,
     document: DipTraceDocument,
@@ -1493,9 +1621,19 @@ def _apply_sync_schematic_to_pcb(
                 ("Int2", "0"),
             ):
                 element.attrib.setdefault(attribute, default)
+            _normalize_sync_pattern_for_pcb_cache(element, units=document.units)
             patterns.append(element)
             existing_pattern_styles.add(key)
             patch_count += 1
+
+    pattern_by_style = {
+        (item.get("PatternStyle") or item.get("Style") or "").casefold(): item
+        for item in patterns.findall("./Pattern")
+        if item.get("PatternStyle") or item.get("Style")
+    }
+    pattern_pad_ids_by_style = {
+        key: _sync_pattern_pad_ids(item) for key, item in pattern_by_style.items()
+    }
 
     components = document.container.find("./Components")
     if components is None:
@@ -1546,35 +1684,31 @@ def _apply_sync_schematic_to_pcb(
             ET.SubElement(target_component, "RefDes").text = spec.refdes
             ET.SubElement(target_component, "Name").text = spec.name
             ET.SubElement(target_component, "Value").text = spec.value
-            for tag, align in (
-                ("RefDesMarking", "Top"),
-                ("NameMarking", "Left"),
-                ("ValueMarking", "Bottom"),
-            ):
-                marking = ET.SubElement(target_component, tag)
-                for surface in ("Silk", "Assy"):
-                    ET.SubElement(
-                        marking,
-                        surface,
-                        {
-                            "Show": "Show",
-                            "Align": align,
-                            "Horz": "Center",
-                            "Vert": "Center",
-                            "X": "0",
-                            "Y": "0",
-                            "Angle": "0",
-                        },
-                    )
+            component_pattern = pattern_by_style.get(spec.pattern_style.casefold())
+            if component_pattern is None:
+                raise EditError(
+                    "Embedded pattern was not found for synchronized component: "
+                    f"{spec.pattern_style}"
+                )
+            _append_sync_component_markings(
+                target_component,
+                component_pattern,
+                units=document.units,
+            )
             _, field_patches = _set_additional_fields(target_component, spec.fields)
             component_pads = ET.SubElement(target_component, "Pads")
-            for pad_index, number in enumerate(spec.pad_numbers):
+            pattern_pad_ids = pattern_pad_ids_by_style.get(spec.pattern_style.casefold(), {})
+            for number in spec.pad_numbers:
+                pad_id = pattern_pad_ids.get(number.casefold())
+                if pad_id is None:
+                    raise EditError(
+                        f"Embedded pattern {spec.pattern_style!r} lacks mapped pad {number!r}"
+                    )
                 ET.SubElement(
                     component_pads,
                     "Pad",
                     {
-                        "Id": str(pad_index),
-                        "Number": number,
+                        "Id": pad_id,
                         "NetId": "-1",
                         "InternalConnection": "-1",
                     },
@@ -1817,6 +1951,10 @@ def _apply_sync_schematic_to_pcb(
                 },
             )
             next_hidden_net_id += 1
+            if operation.create_ratlines:
+                sync_net.set("RouteMode", "Ratlines")
+            else:
+                sync_net.set("HideRatlines", "Y")
             ET.SubElement(sync_net, "Name").text = net_spec.name
             ET.SubElement(sync_net, "Pads")
             ET.SubElement(sync_net, "Traces")
@@ -1836,7 +1974,16 @@ def _apply_sync_schematic_to_pcb(
             next_hidden_net_id += 1
             patch_count += 1
             net_changed = True
-        if not operation.create_ratlines and sync_net.get("HideRatlines") != "Y":
+        if operation.create_ratlines:
+            if sync_net.get("RouteMode") != "Ratlines":
+                sync_net.set("RouteMode", "Ratlines")
+                patch_count += 1
+                net_changed = True
+            if sync_net.get("HideRatlines") is not None:
+                sync_net.attrib.pop("HideRatlines", None)
+                patch_count += 1
+                net_changed = True
+        elif sync_net.get("HideRatlines") != "Y":
             sync_net.set("HideRatlines", "Y")
             patch_count += 1
             net_changed = True

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -10,7 +10,12 @@ from diptrace_mcp.config import Settings
 from diptrace_mcp.errors import EditError, LockedObjectError
 from diptrace_mcp.operations import SyncSchematicToPcbOperation
 from diptrace_mcp.scaffolding import build_pcb_document
-from diptrace_mcp.semantic_compiler import apply_semantic_operations
+from diptrace_mcp.semantic_compiler import (
+    _append_sync_component_markings,
+    _normalize_sync_pattern_for_pcb_cache,
+    _sync_pattern_pad_ids,
+    apply_semantic_operations,
+)
 from diptrace_mcp.service import DipTraceService
 from diptrace_mcp.synchronization import ComponentSyncMapping, build_sync_plan
 from diptrace_mcp.xml_document import DipTraceDocument
@@ -505,3 +510,59 @@ def test_sync_service_produces_guarded_transaction_preview(tmp_path: Path) -> No
     txid = response["transaction"]["txid"]
     assert "<Component" in service.transactions.diff_path(txid).read_text(encoding="utf-8")
     assert pcb_path.read_bytes() == build_pcb_document()
+
+
+
+def test_sync_pattern_cache_normalization_edge_cases() -> None:
+    missing_number = ET.fromstring(
+        '<Pattern><Pads><Pad Id="0" /></Pads></Pattern>'
+    )
+    with pytest.raises(EditError, match="pattern pad has no Number"):
+        _normalize_sync_pattern_for_pcb_cache(missing_number, units="mm")
+
+    duplicate_number = ET.fromstring(
+        '<Pattern><Pads>'
+        '<Pad Id="0"><Number>1</Number></Pad>'
+        '<Pad Id="1"><Number>1</Number></Pad>'
+        '</Pads></Pattern>'
+    )
+    with pytest.raises(EditError, match="duplicate pad number"):
+        _normalize_sync_pattern_for_pcb_cache(duplicate_number, units="mm")
+
+    legacy = ET.fromstring(
+        '<Pattern Height="not-a-number">'
+        '<Pads><Pad Id="0"><Number>1</Number></Pad></Pads>'
+        '<Shapes><Shape PadId="0" /></Shapes>'
+        '<Model3D><Filename><Path>fixture.step</Path><Var /></Filename></Model3D>'
+        '</Pattern>'
+    )
+    _normalize_sync_pattern_for_pcb_cache(legacy, units="mm")
+    shape = legacy.find("./Shapes/Shape")
+    assert shape is not None and shape.get("PadId") == "1"
+    for tag in ("Rotate", "Offset", "Zoom"):
+        transform = legacy.find(f"./Model3D/{tag}")
+        assert transform is not None
+        assert set(transform.attrib) == {"X", "Y", "Z"}
+
+    component = ET.Element("Component")
+    _append_sync_component_markings(component, legacy, units="mm")
+    refdes = component.find("./RefDesMarking/Silk")
+    assert refdes is not None
+    assert float(refdes.get("Y", "0")) < 0
+
+    incomplete = ET.fromstring(
+        '<Pattern><Pads>'
+        '<Pad Id="1" />'
+        '<Pad Id="2"><Number>2</Number></Pad>'
+        '</Pads></Pattern>'
+    )
+    assert _sync_pattern_pad_ids(incomplete) == {"2": "2"}
+
+    duplicate_map = ET.fromstring(
+        '<Pattern><Pads>'
+        '<Pad Id="1"><Number>1</Number></Pad>'
+        '<Pad Id="2"><Number>1</Number></Pad>'
+        '</Pads></Pattern>'
+    )
+    with pytest.raises(EditError, match="duplicate pad number"):
+        _sync_pattern_pad_ids(duplicate_map)

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -106,8 +106,8 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         for net in root.findall("./Board/Nets/Net")
     }
     assert nets == {
-        "VCC": {("0", "0"), ("1", "0")},
-        "SIGNAL": {("0", "1"), ("1", "1")},
+        "VCC": {("0", "1"), ("1", "1")},
+        "SIGNAL": {("0", "2"), ("1", "2")},
     }
     assert {
         (component.get("Id"), pad.get("Id")): (
@@ -117,10 +117,10 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         for component in components
         for pad in component.findall("./Pads/Pad")
     } == {
-        ("0", "0"): ("0", "-1"),
-        ("0", "1"): ("1", "-1"),
-        ("1", "0"): ("0", "-1"),
-        ("1", "1"): ("1", "-1"),
+        ("0", "1"): ("0", "-1"),
+        ("0", "2"): ("1", "-1"),
+        ("1", "1"): ("0", "-1"),
+        ("1", "2"): ("1", "-1"),
     }
     assert root.find("./Board/Ratlines") is None
     assert [net.get("HiddenId") for net in root.findall("./Board/Nets/Net")] == [
@@ -134,9 +134,89 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         refdes_silk = component.find("./RefDesMarking/Silk")
         name_silk = component.find("./NameMarking/Silk")
         value_silk = component.find("./ValueMarking/Silk")
-        assert refdes_silk is not None and refdes_silk.get("Align") == "Top"
-        assert name_silk is not None and name_silk.get("Align") == "Left"
-        assert value_silk is not None and value_silk.get("Align") == "Bottom"
+        assert refdes_silk is not None and refdes_silk.get("Align") == "Position"
+        assert name_silk is not None and name_silk.get("Align") == "Position"
+        assert value_silk is not None and value_silk.get("Align") == "Position"
+
+
+def test_sync_emits_native_pad_ids_ratline_mode_and_marking_positions() -> None:
+    schematic = _load("schematic.xml")
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    plan = build_sync_plan(
+        schematic,
+        pcb,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+    )
+    result = apply_semantic_operations(pcb, [plan.operation])
+    root = ET.fromstring(result.raw_bytes)
+    patterns = {
+        pattern.get("PatternStyle"): pattern
+        for pattern in root.findall(
+            "./Library[@Type='DipTrace-ComponentLibrary']/"
+            "Library[@Type='DipTrace-PatternLibrary']/Patterns/Pattern"
+        )
+    }
+    assert [pad.get("Id") for pad in patterns["PatType0"].findall("./Pads/Pad")] == [
+        "1",
+        "2",
+    ]
+    assert [pad.get("Id") for pad in patterns["PatType1"].findall("./Pads/Pad")] == [
+        "1",
+        "2",
+    ]
+    components = root.findall("./Board/Components/Component")
+    assert [
+        [pad.get("Id") for pad in component.findall("./Pads/Pad")]
+        for component in components
+    ] == [["1", "2"], ["1", "2"]]
+    assert all(
+        pad.get("Number") is None
+        for component in components
+        for pad in component.findall("./Pads/Pad")
+    )
+    assert {net.get("RouteMode") for net in root.findall("./Board/Nets/Net")} == {
+        "Ratlines"
+    }
+    for component in components:
+        refdes = component.find("./RefDesMarking/Silk")
+        name = component.find("./NameMarking/Silk")
+        value = component.find("./ValueMarking/Silk")
+        assert refdes is not None and refdes.get("Align") == "Position"
+        assert name is not None and name.get("Align") == "Position"
+        assert value is not None and value.get("Align") == "Position"
+        assert float(refdes.get("Y", "0")) < 0
+        assert float(name.get("Y", "0")) > 0
+        assert float(value.get("Y", "0")) > float(name.get("Y", "0"))
+        for tag in ("PatternMarking", "ManufacturerMarking", "DatasheetMarking"):
+            extra = component.find(f"./{tag}/Silk")
+            assert extra is not None and extra.get("Show") == "Hide"
+
+
+def test_sync_normalizes_legacy_model3d_filename_for_current_diptrace() -> None:
+    schematic = _load("schematic.xml")
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    plan = build_sync_plan(
+        schematic,
+        pcb,
+        mappings=_mapping(),
+        pattern_documents=[_load("pattern_library.xml")],
+    )
+    result = apply_semantic_operations(pcb, [plan.operation])
+    root = ET.fromstring(result.raw_bytes)
+    pattern = root.find(
+        "./Library[@Type='DipTrace-ComponentLibrary']/"
+        "Library[@Type='DipTrace-PatternLibrary']/Patterns/"
+        "Pattern[@PatternStyle='PatType1']"
+    )
+    assert pattern is not None
+    model = pattern.find("./Model3D")
+    assert model is not None
+    assert model.get("Type") == "File"
+    assert model.get("Units") == result.document.units
+    assert model.findtext("./Filename/Path") == "hdr_1x02.step"
+    assert model.find("./Filename/Var") is not None
+
 
 
 def test_sync_bootstraps_missing_embedded_libraries() -> None:


### PR DESCRIPTION
Real DipTrace 5.3 manual acceptance of `diptrace_current_pcb_roundtrip` on main `0109cfaf65c38d477d34df1a017dd5b550e3fb03` confirmed two blockers after the first roundtrip fix:

- connectivity survives in `Pad@NetId`, but expected ratlines are not shown even with Objects -> Ratlines enabled;
- RefDes/Name/Value markings remain overlapped or unacceptably cluttered through native `.dip` save/reopen.

The diagnostic `.dip -> .dipxml` roundtrip also showed current DipTrace canonicalizes footprint/component pad IDs to 1-based IDs and drops a legacy plain-text Model3D filename representation.

This change:

- normalizes synchronized pattern pad IDs to the native 1-based design-cache shape and maps component pad references to them;
- requests ratline routing with `Net@RouteMode="Ratlines"` while continuing to avoid hand-authoring the derived `<Ratlines>` cache;
- emits Position-based RefDes/Name/Value markings with explicit separated offsets and hides unused marking classes to avoid Common/default clutter;
- normalizes legacy Model3D `<Filename>file.step</Filename>` into the current nested filename structure;
- adds targeted regression coverage.

`FuturePatternData` from the synthetic fixture is intentionally not treated as a DipTrace-supported field; its removal by native DipTrace save remains canonicalization evidence rather than something this patch attempts to preserve through DipTrace itself.

The bootstrap validation before the clean commit passed Ruff, strict Mypy, targeted schematic/PCB sync tests, and format-coverage generation. Full PR CI must still pass before merge.

Manual acceptance must be repeated in real DipTrace after merge; this PR does not mark the gate PASS.