### PR TITLE
Add intelligent schematic layout foundation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ That commit includes the post-PR #65/#66 Ponytail pass (PR #68). Later documenta
 
 The durable recovery record is [MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md](MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md), updated on 2026-08-10. Resume from that checkpoint instead of repeating already accepted gates.
 
+A new product-development track also starts at this checkpoint: **intelligent schematic and PCB design quality**. Formal acceptance remains paused at its existing resume point while the project first proves that it can produce schematics that are not only electrically correct, but compact, readable, intentionally structured and comparable in presentation quality to strong professional reference designs. The schematic track comes first because its geometry is primarily a readability/layout problem; the PCB track follows after the same generate/score/improve architecture is established.
+
 ## Completed real-host / real-client acceptance
 
 The following blocking manual gates are complete:
@@ -81,26 +83,75 @@ The next formal gate remains:
 
 It is **PENDING** and has not been run.
 
-The formal campaign is intentionally paused before that gate. Before spending more time on client/installer lifecycle checks, the project will validate the core product behavior more aggressively: can the current MCP author a normal, readable, useful schematic in real DipTrace?
+The formal campaign is intentionally paused before that gate. Before spending more time on client/installer lifecycle checks, the project will validate and improve the core product behavior: can the current MCP author a normal, readable, useful schematic in real DipTrace, and can it evolve from bounded authoring into an intentional schematic-layout engine?
 
 This pause does not cancel or waive the remaining formal gates.
 
-## Immediate priority — real-world schematic authoring/readability
+## New development track — intelligent schematic and PCB design
+
+### Product goal
+
+The project should progress from "can safely create/edit EDA objects" to "can make defensible engineering-layout decisions". The target is not blind imitation of one vendor style or rigid enforcement of every possible electronics drafting convention. The target is a schematic/PCB that an experienced engineer can open and understand quickly, with sensible grouping, orientation, flow, density and routing decisions.
+
+Reference schematics and layout examples from component datasheets should be treated as **high-value design motifs**, not absolute coordinate templates. The engine should preserve the intent of a reference design — which parts belong together, relative order, orientation, local signal flow, important adjacency and recognizable topology — while adapting that motif to the rest of the actual project.
+
+The long-term architecture is deliberately staged:
+
+```text
+reference / datasheet intent
+          +
+project connectivity and constraints
+          |
+          v
+candidate placement
+          |
+          v
+candidate interconnect routing
+          |
+          v
+quality scoring
+          |
+          +----> placement feedback / local repair
+          |
+          v
+transaction preview -> guarded apply -> review
+```
+
+The same generate -> score -> improve loop should be reusable for PCB work later, where physical/electrical constraints become much stronger.
+
+### Design principles
+
+- Prefer human readability and recognizable functional structure over merely minimizing total geometric wire length.
+- Keep functional blocks compact, but penalize needless schematic-area expansion so the result does not become an oversized empty canvas.
+- Prefer conventional visual flow where it helps understanding: inputs toward outputs, signal flow predominantly left-to-right, supply hierarchy and returns placed consistently, without treating these conventions as hard laws when they make the actual circuit worse.
+- Preserve useful local reference-design structure from datasheets instead of scattering a component's support network across the sheet.
+- Allow placement and wire routing to influence each other. Wiring is not a final cosmetic pass if a small component move can remove pathological crossings, detours or unreadable topology.
+- Prefer deterministic, explainable scoring first. ML remains optional future work and must not be required for the first useful implementation.
+- Do not optimize for "looks standardized" at the expense of engineering clarity. A clean, obvious circuit is more important than ceremonial compliance with drafting conventions that add no value.
+- Every automatic edit remains inside the existing preview/SHA/transaction/review safety model.
+
+## Schematic track — start here
+
+### Phase 26 — real-world readability baseline and benchmark fixtures
+
+**Status: active checkpoint / first task.**
 
 PR #66 added deterministic bounded readability routing for newly authored schematic wires. Its automated goals include component avoidance, text/label avoidance, crossing and overlap avoidance, Manhattan routing, self-intersection avoidance and fewer unnecessary bends. The subsequent Ponytail pass may have modified adjacent behavior.
 
 The historical `diptrace_ratline_and_wire_roundtrip` PASS remains valid for its original scope. It proves wire connectivity and native round-trip behavior, but it does **not** prove that higher-level current schematic authoring consistently produces a schematic a human would consider clean and usable.
 
-The next validation campaign should therefore build small real circuits from a clean starting point and inspect the actual authored result in DipTrace. Suggested cases:
+Build small real circuits from clean starting points and preserve them as regression/quality cases where licensing and provenance allow. Suggested cases:
 
 - resistor divider;
 - LED + resistor;
 - divider + capacitor / simple RC network;
+- LDO or small DC/DC support network;
+- MCU power/decoupling fragment;
 - a deliberately collision-prone layout;
 - RefDes/Value/net-label-near-wire cases;
-- at least one small multi-net schematic.
+- at least one small multi-block, multi-net schematic.
 
-Validate:
+Validate and begin measuring:
 
 - correct components, pins, values and net connectivity;
 - sensible component placement and orientation;
@@ -110,14 +161,149 @@ Validate:
 - no wire covering RefDes, Value or net labels;
 - obvious junction intent;
 - no extreme detours or needless bends;
+- occupied sheet area / bounding-box compactness;
+- functional-group compactness;
+- rough left-to-right signal-flow consistency;
 - native open/save/reopen/re-export preservation;
 - whether the schematic is useful without routine manual cleanup.
 
-A reproducible quality problem found here should become a focused regression case and, if necessary, a separate repair. This stronger product-quality validation must not rewrite historical PASS evidence.
+A reproducible quality problem found here becomes a focused regression case and input to the next phases. Historical PASS evidence is not rewritten.
+
+### Phase 27 — schematic intent and reference-motif model
+
+**Goal:** represent why parts belong together before trying to place them.
+
+Add an internal schematic design-intent layer that can describe:
+
+- functional blocks and sub-blocks;
+- main component versus support components;
+- pin/net roles when they can be resolved safely;
+- repeated channels;
+- signal direction hints;
+- power-tree relationships;
+- local adjacency preferences;
+- preferred symbol orientation / pin-facing relationships;
+- hard versus soft layout constraints;
+- provenance and confidence for every inferred/reference-derived constraint.
+
+Add a reference-motif representation for datasheet/reference circuits. A motif should record relative topology and presentation intent rather than absolute page coordinates. Example concepts include "input capacitor beside VIN/GND", "feedback divider grouped at FB", "crystal network beside oscillator pins" and "connector -> protection -> interface/MCU".
+
+Initial implementation should support project/operator-supplied structured motifs and deterministic built-in heuristics. Automated datasheet ingestion/search can be added later; the layout engine must not depend on online retrieval to work.
+
+### Phase 28 — schematic placement engine v2
+
+**Goal:** place whole functional structures, not isolated symbols.
+
+Build a hierarchical placer:
+
+1. place/pack functional blocks;
+2. place the principal component inside each block;
+3. place its reference/support motif relative to it;
+4. orient symbols to expose connected pins toward the intended local flow;
+5. pack remaining components while respecting text and wiring corridors;
+6. globally compact the result without collapsing readability.
+
+Candidate scoring should include explicit terms for:
+
+- symbol/body overlap;
+- text/label clearance zones;
+- functional-group cohesion;
+- deviation from a trusted reference motif;
+- pin-facing / orientation quality;
+- estimated future wire length;
+- estimated future crossings;
+- alignment and grid regularity;
+- backward or confusing signal flow;
+- whitespace balance / visual density;
+- total occupied schematic area;
+- unnecessary movement from an already-good existing layout.
+
+The engine should generate multiple bounded candidates where useful rather than pretending one greedy placement is globally optimal.
+
+### Phase 29 — human-readable schematic interconnect router
+
+**Goal:** route wires, labels and buses as a readability problem rather than a shortest-path problem.
+
+Extend the current bounded Manhattan wire routing into a sheet-aware interconnect planner that can:
+
+- minimize wire-symbol and wire-text collisions;
+- strongly penalize unnecessary crossings and overlaps;
+- minimize bends where that improves readability;
+- avoid ambiguous junction presentation;
+- keep related parallel signals visually coherent;
+- prefer short local wires inside a functional block;
+- decide when a named net label is clearer than a long cross-sheet wire;
+- support buses/grouped signals where the underlying DipTrace representation is verified;
+- preserve obvious input-to-output visual flow;
+- expose quality metrics for every routed connection.
+
+Crucially, routing may return a structured placement-feedback request rather than accepting a pathological route. Example: "moving U3 right by one grid region removes four crossings and 80 mm of detour". The router must not mutate placement implicitly; it proposes bounded repairs that the joint optimizer can score.
+
+### Phase 30 — joint schematic layout optimizer
+
+**Goal:** optimize placement and wiring together.
+
+Introduce a bounded co-optimization loop:
+
+1. classify blocks and intent;
+2. generate several placement candidates;
+3. route or estimate interconnect for each candidate;
+4. score the complete schematic;
+5. apply local placement feedback for pathological routes;
+6. re-route affected nets only;
+7. stop on convergence, budget exhaustion or no meaningful score improvement;
+8. present the best candidate through the existing guarded plan/preview transaction path.
+
+The score must remain decomposed and explainable. A lower score is meaningful only when its component metrics are disclosed; there should be no opaque "AI quality" number in the deterministic baseline.
+
+### Phase 31 — schematic quality gate and product-level acceptance
+
+**Goal:** prove that the engine produces consistently useful schematics, not just valid XML.
+
+Create a benchmark/acceptance suite containing synthetic, project-owned and legally usable real reference cases. For each case retain the initial state, generated candidate(s), final state and machine-readable metrics.
+
+Quality gates should cover at minimum:
+
+- electrical/connectivity non-regression;
+- no new ERC/review regression within supported checks;
+- collision/crossing/bend metrics;
+- compactness without crowding;
+- stable deterministic output for a fixed seed/config;
+- reference-motif preservation where applicable;
+- real DipTrace open/save/re-export;
+- human review of a representative subset.
+
+This phase closes only when the project can take a deliberately ugly but electrically correct schematic and reliably produce a materially cleaner version without routine manual cleanup.
+
+## PCB track — after the schematic architecture is proven
+
+The PCB track reuses the schematic intent/optimizer architecture, but adds physical electrical constraints. It should not start by attempting a full replacement for a mature EDA autorouter.
+
+### Phase 32 — PCB design-intent and net-policy model
+
+Classify functional blocks and nets by engineering importance and derive explicit routing/placement policies: critical length, via penalty, layer preference, return-path sensitivity, current/power role, noise sensitivity, differential relationship and other available constraints. Datasheet/reference-layout motifs should describe important local placement and loop structure without blindly copying board coordinates.
+
+### Phase 33 — global PCB placement optimizer
+
+Extend the existing local/legalizing placer into hierarchical/global placement with functional groups, support-component adjacency, orientation, decoupling, thermal spacing, connector flow and estimated routeability. Placement scoring must include the cost of the routes it is likely to create, not only ratsnest anchor length.
+
+### Phase 34 — routing policy and placement-routing feedback
+
+Use the current local router and optional Freerouting as candidate generators. Add engineering-aware route ordering and scoring so a via, detour or layer transition carries a different cost for USB/RF/clock/power than for low-speed GPIO/LED signals. Allow routing congestion and critical-route failure to feed back into placement.
+
+### Phase 35 — power, ground and via strategy
+
+Add explicit planning for ground stitching, reference-transition vias, thermal vias, via fences where justified, power-via arrays, plane/pour continuity and return-current considerations. Keep current copper-pour/refill limitations explicit until authoritative geometry is available.
+
+### Phase 36 — joint PCB optimizer and benchmark
+
+Combine placement, routing candidates, power/ground strategy, DRC/review, SI/return-path heuristics and manufacturing constraints into the same bounded generate -> score -> improve loop established by the schematic work. External routers remain untrusted candidate generators; the MCP's own structural review and transaction gates remain authoritative for what it can actually prove.
+
+Benchmark against deliberately poor layouts, hand-improved layouts and legally usable reference boards. Do not claim "optimal PCB" or fabrication sign-off; report measurable improvements and remaining unsupported categories.
 
 ## Remaining blocking formal acceptance
 
