### PR TITLE
Serialize readable native PCB ratlines for DipTrace open

### DIFF
--- a/src/diptrace_mcp/semantic_compiler.py
+++ b/src/diptrace_mcp/semantic_compiler.py
@@ -1501,6 +1501,161 @@ def _append_sync_component_markings(
             )
 
 
+
+def _sync_ratline_cache(
+    document: DipTraceDocument,
+    snapshot: DocumentSnapshot,
+    *,
+    create_ratlines: bool,
+) -> int:
+    """Serialize the native ratline cache needed by DipTrace whole-file XML open."""
+    container = document.container
+    existing = container.find("./Ratlines")
+    existing_rows = (
+        [dict(item.attrib) for item in existing.findall("./Ratline")]
+        if existing is not None
+        else []
+    )
+    desired: list[dict[str, str]] = []
+
+    if create_ratlines:
+        component_xml_by_stable = {
+            record.stable_id: record.xml_id
+            for record in snapshot.objects.values()
+            if record.kind in {"component", "testpoint"} and record.xml_id
+        }
+        endpoint_positions: dict[tuple[str, str], tuple[float, float]] = {}
+        for record in snapshot.objects.values():
+            if (
+                record.kind != "pad"
+                or record.position is None
+                or record.parent_id is None
+                or record.xml_id is None
+            ):
+                continue
+            parent_component_id: str | None = component_xml_by_stable.get(record.parent_id)
+            if parent_component_id is None:
+                continue
+            endpoint_positions[(parent_component_id, record.xml_id)] = (
+                from_mm(float(record.position["x"]), document.units),
+                from_mm(float(record.position["y"]), document.units),
+            )
+
+        nets = list(container.findall("./Nets/Net"))
+        endpoint_net: dict[tuple[str, str], str] = {}
+        traced_net_ids: set[str] = set()
+        for net in nets:
+            net_id = net.get("Id", "")
+            if net.findall("./Traces/Trace"):
+                traced_net_ids.add(net_id)
+            for item in net.findall("./Pads/Item"):
+                endpoint_net[(item.get("Comp", ""), item.get("Pad", ""))] = net_id
+
+        def append_ratline(
+            endpoint1: tuple[str, str],
+            endpoint2: tuple[str, str],
+            *,
+            hidden: str = "N",
+        ) -> None:
+            point1 = endpoint_positions.get(endpoint1)
+            point2 = endpoint_positions.get(endpoint2)
+            if point1 is None or point2 is None:
+                return
+            desired.append(
+                {
+                    "Id": str(len(desired)),
+                    "Hidden": hidden,
+                    "X1": f"{point1[0]:.9g}",
+                    "Y1": f"{point1[1]:.9g}",
+                    "X2": f"{point2[0]:.9g}",
+                    "Y2": f"{point2[1]:.9g}",
+                    "Comp1": endpoint1[0],
+                    "Pad1": endpoint1[1],
+                    "Comp2": endpoint2[0],
+                    "Pad2": endpoint2[1],
+                }
+            )
+
+        # Preserve valid cache edges for nets that already contain traces. For an
+        # unrouted net, rebuild a deterministic minimum spanning tree from current
+        # pad positions so stale connectivity cannot survive a sync edit.
+        for row in existing_rows:
+            endpoint1 = (row.get("Comp1", ""), row.get("Pad1", ""))
+            endpoint2 = (row.get("Comp2", ""), row.get("Pad2", ""))
+            cached_net_id: str | None = endpoint_net.get(endpoint1)
+            if (
+                cached_net_id
+                and cached_net_id == endpoint_net.get(endpoint2)
+                and cached_net_id in traced_net_ids
+            ):
+                append_ratline(endpoint1, endpoint2, hidden=row.get("Hidden", "N"))
+
+        for net in nets:
+            if net.get("HideRatlines") == "Y" or net.findall("./Traces/Trace"):
+                continue
+            endpoints = [
+                (item.get("Comp", ""), item.get("Pad", ""))
+                for item in net.findall("./Pads/Item")
+            ]
+            endpoints = [item for item in endpoints if item in endpoint_positions]
+            if len(endpoints) < 2:
+                continue
+
+            connected = {0}
+            remaining = set(range(1, len(endpoints)))
+            while remaining:
+                candidates: list[
+                    tuple[
+                        float,
+                        tuple[str, str],
+                        tuple[str, str],
+                        int,
+                        int,
+                    ]
+                ] = []
+                for left in connected:
+                    x1, y1 = endpoint_positions[endpoints[left]]
+                    for right in remaining:
+                        x2, y2 = endpoint_positions[endpoints[right]]
+                        distance_sq = (x2 - x1) ** 2 + (y2 - y1) ** 2
+                        candidates.append(
+                            (
+                                distance_sq,
+                                endpoints[left],
+                                endpoints[right],
+                                left,
+                                right,
+                            )
+                        )
+                _distance, _left_key, _right_key, left, right = min(candidates)
+                append_ratline(endpoints[left], endpoints[right])
+                connected.add(right)
+                remaining.remove(right)
+
+    nets_container = container.find("./Nets")
+    order_is_native = True
+    if existing is not None and nets_container is not None:
+        children = list(container)
+        order_is_native = children.index(existing) < children.index(nets_container)
+    if desired and existing is not None and existing_rows == desired and order_is_native:
+        return 0
+
+    patches = 0
+    if existing is not None:
+        container.remove(existing)
+        patches += 1
+    if desired:
+        ratlines = ET.Element("Ratlines")
+        for attributes in desired:
+            ET.SubElement(ratlines, "Ratline", attributes)
+        if nets_container is None:
+            container.append(ratlines)
+        else:
+            container.insert(list(container).index(nets_container), ratlines)
+        patches += 1
+    return patches
+
+
 def _apply_sync_schematic_to_pcb(
     index: int,
     document: DipTraceDocument,
@@ -1657,12 +1812,67 @@ def _apply_sync_schematic_to_pcb(
     next_update_id = max(update_ids, default=99) + 1
     component_by_refdes: dict[str, ET.Element] = {}
 
+    # Keep simple multi-net two-pin relationships human-readable. When two
+    # synchronized two-pin parts are placed on the same row/column and share
+    # two or more distinct nets, leaving both at the same orientation can make
+    # their ratlines collinear and visually indistinguishable. Rotate the later
+    # newly-created part by 90 degrees relative to the earlier one. Existing PCB
+    # component orientation is never changed by this heuristic.
+    component_order = {
+        item.refdes.casefold(): index for index, item in enumerate(operation.components)
+    }
+    component_spec_by_refdes = {
+        item.refdes.casefold(): item for item in operation.components
+    }
+    two_pin_refdes = {
+        key
+        for key, item in component_spec_by_refdes.items()
+        if len(item.pad_numbers) == 2
+    }
+    direct_pair_net_counts: dict[tuple[str, str], int] = {}
+    for net in operation.nets:
+        refs = sorted(
+            {
+                endpoint.refdes.casefold()
+                for endpoint in net.endpoints
+                if endpoint.refdes.casefold() in two_pin_refdes
+            }
+        )
+        if len(refs) != 2:
+            continue
+        pair = (refs[0], refs[1])
+        direct_pair_net_counts[pair] = direct_pair_net_counts.get(pair, 0) + 1
+
+    readability_partner_by_refdes: dict[str, str] = {}
+    for pair, shared_net_count in sorted(direct_pair_net_counts.items()):
+        if shared_net_count < 2:
+            continue
+        first_spec = component_spec_by_refdes[pair[0]]
+        second_spec = component_spec_by_refdes[pair[1]]
+        same_row = math.isclose(first_spec.y, second_spec.y, abs_tol=1e-9)
+        same_column = math.isclose(first_spec.x, second_spec.x, abs_tol=1e-9)
+        if not (same_row or same_column):
+            continue
+        earlier, later = sorted(pair, key=lambda key: component_order[key])
+        readability_partner_by_refdes.setdefault(later, earlier)
+
     for spec in operation.components:
         key = spec.refdes.casefold()
         target_component = existing_components.get(key)
         if target_component is None:
             component_id = str(next_component_id)
             next_component_id += 1
+            readability_angle_rad: float | None = None
+            readability_partner = readability_partner_by_refdes.get(key)
+            if readability_partner is not None:
+                partner_component = component_by_refdes.get(readability_partner)
+                if partner_component is not None:
+                    try:
+                        partner_angle_rad = float(partner_component.get("Angle", "0") or "0")
+                    except ValueError:
+                        partner_angle_rad = 0.0
+                    readability_angle_rad = (partner_angle_rad + math.pi / 2.0) % (2.0 * math.pi)
+
             target_component = ET.SubElement(
                 components,
                 "Component",
@@ -1680,6 +1890,10 @@ def _apply_sync_schematic_to_pcb(
                     "Selected": "N",
                 },
             )
+            if readability_angle_rad is not None and not math.isclose(
+                readability_angle_rad, 0.0, abs_tol=1e-12
+            ):
+                target_component.set("Angle", f"{readability_angle_rad:.12g}")
             next_update_id += 1
             ET.SubElement(target_component, "RefDes").text = spec.refdes
             ET.SubElement(target_component, "Name").text = spec.name
@@ -2070,16 +2284,20 @@ def _apply_sync_schematic_to_pcb(
                 pad.set("InternalConnection", "-1")
                 patch_count += 1
 
-    # Ratlines are a derived DipTrace cache. Pad@NetId is authoritative; keeping
-    # hand-authored ratlines after a connectivity edit can make DipTrace reject the
-    # cache and show a reinitialization warning. Drop it and let DipTrace rebuild.
-    if connectivity_mutated:
-        ratlines = document.container.find("./Ratlines")
-        if ratlines is not None:
-            document.container.remove(ratlines)
-            patch_count += 1
-
+    # Real DipTrace 5.3 native File -> Open does not regenerate a missing
+    # whole-file Ratlines cache from otherwise-correct Pad@NetId membership. Build
+    # the cache from the final semantic state while keeping Pad@NetId authoritative.
     final_snapshot = build_snapshot(document)
+    if (
+        connectivity_mutated
+        or operation.create_ratlines
+        or document.container.find("./Ratlines") is not None
+    ):
+        patch_count += _sync_ratline_cache(
+            document,
+            final_snapshot,
+            create_ratlines=operation.create_ratlines,
+        )
     targets = [
         final_snapshot.objects[stable]
         for stable in dict.fromkeys(changed_ids)

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import shutil
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -127,7 +128,21 @@ def test_sync_populates_empty_pcb_and_copies_patterns() -> None:
         ("1", "1"): ("0", "-1"),
         ("1", "2"): ("1", "-1"),
     }
-    assert root.find("./Board/Ratlines") is None
+    ratlines = root.findall("./Board/Ratlines/Ratline")
+    assert len(ratlines) == 2
+    assert {
+        (item.get("Comp1"), item.get("Pad1"), item.get("Comp2"), item.get("Pad2"))
+        for item in ratlines
+    } == {
+        ("0", "1", "1", "1"),
+        ("0", "2", "1", "2"),
+    }
+    assert all(item.get("Hidden") == "N" for item in ratlines)
+    assert all(
+        item.get(axis) is not None
+        for item in ratlines
+        for axis in ("X1", "Y1", "X2", "Y2")
+    )
     assert [net.get("HiddenId") for net in root.findall("./Board/Nets/Net")] == [
         "0",
         "1",
@@ -183,6 +198,31 @@ def test_sync_emits_native_pad_ids_ratline_mode_and_marking_positions() -> None:
     assert {net.get("RouteMode") for net in root.findall("./Board/Nets/Net")} == {
         "Ratlines"
     }
+    board = root.find("./Board")
+    assert board is not None
+    child_tags = [child.tag for child in board]
+    assert child_tags.index("Ratlines") < child_tags.index("Nets")
+    ratlines = root.findall("./Board/Ratlines/Ratline")
+    assert len(ratlines) == 2
+    assert [item.get("Id") for item in ratlines] == ["0", "1"]
+    components_by_refdes = {
+        component.findtext("./RefDes"): component for component in components
+    }
+    assert components_by_refdes["R1"].get("Angle") is None
+    assert math.isclose(
+        float(components_by_refdes["U1"].get("Angle", "0")),
+        math.pi / 2.0,
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    )
+    vectors = [
+        (
+            float(item.get("X2", "0")) - float(item.get("X1", "0")),
+            float(item.get("Y2", "0")) - float(item.get("Y1", "0")),
+        )
+        for item in ratlines
+    ]
+    assert abs(vectors[0][0] * vectors[1][1] - vectors[0][1] * vectors[1][0]) > 1e-6
     for component in components:
         refdes = component.find("./RefDesMarking/Silk")
         name = component.find("./NameMarking/Silk")
@@ -434,7 +474,7 @@ def test_exact_sync_removes_unmatched_objects_and_changed_net_traces() -> None:
         item.findtext("./Name") for item in root.findall("./Board/Nets/Net")
     } == {"VCC", "SIGNAL"}
     assert root.findall("./Board/Nets/Net/Traces/Trace") == []
-    assert root.find("./Board/Ratlines") is None
+    assert len(root.findall("./Board/Ratlines/Ratline")) == 2
 
     second_plan = build_sync_plan(
         schematic,


### PR DESCRIPTION
Real DipTrace 5.3 manual acceptance of `diptrace_ratline_and_wire_roundtrip` reproduced two native-open usability defects on `main` `b9966f63e8ba3f3cc227dcff18f2de826043ecb7`:

1. Two nets had correct `Pad@NetId`, `Net/Pads`, and `RouteMode="Ratlines"`, but `File -> Open` showed no ratlines. A minimal diagnostic that inserted only a coherent `<Ratlines>` cache made both lines appear immediately, localizing this to whole-file native XML serialization.
2. With both two-pin parts placed on the same row and orientation, the two correct ratlines were collinear enough to look like one line to a human operator. Rotating the second part by 90° made both connections visually obvious.

This change:

- serializes a fresh native `<Ratlines>` cache for visible, fully unrouted synchronized nets when `create_ratlines=true`;
- derives endpoint coordinates from the final semantic snapshot, including component transforms;
- emits a deterministic minimum spanning tree for multi-pad unrouted nets;
- keeps `Pad@NetId` / `Net/Pads` authoritative;
- preserves only still-valid existing cache edges on nets that already contain traces instead of inventing guide geometry over routed nets;
- removes the cache when `create_ratlines=false` while retaining `HideRatlines=Y` behavior;
- places `<Ratlines>` before `<Nets>` in the native board shape;
- for the narrow readability case where two synchronized two-pin parts are center-aligned on one row/column and share at least two distinct nets, rotates the later newly-created part by +90° relative to the earlier one so the connections do not visually collapse onto each other;
- never changes the orientation of an already-existing PCB component through that readability heuristic;
- adds regression coverage for ratline endpoint IDs, coordinates, ordering, exact reconciliation, disabled ratlines, 90° readability orientation, and non-collinear guide geometry.

No public MCP tool/service contract changes are intended.

Targeted validation on the final tree passed Ruff, strict Mypy, and the complete `tests/test_schematic_pcb_sync.py` suite. Full repository CI must pass before merge. After merge, manual acceptance should resume only `diptrace_ratline_and_wire_roundtrip`: PCB Part A first, then schematic Part B if Part A passes.