-When the schematic authoring/readability validation is intentionally finished or paused, resume formal acceptance in this order:
+When the schematic authoring/readability validation and the chosen development checkpoint are intentionally finished or paused, resume formal acceptance in this order:
 
 | Order | Gate | Status |
 | --- | --- | --- |
@@ -152,7 +338,7 @@ These are not core blockers unless the corresponding claim is planned:
 
 ## Repository implementation status
 
-There is no known repository-only implementation blocker that should be completed merely to advance the formal matrix. Current implementation includes:
+The previous repository-only roadmap is implementation-complete, but the new schematic/PCB intelligence track intentionally creates new product-development work. Current implementation already provides the foundation:
 
 - PCB, schematic and library parsing/querying;
 - guarded semantic transactions, rollback, SHA/policy/backup/atomic-write boundaries;
@@ -166,7 +352,7 @@ There is no known repository-only implementation blocker that should be complete
 - bounded DFM/DFA/DFT release-readiness checks;
 - manual-acceptance evidence tooling.
 
-If real schematic authoring exposes a product defect, that defect becomes the next focused repository task even though the generic repository roadmap was previously implementation-complete.
+The new work should reuse these layers rather than duplicating them. In particular, high-level optimizers should produce typed plans/operations that still pass through the existing guarded transaction and review paths.
 
 ## Native library mutation status
 
@@ -178,7 +364,7 @@ This does not silently expand the public MCP contract. Public registration of na
 
 The historical `diptrace_ratline_and_wire_roundtrip` gate is PASS. PCB ratline serialization/collision defects were repaired through PRs #63/#64, and schematic authored-wire connectivity survived native save/reopen/re-export.
 
-PR #66 later added stronger readability routing for newly authored schematic wires. Because that behavior is broader than the historical gate, it now has a separate real-world readability validation priority rather than forcing a rerun of the historical gate.
+PR #66 later added stronger readability routing for newly authored schematic wires. Because that behavior is broader than the historical gate, it now forms the baseline for Phase 26 rather than forcing a rerun of the historical gate.
 
 ## Current public contracts
 
@@ -191,7 +377,7 @@ The maintained public baseline remains:
 - project-owned worker-thread boundary for registered tools;
 - exact SHA, policy, backup, atomic-write, session-lease and trust-authority boundaries.
 
-The acceptance campaign does not implicitly add or remove public tools.
+The acceptance campaign and the new optimizer roadmap do not implicitly add or remove public tools. New optimizer capability should prefer internal domain modules/services and a small deliberate public surface rather than one MCP tool per heuristic.
 
 ## Phase summary
 
@@ -209,15 +395,26 @@ The acceptance campaign does not implicitly add or remove public tools.
 | 23 | baseline complete | deterministic pattern recommendation and privacy-bounded feedback/evaluation |
 | 24 | host-verified internal core | Component/Pattern mutation core has real editor evidence; public registration is deferred |
 | 25 | manual acceptance paused at 8/12 | Through Codex restart PASS; formal resume point is Claude Desktop |
-| 26 | validation priority | Real-world schematic authoring/readability on the accepted post-Ponytail production candidate |
+| 26 | **active checkpoint** | Establish real-world schematic readability baseline and benchmark cases |
+| 27 | planned — schematic | Design intent, functional blocks and datasheet/reference motifs |
+| 28 | planned — schematic | Hierarchical component placement, orientation, compactness and routeability scoring |
+| 29 | planned — schematic | Human-readable wire/label/bus routing with placement feedback |
+| 30 | planned — schematic | Joint placement/interconnect optimizer with bounded iterative repair |
+| 31 | planned — schematic | Quality benchmark, real-DipTrace acceptance and product-level readability gate |
+| 32 | planned — PCB | PCB design-intent and engineering-aware net policy model |
+| 33 | planned — PCB | Global/hierarchical PCB placement optimizer |
+| 34 | planned — PCB | Engineering-aware routing policy and placement-routing feedback |
+| 35 | planned — PCB | Power/ground, stitching and via strategy |
+| 36 | planned — PCB | Joint PCB optimizer, review loop and measurable benchmark |
 
 ## Permanent limitations and non-claims
 
 - Synthetic scaffolds and generated fixture packs are MCP-generated XML, not DipTrace exports.
 - Changing `format_version` is not conversion or compatibility evidence.
+- Reference datasheet/reference-board motifs are guidance and provenance-bearing constraints, not proof that the generated design is manufacturer-approved.
 - The local router is bounded and is not a full push-and-shove/free-angle/global EDA router.
 - Copper-pour, return-path, impedance, thermal, DFM/DFA/DFT and manufacturing reviews retain approximation/skip boundaries.
 - Generic fabrication/assembly manifests are not native Gerber, NC Drill, ODB++, IPC-2581 or assembler sign-off packages.
 - The ngspice adapter runs user-provided netlists; it does not generate a complete simulation netlist from a DipTrace design.
 - Native manufacturing generation remains unavailable because no verified DipTrace output API is claimed.
-- The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review or production readiness.
+- The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review, production readiness or globally optimal schematic/PCB layout.

--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -1,0 +1,143 @@
+# Schematic Layout Engine
+
+## Status
+
+This document describes the first deterministic foundation for the intelligent schematic
+layout track in `docs/ROADMAP.md`.
+
+The implementation is internal and does not add public MCP tools or change the published
+tools/list contract. It builds on the existing schematic parser, semantic operations,
+transaction safety model, and authored-wire quality layer.
+
+The first implementation lives in `src/diptrace_mcp/schematic_layout.py` and provides:
+
+- conservative schematic design-intent inference;
+- functional-block grouping;
+- structured reference motifs;
+- deterministic readability metrics and a decomposed layout score;
+- a first-pass hierarchical placer for unwired schematics.
+
+## Design intent
+
+The intent layer is deliberately conservative. It uses only facts already available in the
+normalized schematic:
+
+- RefDes and component naming conventions;
+- part value/name metadata;
+- net names;
+- pin/net connectivity;
+- multipart component identity.
+
+It does not pretend to know a component's datasheet from its name alone.
+
+Parts receive a coarse role such as active device, power-control device, connector,
+support component, timing component, protection device, control device, or other. Nets
+receive coarse roles such as ground, power, clock, reset, interface, signal, or unknown.
+
+Functional blocks are then seeded by active devices and connectors. Multipart components
+with the same RefDes are treated as one anchor group. Support components are assigned to an
+anchor only when connectivity gives a unique deterministic result. Ground and power nets
+are intentionally weak grouping evidence because they commonly span the whole design.
+Ambiguous components remain in generic blocks rather than being guessed into the wrong
+functional block.
+
+## Reference motifs
+
+Reference schematics from datasheets should be represented as relative engineering and
+presentation constraints rather than absolute page coordinates.
+
+The current motif model supports relations such as:
+
+- near;
+- left/right of another element;
+- above/below another element;
+- same row;
+- same column.
+
+A motif has explicit provenance (`datasheet`, `reference_design`, `project`, or `builtin`)
+and confidence. A `BoundReferenceMotif` maps semantic motif keys to actual schematic part
+IDs. This keeps the layout engine independent of online retrieval and prevents component
+names from silently minting fake datasheet knowledge.
+
+Automatic datasheet ingestion is intentionally deferred. The deterministic layout engine
+must remain useful with project/operator-supplied motifs and without network access.
+
+## Readability score
+
+`analyze_schematic_layout` produces separate machine-readable metrics rather than one
+opaque quality number. Current terms include:
+
+- part overlap count;
+- cross-net wire crossing count;
+- wire overlap count;
+- diagonal segment count;
+- bend count;
+- total wire length;
+- functional-block span;
+- occupied sheet area;
+- approximate content density;
+- reference-motif violations.
+
+The total score is a weighted sum of disclosed terms. Lower is better only under the
+reported weights and terms. It is not an engineering certification or an ML-generated
+quality judgement.
+
+The first score intentionally does not claim exact symbol/pin graphics. Current schematic
+part bounds are conservative proxies, and exact pin coordinates are not normalized yet.
+This limitation is reported instead of being hidden behind guessed geometry.
+
+## First placement planner
+
+`plan_schematic_placement` is the Phase 28 foundation, not the final optimizer.
+
+The current planner:
+
+1. infers functional blocks;
+2. orders block classes deterministically;
+3. places anchor parts first;
+4. packs support parts near their anchor block;
+5. snaps placement to a configurable grid;
+6. packs blocks left-to-right with bounded row wrapping;
+7. preserves locked parts;
+8. emits ordinary `MoveComponentsOperation` objects.
+
+The generated operations therefore still use the existing semantic compiler,
+preview/SHA/transaction/review safety path. The layout engine does not write XML directly.
+
+The planner refuses an already-wired schematic by default. Moving symbols while leaving
+wire geometry behind would make the drawing worse. Existing-wire support belongs in the
+joint placement/routing optimizer, where affected wires can be rerouted atomically.
+
+Rotation is also preserved in the first version. Exact schematic pin geometry is required
+before automatic orientation can be scored reliably enough to justify moving user-visible
+symbols.
+
+## Existing wire-quality layer
+
+The repository already has a bounded deterministic authored-wire quality layer in
+`services/schematic_wire_quality.py`. It can reroute newly authored wires around component
+and text obstacles and strongly penalizes crossings and overlaps.
+
+The new layout module does not duplicate that router. The next routing phase should expose
+and extend it into a sheet-level candidate planner whose metrics can feed back into
+placement.
+
+## Next implementation steps
+
+The intended order is:
+
+1. establish quality fixtures and keep the new metric contract stable enough for regression
+   tests;
+2. normalize or otherwise obtain trustworthy symbol/pin geometry where DipTrace evidence
+   permits it;
+3. generate several placement candidates rather than one deterministic packing candidate;
+4. use reference motifs during candidate generation, not only scoring;
+5. promote the existing authored-wire cleaner into a sheet-level interconnect planner;
+6. allow routing to return bounded placement-feedback proposals;
+7. run placement, routing and scoring in a bounded generate -> score -> improve loop;
+8. preserve the existing guarded transaction/review path for the selected candidate;
+9. expose only a small deliberate public MCP surface after the internal architecture is
+   proven.
+
+The quality target is practical: a deliberately ugly but electrically correct schematic
+should become materially easier for an engineer to read without routine manual cleanup.

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -56,6 +56,7 @@ docs/REVIEW_ENGINE.md
 docs/ROADMAP.md
 docs/ROUTING_ENGINE.md
 docs/SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md
+docs/SCHEMATIC_LAYOUT_ENGINE.md
 docs/SECURITY_AND_POLICY.md
 docs/SERVICE_DECOMPOSITION.md
 docs/SIGNING.md
@@ -245,6 +246,7 @@ src/diptrace_mcp/review.py
 src/diptrace_mcp/routing.py
 src/diptrace_mcp/routing_compiler.py
 src/diptrace_mcp/scaffolding.py
+src/diptrace_mcp/schematic_layout.py
 src/diptrace_mcp/semantic_compiler.py
 src/diptrace_mcp/server.py
 src/diptrace_mcp/server_inputs.py
@@ -383,6 +385,7 @@ tests/test_routing_4layer.py
 tests/test_routing_primitives.py
 tests/test_scaffolding.py
 tests/test_schematic_authoring.py
+tests/test_schematic_layout.py
 tests/test_schematic_pcb_sync.py
 tests/test_schematic_wire_quality.py
 tests/test_semantic_dispatch.py

--- a/src/diptrace_mcp/schematic_layout.py
+++ b/src/diptrace_mcp/schematic_layout.py
@@ -1,0 +1,1097 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from .adapters import DocumentSnapshot
+from .domain import ObjectRecord, QuerySelector, StrictModel
+from .errors import CapabilityUnavailableError
+from .geometry import BBox, Point, distance
+from .operations import MoveComponentsOperation, SemanticOperation
+
+_EPS = 1e-9
+PartRole = Literal[
+    "active",
+    "power_control",
+    "connector",
+    "support",
+    "protection",
+    "timing",
+    "control",
+    "other",
+]
+NetRole = Literal["ground", "power", "clock", "reset", "interface", "signal", "unknown"]
+BlockRole = Literal["connector", "power", "functional", "generic"]
+
+
+class SchematicPartIntent(StrictModel):
+    part_id: str
+    refdes: str | None = None
+    role: PartRole
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SchematicNetIntent(StrictModel):
+    net_id: str
+    name: str | None = None
+    role: NetRole
+    confidence: float = Field(ge=0.0, le=1.0)
+    part_ids: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SchematicFunctionalBlock(StrictModel):
+    block_id: str
+    role: BlockRole
+    anchor_part_ids: list[str] = Field(default_factory=list)
+    member_part_ids: list[str] = Field(default_factory=list)
+    support_part_ids: list[str] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class ReferenceMotifConstraint(StrictModel):
+    first_key: str = Field(min_length=1, max_length=128)
+    second_key: str = Field(min_length=1, max_length=128)
+    relation: Literal[
+        "near",
+        "left_of",
+        "right_of",
+        "above",
+        "below",
+        "same_row",
+        "same_column",
+    ]
+    max_distance_mm: float | None = Field(default=None, gt=0.0, allow_inf_nan=False)
+    tolerance_mm: float = Field(default=2.5, ge=0.0, allow_inf_nan=False)
+    weight: float = Field(default=1.0, gt=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def validate_constraint(self) -> ReferenceMotifConstraint:
+        if self.first_key == self.second_key:
+            raise ValueError("motif constraint endpoints must be different")
+        if self.relation == "near" and self.max_distance_mm is None:
+            raise ValueError("near motif constraint requires max_distance_mm")
+        return self
+
+
+class ReferenceMotif(StrictModel):
+    name: str = Field(min_length=1, max_length=256)
+    source: str = Field(min_length=1, max_length=2_048)
+    source_kind: Literal["datasheet", "reference_design", "project", "builtin"]
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    constraints: list[ReferenceMotifConstraint] = Field(default_factory=list)
+
+
+class BoundReferenceMotif(StrictModel):
+    motif: ReferenceMotif
+    bindings: dict[str, str] = Field(default_factory=dict)
+
+
+class SchematicDesignIntent(StrictModel):
+    document_id: str
+    parts: list[SchematicPartIntent] = Field(default_factory=list)
+    nets: list[SchematicNetIntent] = Field(default_factory=list)
+    blocks: list[SchematicFunctionalBlock] = Field(default_factory=list)
+    motifs: list[BoundReferenceMotif] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class SchematicLayoutWeights(StrictModel):
+    part_overlap: float = Field(default=10_000.0, ge=0.0)
+    wire_overlap: float = Field(default=5_000.0, ge=0.0)
+    wire_crossing: float = Field(default=1_000.0, ge=0.0)
+    diagonal_segment: float = Field(default=250.0, ge=0.0)
+    bend: float = Field(default=1.0, ge=0.0)
+    wire_length: float = Field(default=0.05, ge=0.0)
+    block_span: float = Field(default=0.2, ge=0.0)
+    occupied_area: float = Field(default=0.001, ge=0.0)
+    motif_violation: float = Field(default=100.0, ge=0.0)
+
+
+class SchematicLayoutMetrics(StrictModel):
+    part_count: int = Field(ge=0)
+    block_count: int = Field(ge=0)
+    wire_count: int = Field(ge=0)
+    part_overlap_count: int = Field(ge=0)
+    wire_overlap_count: int = Field(ge=0)
+    wire_crossing_count: int = Field(ge=0)
+    diagonal_segment_count: int = Field(ge=0)
+    bend_count: int = Field(ge=0)
+    total_wire_length_mm: float = Field(ge=0.0)
+    occupied_width_mm: float = Field(ge=0.0)
+    occupied_height_mm: float = Field(ge=0.0)
+    occupied_area_mm2: float = Field(ge=0.0)
+    content_area_mm2: float = Field(ge=0.0)
+    density_ratio: float = Field(ge=0.0)
+    mean_block_span_mm: float = Field(ge=0.0)
+    max_block_span_mm: float = Field(ge=0.0)
+    motif_violation_count: int = Field(ge=0)
+    score_terms: dict[str, float] = Field(default_factory=dict)
+    score: float = Field(ge=0.0)
+
+
+class SchematicLayoutAnalysis(StrictModel):
+    intent: SchematicDesignIntent
+    metrics: SchematicLayoutMetrics
+    motif_results: list[dict[str, Any]] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+class SchematicPlacementConfig(StrictModel):
+    grid_mm: float = Field(default=2.5, gt=0.0, le=100.0)
+    origin_x_mm: float = Field(default=20.0, allow_inf_nan=False)
+    origin_y_mm: float = Field(default=20.0, allow_inf_nan=False)
+    block_gap_x_mm: float = Field(default=20.0, gt=0.0, le=500.0)
+    block_gap_y_mm: float = Field(default=15.0, gt=0.0, le=500.0)
+    anchor_gap_y_mm: float = Field(default=10.0, gt=0.0, le=500.0)
+    member_gap_x_mm: float = Field(default=15.0, gt=0.0, le=500.0)
+    member_gap_y_mm: float = Field(default=10.0, gt=0.0, le=500.0)
+    target_row_width_mm: float = Field(default=140.0, gt=20.0, le=2_000.0)
+    max_parts: int = Field(default=200, ge=1, le=2_000)
+    allow_existing_wires: bool = False
+    weights: SchematicLayoutWeights = Field(default_factory=SchematicLayoutWeights)
+
+
+@dataclass(frozen=True, slots=True)
+class SchematicPlacementPlan:
+    operations: list[SemanticOperation]
+    placements: dict[str, Point]
+    before: SchematicLayoutAnalysis
+    after: SchematicLayoutAnalysis
+    changed_part_ids: list[str]
+    unresolved: list[dict[str, Any]]
+    assumptions: list[str]
+    warnings: list[str]
+    limitations: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class _Segment:
+    start: Point
+    end: Point
+
+    @property
+    def length(self) -> float:
+        return math.hypot(self.end.x - self.start.x, self.end.y - self.start.y)
+
+    @property
+    def horizontal(self) -> bool:
+        return math.isclose(self.start.y, self.end.y, abs_tol=_EPS)
+
+    @property
+    def vertical(self) -> bool:
+        return math.isclose(self.start.x, self.end.x, abs_tol=_EPS)
+
+
+def _require_schematic(snapshot: DocumentSnapshot) -> None:
+    if snapshot.schematic is None:
+        raise CapabilityUnavailableError("Schematic layout analysis requires a schematic document")
+
+
+def _part_role(part: ObjectRecord) -> SchematicPartIntent:
+    refdes = (part.refdes or "").upper()
+    prefix_match = re.match(r"[A-Z]+", refdes)
+    prefix = prefix_match.group(0) if prefix_match else ""
+    text = " ".join(
+        value
+        for value in (
+            part.refdes,
+            part.name,
+            part.value,
+            str(part.attributes.get("part_name", "")),
+        )
+        if value
+    ).upper()
+    if prefix in {"J", "P", "CN", "CON"} or any(
+        token in text for token in ("CONNECTOR", "HEADER", "USB-C", "TYPE-C")
+    ):
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="connector",
+            confidence=0.9,
+            reasons=["connector-like RefDes/name"],
+        )
+    if prefix in {"U", "IC"}:
+        if any(
+            token in text
+            for token in ("LDO", "BUCK", "BOOST", "REGULATOR", "PMIC", "CONVERTER", "DCDC", "DC/DC")
+        ):
+            return SchematicPartIntent(
+                part_id=part.stable_id,
+                refdes=part.refdes,
+                role="power_control",
+                confidence=0.85,
+                reasons=["active device with power-conversion/regulation keyword"],
+            )
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="active",
+            confidence=0.8,
+            reasons=["IC-style RefDes"],
+        )
+    if prefix in {"Q", "T", "K"}:
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="active",
+            confidence=0.7,
+            reasons=["active-device RefDes"],
+        )
+    if prefix in {"Y", "X"} or any(token in text for token in ("XTAL", "CRYSTAL", "OSCILLATOR")):
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="timing",
+            confidence=0.85,
+            reasons=["timing-source RefDes/name"],
+        )
+    if prefix == "F" or any(token in text for token in ("TVS", "ESD", "FUSE")):
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="protection",
+            confidence=0.8,
+            reasons=["protection-device RefDes/name"],
+        )
+    if prefix in {"SW", "S"} or "SWITCH" in text or "BUTTON" in text:
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="control",
+            confidence=0.75,
+            reasons=["human/control-device RefDes/name"],
+        )
+    if prefix in {"R", "C", "L", "D", "FB", "NTC", "RT", "LED"}:
+        return SchematicPartIntent(
+            part_id=part.stable_id,
+            refdes=part.refdes,
+            role="support",
+            confidence=0.75,
+            reasons=["passive/support RefDes"],
+        )
+    return SchematicPartIntent(
+        part_id=part.stable_id,
+        refdes=part.refdes,
+        role="other",
+        confidence=0.4,
+        reasons=["no stronger deterministic role signal"],
+    )
+
+
+def _net_role(net: ObjectRecord, part_ids: list[str]) -> SchematicNetIntent:
+    name = (net.name or net.net_name or "").strip()
+    folded = name.upper().replace(" ", "")
+    if not folded:
+        return SchematicNetIntent(
+            net_id=net.stable_id,
+            name=None,
+            role="unknown",
+            confidence=0.2,
+            part_ids=part_ids,
+            reasons=["net has no usable name"],
+        )
+    if re.match(r"^(GND|AGND|DGND|PGND|0V|VSS)([_-].*)?$", folded):
+        role: NetRole = "ground"
+        confidence = 0.98
+        reason = "ground-name pattern"
+    elif re.match(r"^(\+?-?[0-9]+V[0-9]*|VCC|VDD|VIN|VOUT|VBAT|VSYS|VREF)([_-].*)?$", folded):
+        role = "power"
+        confidence = 0.92
+        reason = "power-rail name pattern"
+    elif any(token in folded for token in ("CLK", "CLOCK", "XTAL", "OSC")):
+        role = "clock"
+        confidence = 0.9
+        reason = "clock/timing keyword"
+    elif any(token in folded for token in ("RESET", "NRST", "RST")):
+        role = "reset"
+        confidence = 0.9
+        reason = "reset keyword"
+    elif any(
+        token in folded
+        for token in (
+            "USB",
+            "CAN",
+            "I2C",
+            "SCL",
+            "SDA",
+            "SPI",
+            "MOSI",
+            "MISO",
+            "SCK",
+            "UART",
+            "TX",
+            "RX",
+            "SWD",
+            "JTAG",
+        )
+    ):
+        role = "interface"
+        confidence = 0.8
+        reason = "common interface keyword"
+    else:
+        role = "signal"
+        confidence = 0.55
+        reason = "named net without a stronger deterministic class"
+    return SchematicNetIntent(
+        net_id=net.stable_id,
+        name=name,
+        role=role,
+        confidence=confidence,
+        part_ids=part_ids,
+        reasons=[reason],
+    )
+
+
+def _net_parts(snapshot: DocumentSnapshot) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    assert snapshot.schematic is not None
+    pins = {pin.stable_id: pin for pin in snapshot.schematic.pins}
+    net_parts: dict[str, list[str]] = {}
+    part_nets: dict[str, set[str]] = defaultdict(set)
+    for net in snapshot.schematic.nets:
+        owners: set[str] = set()
+        for endpoint_id in net.relationships.get("endpoints", []):
+            pin = pins.get(endpoint_id)
+            if pin is not None and pin.parent_id is not None:
+                owners.add(pin.parent_id)
+        ordered = sorted(owners)
+        net_parts[net.stable_id] = ordered
+        for part_id in ordered:
+            part_nets[part_id].add(net.stable_id)
+    return net_parts, part_nets
+
+
+def _block_id(member_ids: list[str]) -> str:
+    digest = hashlib.sha256("\0".join(sorted(member_ids)).encode("utf-8")).hexdigest()[:16]
+    return f"schematic-block-{digest}"
+
+
+def _block_role(anchor_roles: set[PartRole]) -> BlockRole:
+    if "connector" in anchor_roles:
+        return "connector"
+    if "power_control" in anchor_roles:
+        return "power"
+    if "active" in anchor_roles:
+        return "functional"
+    return "generic"
+
+
+def infer_schematic_design_intent(
+    snapshot: DocumentSnapshot,
+    *,
+    motifs: list[BoundReferenceMotif] | None = None,
+) -> SchematicDesignIntent:
+    """Infer a conservative, deterministic schematic intent model.
+
+    The baseline intentionally relies only on information already present in the
+    normalized schematic. It does not invent datasheet knowledge. Ambiguous
+    support-part assignment is left unresolved instead of being guessed.
+    """
+    _require_schematic(snapshot)
+    assert snapshot.schematic is not None
+    part_intents = [_part_role(part) for part in snapshot.schematic.parts]
+    part_intent_by_id = {item.part_id: item for item in part_intents}
+    net_parts, part_nets = _net_parts(snapshot)
+    net_intents = [
+        _net_role(net, net_parts.get(net.stable_id, [])) for net in snapshot.schematic.nets
+    ]
+    net_role_by_id = {item.net_id: item.role for item in net_intents}
+
+    parts_by_id = {part.stable_id: part for part in snapshot.schematic.parts}
+    anchor_roles: set[PartRole] = {"active", "power_control", "connector"}
+    anchor_groups: dict[str, list[str]] = defaultdict(list)
+    for part in snapshot.schematic.parts:
+        role = part_intent_by_id[part.stable_id].role
+        if role not in anchor_roles:
+            continue
+        group_key = (part.refdes or part.stable_id).casefold()
+        anchor_groups[group_key].append(part.stable_id)
+
+    assigned: set[str] = set()
+    block_members: dict[str, list[str]] = {}
+    block_anchors: dict[str, list[str]] = {}
+    block_reasons: dict[str, list[str]] = {}
+    for key, anchor_ids in sorted(anchor_groups.items()):
+        ordered = sorted(anchor_ids)
+        block_members[key] = list(ordered)
+        block_anchors[key] = list(ordered)
+        block_reasons[key] = ["block seeded by active/connector anchor"]
+        assigned.update(ordered)
+
+    support_roles: set[PartRole] = {"support", "protection", "timing", "control", "other"}
+    for part in sorted(snapshot.schematic.parts, key=lambda item: item.stable_id):
+        if part.stable_id in assigned:
+            continue
+        if part_intent_by_id[part.stable_id].role not in support_roles:
+            continue
+        scores: list[tuple[int, str]] = []
+        own_nets = part_nets.get(part.stable_id, set())
+        for key, anchor_ids in anchor_groups.items():
+            anchor_nets: set[str] = set()
+            for anchor_id in anchor_ids:
+                anchor_nets.update(part_nets.get(anchor_id, set()))
+            score = 0
+            for net_id in own_nets & anchor_nets:
+                role = net_role_by_id.get(net_id, "unknown")
+                score += 1 if role in {"ground", "power"} else 10
+            if score > 0:
+                scores.append((score, key))
+        if not scores:
+            continue
+        best_score = max(score for score, _key in scores)
+        winners = sorted(key for score, key in scores if score == best_score)
+        if len(winners) != 1:
+            continue
+        winner = winners[0]
+        block_members[winner].append(part.stable_id)
+        block_reasons[winner].append(
+            f"support part {part.refdes or part.stable_id} assigned by unique connectivity score"
+        )
+        assigned.add(part.stable_id)
+
+    adjacency: dict[str, set[str]] = {part.stable_id: set() for part in snapshot.schematic.parts}
+    for net_intent in net_intents:
+        if net_intent.role in {"ground", "power"}:
+            continue
+        members = [part_id for part_id in net_intent.part_ids if part_id not in assigned]
+        for index, first in enumerate(members):
+            adjacency[first].update(members[:index])
+            adjacency[first].update(members[index + 1 :])
+
+    unassigned = sorted(set(parts_by_id) - assigned)
+    seen: set[str] = set()
+    generic_index = 0
+    for start in unassigned:
+        if start in seen:
+            continue
+        stack = [start]
+        component: list[str] = []
+        while stack:
+            current = stack.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            component.append(current)
+            stack.extend(sorted(adjacency.get(current, set()) - seen, reverse=True))
+        key = f"generic-{generic_index:04d}"
+        generic_index += 1
+        block_members[key] = sorted(component)
+        block_anchors[key] = []
+        block_reasons[key] = ["no unique active/connector anchor was inferable"]
+
+    blocks: list[SchematicFunctionalBlock] = []
+    for key in sorted(block_members):
+        members = sorted(block_members[key])
+        anchors = sorted(block_anchors.get(key, []))
+        anchor_role_set = {part_intent_by_id[item].role for item in anchors}
+        support_ids = sorted(set(members) - set(anchors))
+        confidence = (
+            min((part_intent_by_id[item].confidence for item in anchors), default=0.45)
+            if anchors
+            else 0.4
+        )
+        blocks.append(
+            SchematicFunctionalBlock(
+                block_id=_block_id(members),
+                role=_block_role(anchor_role_set),
+                anchor_part_ids=anchors,
+                member_part_ids=members,
+                support_part_ids=support_ids,
+                confidence=confidence,
+                reasons=block_reasons[key],
+            )
+        )
+
+    warnings: list[str] = []
+    unresolved_support = [
+        part
+        for part in part_intents
+        if part.role in support_roles
+        and all(part.part_id not in block.anchor_part_ids for block in blocks)
+        and any(
+            part.part_id in block.member_part_ids and block.role == "generic" for block in blocks
+        )
+    ]
+    if unresolved_support:
+        warnings.append(
+            f"{len(unresolved_support)} support/other parts could not be assigned "
+            "to a unique anchor"
+        )
+    return SchematicDesignIntent(
+        document_id=snapshot.schematic.document_id,
+        parts=part_intents,
+        nets=net_intents,
+        blocks=blocks,
+        motifs=list(motifs or []),
+        assumptions=[
+            "Intent inference uses only schematic XML topology, names and RefDes conventions.",
+            "Power and ground nets are weak grouping evidence because they commonly "
+            "span many blocks.",
+            "Reference motifs are never invented from a component name; they must be "
+            "supplied explicitly.",
+        ],
+        warnings=warnings,
+    )
+
+
+def _position_for(part: ObjectRecord, placements: Mapping[str, Point] | None) -> Point | None:
+    if placements is not None and part.stable_id in placements:
+        return placements[part.stable_id]
+    if part.position is None:
+        return None
+    return Point(**part.position)
+
+
+def _bbox_for(part: ObjectRecord, placements: Mapping[str, Point] | None) -> BBox | None:
+    if part.bbox is None:
+        return None
+    box = BBox(**part.bbox)
+    if placements is None or part.stable_id not in placements or part.position is None:
+        return box
+    original = Point(**part.position)
+    target = placements[part.stable_id]
+    return BBox(
+        box.min_x + target.x - original.x,
+        box.min_y + target.y - original.y,
+        box.max_x + target.x - original.x,
+        box.max_y + target.y - original.y,
+    )
+
+
+def _wire_points(wire: ObjectRecord) -> list[Point]:
+    raw = wire.attributes.get("points", [])
+    if not isinstance(raw, list):
+        return []
+    return [
+        Point(float(item["x"]), float(item["y"]))
+        for item in raw
+        if isinstance(item, dict) and "x" in item and "y" in item
+    ]
+
+
+def _same_point(first: Point, second: Point) -> bool:
+    return math.isclose(first.x, second.x, abs_tol=_EPS) and math.isclose(
+        first.y, second.y, abs_tol=_EPS
+    )
+
+
+def _cross(first: Point, second: Point, third: Point) -> float:
+    return (second.x - first.x) * (third.y - first.y) - (
+        second.y - first.y
+    ) * (third.x - first.x)
+
+
+def _point_on_segment(point: Point, segment: _Segment) -> bool:
+    return (
+        abs(_cross(segment.start, segment.end, point)) <= _EPS
+        and min(segment.start.x, segment.end.x) - _EPS
+        <= point.x
+        <= max(segment.start.x, segment.end.x) + _EPS
+        and min(segment.start.y, segment.end.y) - _EPS
+        <= point.y
+        <= max(segment.start.y, segment.end.y) + _EPS
+    )
+
+
+def _segments_intersect(first: _Segment, second: _Segment) -> bool:
+    c1 = _cross(first.start, first.end, second.start)
+    c2 = _cross(first.start, first.end, second.end)
+    c3 = _cross(second.start, second.end, first.start)
+    c4 = _cross(second.start, second.end, first.end)
+    if (
+        ((c1 > _EPS and c2 < -_EPS) or (c1 < -_EPS and c2 > _EPS))
+        and ((c3 > _EPS and c4 < -_EPS) or (c3 < -_EPS and c4 > _EPS))
+    ):
+        return True
+    return (
+        (abs(c1) <= _EPS and _point_on_segment(second.start, first))
+        or (abs(c2) <= _EPS and _point_on_segment(second.end, first))
+        or (abs(c3) <= _EPS and _point_on_segment(first.start, second))
+        or (abs(c4) <= _EPS and _point_on_segment(first.end, second))
+    )
+
+
+def _collinear_overlap_length(first: _Segment, second: _Segment) -> float:
+    if abs(_cross(first.start, first.end, second.start)) > _EPS or abs(
+        _cross(first.start, first.end, second.end)
+    ) > _EPS:
+        return 0.0
+    if first.horizontal and second.horizontal:
+        return max(
+            0.0,
+            min(max(first.start.x, first.end.x), max(second.start.x, second.end.x))
+            - max(min(first.start.x, first.end.x), min(second.start.x, second.end.x)),
+        )
+    if first.vertical and second.vertical:
+        return max(
+            0.0,
+            min(max(first.start.y, first.end.y), max(second.start.y, second.end.y))
+            - max(min(first.start.y, first.end.y), min(second.start.y, second.end.y)),
+        )
+    return 0.0
+
+
+def _wire_metrics(wires: list[ObjectRecord]) -> tuple[int, int, int, int, float, list[Point]]:
+    wire_segments: list[tuple[str | None, int, _Segment]] = []
+    diagonal_count = 0
+    bend_count = 0
+    total_length = 0.0
+    all_points: list[Point] = []
+    for wire_index, wire in enumerate(wires):
+        points = _wire_points(wire)
+        all_points.extend(points)
+        segments = [
+            _Segment(first, second)
+            for first, second in zip(points, points[1:], strict=False)
+            if not _same_point(first, second)
+        ]
+        total_length += sum(segment.length for segment in segments)
+        diagonal_count += sum(
+            not (segment.horizontal or segment.vertical) for segment in segments
+        )
+        for first, second in zip(segments, segments[1:], strict=False):
+            first_dx = first.end.x - first.start.x
+            first_dy = first.end.y - first.start.y
+            second_dx = second.end.x - second.start.x
+            second_dy = second.end.y - second.start.y
+            if abs(first_dx * second_dy - first_dy * second_dx) > _EPS:
+                bend_count += 1
+        wire_segments.extend((wire.net_name, wire_index, segment) for segment in segments)
+
+    crossing_count = 0
+    overlap_count = 0
+    for index, (first_net, first_wire, first) in enumerate(wire_segments):
+        for second_net, second_wire, second in wire_segments[index + 1 :]:
+            if first_wire == second_wire:
+                continue
+            overlap = _collinear_overlap_length(first, second)
+            if overlap > _EPS:
+                overlap_count += 1
+                continue
+            if not _segments_intersect(first, second):
+                continue
+            if (
+                _same_point(first.start, second.start)
+                or _same_point(first.start, second.end)
+                or _same_point(first.end, second.start)
+                or _same_point(first.end, second.end)
+            ):
+                continue
+            if first_net == second_net:
+                continue
+            crossing_count += 1
+    return overlap_count, crossing_count, diagonal_count, bend_count, total_length, all_points
+
+
+def _motif_relation_error(
+    first: Point,
+    second: Point,
+    constraint: ReferenceMotifConstraint,
+) -> float:
+    if constraint.relation == "near":
+        assert constraint.max_distance_mm is not None
+        return max(0.0, distance(first, second) - constraint.max_distance_mm)
+    if constraint.relation == "left_of":
+        return max(0.0, first.x - second.x + constraint.tolerance_mm)
+    if constraint.relation == "right_of":
+        return max(0.0, second.x - first.x + constraint.tolerance_mm)
+    if constraint.relation == "above":
+        return max(0.0, first.y - second.y + constraint.tolerance_mm)
+    if constraint.relation == "below":
+        return max(0.0, second.y - first.y + constraint.tolerance_mm)
+    if constraint.relation == "same_row":
+        return max(0.0, abs(first.y - second.y) - constraint.tolerance_mm)
+    return max(0.0, abs(first.x - second.x) - constraint.tolerance_mm)
+
+
+def score_reference_motif(
+    snapshot: DocumentSnapshot,
+    bound: BoundReferenceMotif,
+    *,
+    placements: Mapping[str, Point] | None = None,
+) -> dict[str, Any]:
+    _require_schematic(snapshot)
+    assert snapshot.schematic is not None
+    parts_by_id = {part.stable_id: part for part in snapshot.schematic.parts}
+    violations: list[dict[str, Any]] = []
+    score = 0.0
+    for constraint in bound.motif.constraints:
+        first_id = bound.bindings.get(constraint.first_key)
+        second_id = bound.bindings.get(constraint.second_key)
+        if first_id is None or second_id is None:
+            violations.append(
+                {"constraint": constraint.model_dump(mode="json"), "reason": "unbound_motif_key"}
+            )
+            score += constraint.weight
+            continue
+        first_part = parts_by_id.get(first_id)
+        second_part = parts_by_id.get(second_id)
+        if first_part is None or second_part is None:
+            violations.append(
+                {"constraint": constraint.model_dump(mode="json"), "reason": "bound_part_missing"}
+            )
+            score += constraint.weight
+            continue
+        first = _position_for(first_part, placements)
+        second = _position_for(second_part, placements)
+        if first is None or second is None:
+            violations.append(
+                {"constraint": constraint.model_dump(mode="json"), "reason": "position_missing"}
+            )
+            score += constraint.weight
+            continue
+        error = _motif_relation_error(first, second, constraint)
+        if error <= _EPS:
+            continue
+        contribution = error * constraint.weight
+        score += contribution
+        violations.append(
+            {
+                "constraint": constraint.model_dump(mode="json"),
+                "error_mm": error,
+                "contribution": contribution,
+            }
+        )
+    return {
+        "name": bound.motif.name,
+        "source": bound.motif.source,
+        "source_kind": bound.motif.source_kind,
+        "score": score,
+        "violation_count": len(violations),
+        "violations": violations,
+    }
+
+
+def analyze_schematic_layout(
+    snapshot: DocumentSnapshot,
+    *,
+    intent: SchematicDesignIntent | None = None,
+    placements: Mapping[str, Point] | None = None,
+    motifs: list[BoundReferenceMotif] | None = None,
+    weights: SchematicLayoutWeights | None = None,
+) -> SchematicLayoutAnalysis:
+    """Measure deterministic readability/layout properties of a schematic."""
+    _require_schematic(snapshot)
+    assert snapshot.schematic is not None
+    weights = weights or SchematicLayoutWeights()
+    intent = intent or infer_schematic_design_intent(snapshot, motifs=motifs)
+    if motifs is None:
+        motifs = intent.motifs
+
+    parts = snapshot.schematic.parts
+    part_overlap_count = 0
+    part_boxes: list[tuple[str, BBox]] = []
+    content_area = 0.0
+    extent_points: list[Point] = []
+    for part in parts:
+        position = _position_for(part, placements)
+        if position is not None:
+            extent_points.append(position)
+        box = _bbox_for(part, placements)
+        if box is None:
+            continue
+        content_area += box.area
+        part_boxes.append((str(part.attributes.get("sheet", "0")), box))
+        extent_points.extend([Point(box.min_x, box.min_y), Point(box.max_x, box.max_y)])
+    for index, (first_sheet, first) in enumerate(part_boxes):
+        for second_sheet, second in part_boxes[index + 1 :]:
+            if first_sheet == second_sheet and first.overlap_area(second) > _EPS:
+                part_overlap_count += 1
+
+    (
+        wire_overlap_count,
+        wire_crossing_count,
+        diagonal_segment_count,
+        bend_count,
+        total_wire_length,
+        wire_extent_points,
+    ) = _wire_metrics(snapshot.schematic.wires)
+    extent_points.extend(wire_extent_points)
+
+    if extent_points:
+        min_x = min(point.x for point in extent_points)
+        min_y = min(point.y for point in extent_points)
+        max_x = max(point.x for point in extent_points)
+        max_y = max(point.y for point in extent_points)
+        occupied_width = max_x - min_x
+        occupied_height = max_y - min_y
+        occupied_area = occupied_width * occupied_height
+    else:
+        occupied_width = occupied_height = occupied_area = 0.0
+    density = content_area / occupied_area if occupied_area > _EPS else 0.0
+
+    parts_by_id = {part.stable_id: part for part in parts}
+    block_spans: list[float] = []
+    for block in intent.blocks:
+        positions = [
+            point
+            for part_id in block.member_part_ids
+            if (part := parts_by_id.get(part_id)) is not None
+            and (point := _position_for(part, placements)) is not None
+        ]
+        if len(positions) < 2:
+            block_spans.append(0.0)
+            continue
+        block_box = BBox.from_points(positions)
+        block_spans.append(
+            math.hypot(block_box.max_x - block_box.min_x, block_box.max_y - block_box.min_y)
+        )
+    mean_block_span = sum(block_spans) / len(block_spans) if block_spans else 0.0
+    max_block_span = max(block_spans, default=0.0)
+
+    motif_results = [
+        score_reference_motif(snapshot, bound, placements=placements) for bound in motifs
+    ]
+    motif_violation_count = sum(int(result["violation_count"]) for result in motif_results)
+    motif_score = sum(float(result["score"]) for result in motif_results)
+
+    score_terms = {
+        "part_overlap": part_overlap_count * weights.part_overlap,
+        "wire_overlap": wire_overlap_count * weights.wire_overlap,
+        "wire_crossing": wire_crossing_count * weights.wire_crossing,
+        "diagonal_segment": diagonal_segment_count * weights.diagonal_segment,
+        "bend": bend_count * weights.bend,
+        "wire_length": total_wire_length * weights.wire_length,
+        "block_span": mean_block_span * weights.block_span,
+        "occupied_area": occupied_area * weights.occupied_area,
+        "motif_violation": motif_score * weights.motif_violation,
+    }
+    metrics = SchematicLayoutMetrics(
+        part_count=len(parts),
+        block_count=len(intent.blocks),
+        wire_count=len(snapshot.schematic.wires),
+        part_overlap_count=part_overlap_count,
+        wire_overlap_count=wire_overlap_count,
+        wire_crossing_count=wire_crossing_count,
+        diagonal_segment_count=diagonal_segment_count,
+        bend_count=bend_count,
+        total_wire_length_mm=total_wire_length,
+        occupied_width_mm=occupied_width,
+        occupied_height_mm=occupied_height,
+        occupied_area_mm2=occupied_area,
+        content_area_mm2=content_area,
+        density_ratio=density,
+        mean_block_span_mm=mean_block_span,
+        max_block_span_mm=max_block_span,
+        motif_violation_count=motif_violation_count,
+        score_terms=score_terms,
+        score=sum(score_terms.values()),
+    )
+    warnings = list(intent.warnings)
+    if placements and snapshot.schematic.wires:
+        warnings.append(
+            "Wire geometry was measured at its current coordinates while placement "
+            "overrides were supplied."
+        )
+    return SchematicLayoutAnalysis(
+        intent=intent,
+        metrics=metrics,
+        motif_results=motif_results,
+        assumptions=[
+            "Lower score is better only within the disclosed deterministic score terms.",
+            "Part geometry uses the currently normalized schematic bounding boxes.",
+        ],
+        warnings=warnings,
+        limitations=[
+            "Current schematic part bounds are conservative position proxies, not "
+            "authoritative symbol extents.",
+            "Exact pin graphics/coordinates are not normalized, so pin-facing quality "
+            "is not yet scored.",
+            "Same-net wire intersections are not counted as crossings because junction "
+            "intent is not yet normalized.",
+            "Reference motifs are structured constraints; automatic datasheet ingestion "
+            "is not implemented.",
+        ],
+    )
+
+
+def _snap(value: float, grid: float) -> float:
+    return round(value / grid) * grid
+
+
+def _local_block_layout(
+    block: SchematicFunctionalBlock,
+    config: SchematicPlacementConfig,
+) -> tuple[dict[str, Point], float, float]:
+    placements: dict[str, Point] = {}
+    anchors = list(block.anchor_part_ids)
+    anchor_set = set(anchors)
+    supports = [item for item in block.member_part_ids if item not in anchor_set]
+    for index, part_id in enumerate(anchors):
+        placements[part_id] = Point(0.0, index * config.anchor_gap_y_mm)
+    if anchors:
+        anchor_height = max(config.anchor_gap_y_mm, len(anchors) * config.anchor_gap_y_mm)
+        support_origin_x = config.member_gap_x_mm
+        for index, part_id in enumerate(supports):
+            row = index % 4
+            column = index // 4
+            placements[part_id] = Point(
+                support_origin_x + column * config.member_gap_x_mm,
+                row * config.member_gap_y_mm,
+            )
+        width = config.member_gap_x_mm * (1 + max(1, math.ceil(len(supports) / 4)))
+        height = max(
+            anchor_height,
+            config.member_gap_y_mm * max(1, min(4, len(supports))),
+        )
+    else:
+        for index, part_id in enumerate(block.member_part_ids):
+            row = index % 4
+            column = index // 4
+            placements[part_id] = Point(
+                column * config.member_gap_x_mm,
+                row * config.member_gap_y_mm,
+            )
+        width = config.member_gap_x_mm * max(1, math.ceil(len(block.member_part_ids) / 4))
+        height = config.member_gap_y_mm * max(1, min(4, len(block.member_part_ids)))
+    return placements, max(width, config.member_gap_x_mm), max(height, config.member_gap_y_mm)
+
+
+def plan_schematic_placement(
+    snapshot: DocumentSnapshot,
+    *,
+    intent: SchematicDesignIntent | None = None,
+    motifs: list[BoundReferenceMotif] | None = None,
+    config: SchematicPlacementConfig | None = None,
+) -> SchematicPlacementPlan:
+    """Create a deterministic first-pass placement plan for an unwired schematic.
+
+    This is deliberately a hierarchical block placer, not the final joint
+    placement/wiring optimizer. Existing wires are refused by default because
+    moving their endpoint symbols without rerouting would degrade the drawing.
+    """
+    _require_schematic(snapshot)
+    assert snapshot.schematic is not None
+    config = config or SchematicPlacementConfig()
+    if len(snapshot.schematic.parts) > config.max_parts:
+        raise CapabilityUnavailableError(
+            f"Schematic placement is limited to {config.max_parts} parts per plan"
+        )
+    if snapshot.schematic.wires and not config.allow_existing_wires:
+        raise CapabilityUnavailableError(
+            "Schematic placement refuses existing wires until joint placement/rerouting is enabled"
+        )
+    intent = intent or infer_schematic_design_intent(snapshot, motifs=motifs)
+    before = analyze_schematic_layout(
+        snapshot,
+        intent=intent,
+        motifs=motifs,
+        weights=config.weights,
+    )
+    parts_by_id = {part.stable_id: part for part in snapshot.schematic.parts}
+    role_rank: dict[BlockRole, int] = {
+        "connector": 0,
+        "power": 1,
+        "functional": 2,
+        "generic": 3,
+    }
+    blocks = sorted(intent.blocks, key=lambda block: (role_rank[block.role], block.block_id))
+
+    targets: dict[str, Point] = {}
+    unresolved: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    cursor_x = config.origin_x_mm
+    cursor_y = config.origin_y_mm
+    row_height = 0.0
+    for block in blocks:
+        local, width, height = _local_block_layout(block, config)
+        if (
+            cursor_x > config.origin_x_mm
+            and cursor_x + width - config.origin_x_mm > config.target_row_width_mm
+        ):
+            cursor_x = config.origin_x_mm
+            cursor_y += row_height + config.block_gap_y_mm
+            row_height = 0.0
+        block_origin = Point(cursor_x, cursor_y)
+        locked_members = [
+            part_id
+            for part_id in block.member_part_ids
+            if (part := parts_by_id.get(part_id)) is not None and part.locked
+        ]
+        if locked_members:
+            warnings.append(
+                f"Block {block.block_id} contains {len(locked_members)} locked part(s); "
+                "they are preserved."
+            )
+        for part_id, offset in local.items():
+            part = parts_by_id.get(part_id)
+            if part is None:
+                unresolved.append({"part_id": part_id, "reason": "part_missing"})
+                continue
+            if part.locked:
+                current = _position_for(part, None)
+                if current is not None:
+                    targets[part_id] = current
+                else:
+                    unresolved.append({"part_id": part_id, "reason": "locked_position_missing"})
+                continue
+            targets[part_id] = Point(
+                _snap(block_origin.x + offset.x, config.grid_mm),
+                _snap(block_origin.y + offset.y, config.grid_mm),
+            )
+        cursor_x += width + config.block_gap_x_mm
+        row_height = max(row_height, height)
+
+    operations: list[SemanticOperation] = []
+    changed: list[str] = []
+    for part_id in sorted(targets):
+        part = parts_by_id[part_id]
+        current = _position_for(part, None)
+        target = targets[part_id]
+        if current is None:
+            unresolved.append({"part_id": part_id, "reason": "position_missing"})
+            continue
+        if _same_point(current, target):
+            continue
+        operations.append(
+            MoveComponentsOperation(
+                selector=QuerySelector(ids=[part_id]),
+                absolute_x=target.x,
+                absolute_y=target.y,
+            )
+        )
+        changed.append(part_id)
+
+    after = analyze_schematic_layout(
+        snapshot,
+        intent=intent,
+        placements=targets,
+        motifs=motifs,
+        weights=config.weights,
+    )
+    return SchematicPlacementPlan(
+        operations=operations,
+        placements=targets,
+        before=before,
+        after=after,
+        changed_part_ids=changed,
+        unresolved=unresolved,
+        assumptions=[
+            "Blocks are packed deterministically left-to-right and wrapped by a target row width.",
+            "Anchor parts are placed first; support parts are packed near the anchor block.",
+            "Existing part rotation is preserved because exact schematic pin geometry "
+            "is not normalized.",
+        ],
+        warnings=warnings,
+        limitations=[
+            "This first-pass placer does not yet reroute existing wires.",
+            "Datasheet motifs affect scoring only; motif-driven candidate generation "
+            "is a later phase.",
+            "Locked parts are preserved but are not yet used as hard packing obstacles "
+            "for other blocks.",
+            "The planner does not yet generate multiple global placement candidates.",
+        ],
+    )

--- a/src/diptrace_mcp/schematic_layout.py
+++ b/src/diptrace_mcp/schematic_layout.py
@@ -227,7 +227,16 @@ def _part_role(part: ObjectRecord) -> SchematicPartIntent:
     if prefix in {"U", "IC"}:
         if any(
             token in text
-            for token in ("LDO", "BUCK", "BOOST", "REGULATOR", "PMIC", "CONVERTER", "DCDC", "DC/DC")
+            for token in (
+                "LDO",
+                "BUCK",
+                "BOOST",
+                "REGULATOR",
+                "PMIC",
+                "CONVERTER",
+                "DCDC",
+                "DC/DC",
+            )
         ):
             return SchematicPartIntent(
                 part_id=part.stable_id,
@@ -251,7 +260,9 @@ def _part_role(part: ObjectRecord) -> SchematicPartIntent:
             confidence=0.7,
             reasons=["active-device RefDes"],
         )
-    if prefix in {"Y", "X"} or any(token in text for token in ("XTAL", "CRYSTAL", "OSCILLATOR")):
+    if prefix in {"Y", "X"} or any(
+        token in text for token in ("XTAL", "CRYSTAL", "OSCILLATOR")
+    ):
         return SchematicPartIntent(
             part_id=part.stable_id,
             refdes=part.refdes,
@@ -308,7 +319,10 @@ def _net_role(net: ObjectRecord, part_ids: list[str]) -> SchematicNetIntent:
         role: NetRole = "ground"
         confidence = 0.98
         reason = "ground-name pattern"
-    elif re.match(r"^(\+?-?[0-9]+V[0-9]*|VCC|VDD|VIN|VOUT|VBAT|VSYS|VREF)([_-].*)?$", folded):
+    elif re.match(
+        r"^(\+?-?[0-9]+V[0-9]*|VCC|VDD|VIN|VOUT|VBAT|VSYS|VREF)([_-].*)?$",
+        folded,
+    ):
         role = "power"
         confidence = 0.92
         reason = "power-rail name pattern"
@@ -445,8 +459,8 @@ def infer_schematic_design_intent(
                 anchor_nets.update(part_nets.get(anchor_id, set()))
             score = 0
             for net_id in own_nets & anchor_nets:
-                role = net_role_by_id.get(net_id, "unknown")
-                score += 1 if role in {"ground", "power"} else 10
+                net_role = net_role_by_id.get(net_id, "unknown")
+                score += 1 if net_role in {"ground", "power"} else 10
             if score > 0:
                 scores.append((score, key))
         if not scores:
@@ -836,12 +850,14 @@ def analyze_schematic_layout(
     parts_by_id = {part.stable_id: part for part in parts}
     block_spans: list[float] = []
     for block in intent.blocks:
-        positions = [
-            point
-            for part_id in block.member_part_ids
-            if (part := parts_by_id.get(part_id)) is not None
-            and (point := _position_for(part, placements)) is not None
-        ]
+        positions: list[Point] = []
+        for part_id in block.member_part_ids:
+            member_part = parts_by_id.get(part_id)
+            if member_part is None:
+                continue
+            point = _position_for(member_part, placements)
+            if point is not None:
+                positions.append(point)
         if len(positions) < 2:
             block_spans.append(0.0)
             continue
@@ -1019,7 +1035,7 @@ def plan_schematic_placement(
         locked_members = [
             part_id
             for part_id in block.member_part_ids
-            if (part := parts_by_id.get(part_id)) is not None and part.locked
+            if (member_part := parts_by_id.get(part_id)) is not None and member_part.locked
         ]
         if locked_members:
             warnings.append(

--- a/tests/test_schematic_layout.py
+++ b/tests/test_schematic_layout.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from diptrace_mcp.adapters import build_snapshot, stable_id
+from diptrace_mcp.domain import ObjectRecord
+from diptrace_mcp.errors import CapabilityUnavailableError
+from diptrace_mcp.operations import AddWireOperation
+from diptrace_mcp.schematic_layout import (
+    BoundReferenceMotif,
+    ReferenceMotif,
+    ReferenceMotifConstraint,
+    analyze_schematic_layout,
+    infer_schematic_design_intent,
+    plan_schematic_placement,
+    score_reference_motif,
+)
+from diptrace_mcp.semantic_compiler import apply_semantic_operations
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MAX_BYTES = 10_000_000
+
+
+def _load() -> DipTraceDocument:
+    return DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+
+
+def _part(snapshot: object, refdes: str, part_name: str | None = None) -> ObjectRecord:
+    schematic = getattr(snapshot, "schematic")
+    assert schematic is not None
+    matches = [
+        item
+        for item in schematic.parts
+        if item.refdes == refdes
+        and (part_name is None or item.attributes.get("part_name") == part_name)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_intent_groups_support_part_with_multipart_anchor() -> None:
+    snapshot = build_snapshot(_load())
+    intent = infer_schematic_design_intent(snapshot)
+
+    r1 = _part(snapshot, "R1")
+    u1_power = _part(snapshot, "U1", "Power")
+    u1_gpio = _part(snapshot, "U1", "GPIO")
+    block = next(item for item in intent.blocks if u1_power.stable_id in item.anchor_part_ids)
+
+    assert set(block.anchor_part_ids) == {u1_power.stable_id, u1_gpio.stable_id}
+    assert r1.stable_id in block.support_part_ids
+    assert {item.name: item.role for item in intent.nets} == {
+        "VCC": "power",
+        "SIGNAL": "signal",
+    }
+
+
+def test_layout_analysis_exposes_decomposed_baseline_metrics() -> None:
+    analysis = analyze_schematic_layout(build_snapshot(_load()))
+
+    assert analysis.metrics.part_count == 3
+    assert analysis.metrics.block_count == 1
+    assert analysis.metrics.wire_count == 0
+    assert analysis.metrics.part_overlap_count == 0
+    assert analysis.metrics.wire_crossing_count == 0
+    assert analysis.metrics.occupied_area_mm2 > 0
+    assert analysis.metrics.score == pytest.approx(sum(analysis.metrics.score_terms.values()))
+
+
+def test_first_pass_placement_is_deterministic_and_replayable() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+
+    first = plan_schematic_placement(snapshot)
+    second = plan_schematic_placement(snapshot)
+
+    assert [item.model_dump(mode="json") for item in first.operations] == [
+        item.model_dump(mode="json") for item in second.operations
+    ]
+    assert first.after.metrics.mean_block_span_mm <= first.before.metrics.mean_block_span_mm
+    assert first.operations
+
+    applied = apply_semantic_operations(document, first.operations)
+    after_snapshot = build_snapshot(applied.document)
+    for part_id in first.changed_part_ids:
+        expected = first.placements[part_id]
+        actual = after_snapshot.get_object(part_id).position
+        assert actual is not None
+        assert actual["x"] == pytest.approx(expected.x)
+        assert actual["y"] == pytest.approx(expected.y)
+
+
+def test_first_pass_placement_refuses_existing_wires() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+    u1_power = _part(snapshot, "U1", "Power")
+    wired = apply_semantic_operations(
+        document,
+        [
+            AddWireOperation(
+                net="VCC",
+                sheet=0,
+                points=[{"x": 10.0, "y": 20.0}, {"x": 30.0, "y": 20.0}],
+                start={"type": "Pin", "refdes": "R1", "pin": 0},
+                end={"type": "Pin", "part_id": u1_power.stable_id, "pin": 0},
+            )
+        ],
+    )
+
+    with pytest.raises(CapabilityUnavailableError, match="existing wires"):
+        plan_schematic_placement(build_snapshot(wired.document))
+
+
+def test_reference_motif_scores_relative_relationships() -> None:
+    snapshot = build_snapshot(_load())
+    r1 = _part(snapshot, "R1")
+    u1_power = _part(snapshot, "U1", "Power")
+
+    good = BoundReferenceMotif(
+        motif=ReferenceMotif(
+            name="support-left-of-anchor",
+            source="test fixture",
+            source_kind="project",
+            constraints=[
+                ReferenceMotifConstraint(
+                    first_key="support",
+                    second_key="anchor",
+                    relation="left_of",
+                    tolerance_mm=0.0,
+                )
+            ],
+        ),
+        bindings={"support": r1.stable_id, "anchor": u1_power.stable_id},
+    )
+    bad = BoundReferenceMotif(
+        motif=ReferenceMotif(
+            name="support-right-of-anchor",
+            source="test fixture",
+            source_kind="project",
+            constraints=[
+                ReferenceMotifConstraint(
+                    first_key="support",
+                    second_key="anchor",
+                    relation="right_of",
+                    tolerance_mm=0.0,
+                )
+            ],
+        ),
+        bindings={"support": r1.stable_id, "anchor": u1_power.stable_id},
+    )
+
+    assert score_reference_motif(snapshot, good)["violation_count"] == 0
+    assert score_reference_motif(snapshot, bad)["violation_count"] == 1
+
+
+def test_layout_analysis_counts_crossing_between_different_nets() -> None:
+    snapshot = build_snapshot(_load())
+    assert snapshot.schematic is not None
+    snapshot.schematic.wires = [
+        ObjectRecord(
+            stable_id=stable_id("wire", "test", "one"),
+            kind="wire",
+            net_name="A",
+            attributes={
+                "points": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 10.0, "y": 10.0},
+                ]
+            },
+        ),
+        ObjectRecord(
+            stable_id=stable_id("wire", "test", "two"),
+            kind="wire",
+            net_name="B",
+            attributes={
+                "points": [
+                    {"x": 0.0, "y": 10.0},
+                    {"x": 10.0, "y": 0.0},
+                ]
+            },
+        ),
+    ]
+
+    analysis = analyze_schematic_layout(snapshot)
+
+    assert analysis.metrics.wire_crossing_count == 1
+    assert analysis.metrics.diagonal_segment_count == 2

--- a/tests/test_schematic_layout.py
+++ b/tests/test_schematic_layout.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from diptrace_mcp.adapters import build_snapshot, stable_id
+from diptrace_mcp.adapters import DocumentSnapshot, build_snapshot, stable_id
 from diptrace_mcp.domain import ObjectRecord
 from diptrace_mcp.errors import CapabilityUnavailableError
 from diptrace_mcp.operations import AddWireOperation
@@ -28,8 +28,12 @@ def _load() -> DipTraceDocument:
     return DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
 
 
-def _part(snapshot: object, refdes: str, part_name: str | None = None) -> ObjectRecord:
-    schematic = getattr(snapshot, "schematic")
+def _part(
+    snapshot: DocumentSnapshot,
+    refdes: str,
+    part_name: str | None = None,
+) -> ObjectRecord:
+    schematic = snapshot.schematic
     assert schematic is not None
     matches = [
         item


### PR DESCRIPTION
## What changed

- records the intelligent schematic/PCB design track in `docs/ROADMAP.md`;
- adds `src/diptrace_mcp/schematic_layout.py` with conservative design-intent inference, functional-block grouping, structured reference motifs, deterministic readability scoring, and a first hierarchical placement planner;
- adds regression coverage in `tests/test_schematic_layout.py`;
- adds `docs/SCHEMATIC_LAYOUT_ENGINE.md` describing the architecture, limits, and next implementation stages;
- keeps the public MCP tools/list contract unchanged;
- reuses the existing semantic operation and guarded transaction paths rather than introducing a parallel writer.

## Design decisions

- datasheet/reference schematics are modeled as relative motifs, not absolute page-coordinate templates;
- ambiguous support-component grouping is left unresolved instead of guessed;
- power/ground connectivity is weak grouping evidence because those nets commonly span multiple blocks;
- the quality score is decomposed and deterministic rather than an opaque AI score;
- the first placement planner refuses an already-wired schematic by default because moving symbols without rerouting wires would degrade the drawing;
- symbol rotation remains unchanged until trustworthy schematic pin geometry can be scored;
- the existing authored-wire quality layer is intended to become the routing half of the later joint optimizer.

## Why

The project is moving from safe EDA object mutation toward defensible engineering-layout decisions. Schematic layout is the first implementation target because it establishes the generate -> score -> improve architecture before PCB physical constraints are added.

## Validation

- all commits carry DCO sign-off;
- new deterministic unit/regression tests cover intent inference, baseline metrics, replayable placement operations, existing-wire refusal, relative reference motifs, and cross-net wire crossing detection;
- CI is expected to validate pytest, Ruff, mypy, contract checks, and platform builds for the branch.

## Public impact

No public MCP tool, service-method contract, package version, or accepted historical manual-evidence record is changed by this PR.