### PR TITLE
Expose non-mutating schematic wire planning feedback

### DIFF
--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -14,7 +14,9 @@ The current implementation lives in:
 - `src/diptrace_mcp/schematic_layout.py` for design intent, reference motifs,
   deterministic readability metrics, and the first hierarchical placement planner;
 - `src/diptrace_mcp/schematic_optimizer.py` for bounded multi-candidate placement search,
-  estimated future-interconnect cost, candidate ranking, and safe operation planning.
+  estimated future-interconnect cost, candidate ranking, and safe operation planning;
+- `src/diptrace_mcp/schematic_wire_planner.py` for non-mutating route-candidate metrics and
+  explicit placement feedback on pathological schematic interconnect.
 
 ## Design intent
 
@@ -148,11 +150,46 @@ The repository already has a bounded deterministic authored-wire quality layer i
 `services/schematic_wire_quality.py`. It can reroute newly authored wires around component
 and text obstacles and strongly penalizes crossings and overlaps.
 
-The layout modules do not duplicate that router. The next routing phase should expose and
-extend it into a sheet-level candidate planner whose metrics can feed back into placement.
+The layout modules do not duplicate that router. The router remains the candidate generator;
+the planner layer measures and judges the resulting route.
 
-Both placement planners currently refuse an already-wired schematic by default. Moving
-symbols while leaving wire geometry behind would make the drawing worse. Existing-wire
+## Non-mutating wire planner and placement feedback
+
+`schematic_wire_planner.py` is the first Phase 29 coupling layer. It does not apply a wire
+and does not move a symbol. Instead it:
+
+1. measures the caller-supplied `AddWireOperation`;
+2. asks the existing bounded wire cleaner for its deterministic cleaned candidate;
+3. measures that candidate with the same obstacle/crossing model;
+4. selects the lexicographically non-worse route;
+5. checks explicit readability thresholds;
+6. returns `placement_feedback` when the selected route remains pathological.
+
+The exposed wire metrics include:
+
+- component/text obstacle hits;
+- collinear overlaps with existing wires;
+- crossings with existing wires;
+- self-intersections;
+- diagonal segments;
+- bend count;
+- routed length;
+- direct endpoint distance;
+- detour ratio.
+
+Feedback is intentionally advisory. Current repair intents include opening a routing
+corridor, moving endpoint blocks closer, or repacking endpoint blocks. Pin endpoints are
+resolved back to normalized stable part IDs, including multipart RefDes groups where
+applicable, so the later joint optimizer has an explicit target set. The planner does not
+yet invent final move coordinates because trustworthy exact schematic pin geometry is not
+available.
+
+This is the key boundary needed for co-optimization: a router is now allowed to say
+"this route is still bad; placement must change" instead of silently accepting a long or
+collision-prone wire.
+
+Both placement planners still refuse an already-wired schematic by default. Moving symbols
+while leaving existing wire geometry behind would make the drawing worse. Existing-wire
 support belongs in the joint placement/routing optimizer, where affected wires can be
 rerouted atomically.
 
@@ -163,11 +200,10 @@ orientation can be scored reliably enough to justify rotating user-visible symbo
 
 The intended order is:
 
-1. expose the current authored-wire cleaner as a non-mutating route-candidate/metrics API;
-2. let placement candidates be scored with real bounded route candidates, not only the
+1. score placement candidates with real bounded wire candidates instead of only the
    Manhattan estimate;
-3. allow routing to return bounded placement-feedback proposals when a small move removes
-   pathological crossings or detours;
+2. promote single-connection planning into bounded sheet-level net ordering;
+3. turn advisory placement feedback into bounded candidate moves and re-score them;
 4. re-route only affected nets after a placement repair;
 5. add reference-motif-driven placement candidate generation;
 6. normalize or otherwise obtain trustworthy symbol/pin geometry where DipTrace evidence

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -248,6 +248,7 @@ src/diptrace_mcp/routing_compiler.py
 src/diptrace_mcp/scaffolding.py
 src/diptrace_mcp/schematic_layout.py
 src/diptrace_mcp/schematic_optimizer.py
+src/diptrace_mcp/schematic_wire_planner.py
 src/diptrace_mcp/semantic_compiler.py
 src/diptrace_mcp/server.py
 src/diptrace_mcp/server_inputs.py
@@ -389,6 +390,7 @@ tests/test_schematic_authoring.py
 tests/test_schematic_layout.py
 tests/test_schematic_optimizer.py
 tests/test_schematic_pcb_sync.py
+tests/test_schematic_wire_planner.py
 tests/test_schematic_wire_quality.py
 tests/test_semantic_dispatch.py
 tests/test_server.py

--- a/src/diptrace_mcp/schematic_wire_planner.py
+++ b/src/diptrace_mcp/schematic_wire_planner.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field
+
+from .adapters import DocumentSnapshot
+from .domain import StrictModel
+from .geometry import Point, distance
+from .operations import AddWireOperation, WireEndpoint
+from .services.schematic_wire_quality import (
+    _existing_wire_segments,
+    _intentional_wire_touches,
+    _part_obstacles,
+    _quality,
+    _simplify_points,
+    _text_obstacles,
+    _wire_anchor,
+    clean_schematic_wire_operation,
+)
+from .xml_document import DipTraceDocument
+
+_EPS = 1e-9
+FeedbackKind = Literal[
+    "none",
+    "open_routing_corridor",
+    "move_endpoint_blocks_closer",
+    "repack_endpoint_blocks",
+]
+
+
+class SchematicWirePlannerConfig(StrictModel):
+    max_detour_ratio: float = Field(default=2.5, ge=1.0, le=100.0)
+    max_bends: int = Field(default=6, ge=0, le=1_000)
+    require_zero_obstacle_hits: bool = True
+    require_zero_overlaps: bool = True
+    require_zero_crossings: bool = True
+    require_zero_self_intersections: bool = True
+    require_orthogonal: bool = True
+
+
+class SchematicWireMetrics(StrictModel):
+    obstacle_hits: int = Field(ge=0)
+    overlaps: int = Field(ge=0)
+    crossings: int = Field(ge=0)
+    self_intersections: int = Field(ge=0)
+    diagonals: int = Field(ge=0)
+    bends: int = Field(ge=0)
+    length_mm: float = Field(ge=0.0)
+    direct_distance_mm: float = Field(ge=0.0)
+    detour_ratio: float = Field(ge=1.0)
+    quality_key: list[float] = Field(min_length=7, max_length=7)
+
+
+class SchematicWireCandidate(StrictModel):
+    source: Literal["supplied", "cleaned"]
+    operation: AddWireOperation
+    metrics: SchematicWireMetrics
+
+
+class SchematicPlacementFeedback(StrictModel):
+    required: bool
+    kind: FeedbackKind
+    endpoint_part_ids: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SchematicWirePlan(StrictModel):
+    original: SchematicWireCandidate
+    selected: SchematicWireCandidate
+    improved: bool
+    accept_route: bool
+    placement_feedback: SchematicPlacementFeedback
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+def _normalized_points(
+    snapshot: DocumentSnapshot,
+    operation: AddWireOperation,
+) -> list[Point]:
+    points = _simplify_points([Point(item.x, item.y) for item in operation.points])
+    if len(points) < 2:
+        return points
+    points[0] = _wire_anchor(snapshot, operation.start, points[0])
+    points[-1] = _wire_anchor(snapshot, operation.end, points[-1])
+    return _simplify_points(points)
+
+
+def measure_schematic_wire_operation(
+    document: DipTraceDocument,
+    snapshot: DocumentSnapshot,
+    operation: AddWireOperation,
+) -> SchematicWireMetrics:
+    """Measure one authored-wire candidate without mutating the document or snapshot."""
+    points = _normalized_points(snapshot, operation)
+    if len(points) < 2:
+        return SchematicWireMetrics(
+            obstacle_hits=0,
+            overlaps=0,
+            crossings=0,
+            self_intersections=0,
+            diagonals=0,
+            bends=0,
+            length_mm=0.0,
+            direct_distance_mm=0.0,
+            detour_ratio=1.0,
+            quality_key=[0.0] * 7,
+        )
+    start, end = points[0], points[-1]
+    obstacles = [
+        *_part_obstacles(snapshot, operation),
+        *_text_obstacles(document, operation.sheet),
+    ]
+    existing = _existing_wire_segments(snapshot, operation.sheet)
+    touches = _intentional_wire_touches(operation, start, end)
+    quality = _quality(points, obstacles, existing, touches)
+    direct_distance = distance(start, end)
+    detour_ratio = (
+        max(1.0, quality.length / direct_distance)
+        if direct_distance > _EPS
+        else 1.0
+    )
+    return SchematicWireMetrics(
+        obstacle_hits=quality.obstacle_hits,
+        overlaps=quality.overlaps,
+        crossings=quality.crossings,
+        self_intersections=quality.self_intersections,
+        diagonals=quality.diagonals,
+        bends=quality.bends,
+        length_mm=quality.length,
+        direct_distance_mm=direct_distance,
+        detour_ratio=detour_ratio,
+        quality_key=[
+            float(quality.obstacle_hits),
+            float(quality.overlaps),
+            float(quality.crossings),
+            float(quality.self_intersections),
+            float(quality.diagonals),
+            float(quality.bends),
+            quality.length,
+        ],
+    )
+
+
+def _endpoint_part_ids(snapshot: DocumentSnapshot, endpoint: WireEndpoint) -> list[str]:
+    if endpoint.type != "Pin" or snapshot.schematic is None:
+        return []
+    if endpoint.part_id is not None:
+        return sorted(
+            part.stable_id
+            for part in snapshot.schematic.parts
+            if endpoint.part_id in {part.stable_id, part.xml_id or ""}
+        )
+    assert endpoint.refdes is not None
+    return sorted(
+        part.stable_id
+        for part in snapshot.schematic.parts
+        if (part.refdes or "").casefold() == endpoint.refdes.casefold()
+    )
+
+
+def _feedback(
+    snapshot: DocumentSnapshot,
+    operation: AddWireOperation,
+    metrics: SchematicWireMetrics,
+    config: SchematicWirePlannerConfig,
+) -> SchematicPlacementFeedback:
+    reasons: list[str] = []
+    hard_geometry_problem = False
+    if config.require_zero_obstacle_hits and metrics.obstacle_hits:
+        reasons.append(f"route still intersects {metrics.obstacle_hits} visual obstacle(s)")
+        hard_geometry_problem = True
+    if config.require_zero_overlaps and metrics.overlaps:
+        reasons.append(f"route still overlaps {metrics.overlaps} existing wire segment(s)")
+        hard_geometry_problem = True
+    if config.require_zero_crossings and metrics.crossings:
+        reasons.append(f"route still crosses {metrics.crossings} existing wire segment(s)")
+        hard_geometry_problem = True
+    if config.require_zero_self_intersections and metrics.self_intersections:
+        reasons.append(
+            f"route still contains {metrics.self_intersections} self-intersection(s)"
+        )
+        hard_geometry_problem = True
+    if config.require_orthogonal and metrics.diagonals:
+        reasons.append(f"route still contains {metrics.diagonals} diagonal segment(s)")
+        hard_geometry_problem = True
+
+    detour_problem = metrics.detour_ratio > config.max_detour_ratio + _EPS
+    bend_problem = metrics.bends > config.max_bends
+    if detour_problem:
+        reasons.append(
+            f"route detour ratio {metrics.detour_ratio:.3g} exceeds "
+            f"{config.max_detour_ratio:.3g}"
+        )
+    if bend_problem:
+        reasons.append(f"route has {metrics.bends} bends, above limit {config.max_bends}")
+
+    if hard_geometry_problem:
+        kind: FeedbackKind = "open_routing_corridor"
+    elif detour_problem:
+        kind = "move_endpoint_blocks_closer"
+    elif bend_problem:
+        kind = "repack_endpoint_blocks"
+    else:
+        kind = "none"
+
+    endpoint_part_ids = sorted(
+        {
+            *_endpoint_part_ids(snapshot, operation.start),
+            *_endpoint_part_ids(snapshot, operation.end),
+        }
+    )
+    return SchematicPlacementFeedback(
+        required=bool(reasons),
+        kind=kind,
+        endpoint_part_ids=endpoint_part_ids,
+        reasons=reasons,
+    )
+
+
+def plan_schematic_wire_candidate(
+    document: DipTraceDocument,
+    snapshot: DocumentSnapshot,
+    operation: AddWireOperation,
+    *,
+    config: SchematicWirePlannerConfig | None = None,
+) -> SchematicWirePlan:
+    """Return a non-mutating wire candidate and explicit placement feedback.
+
+    The existing bounded wire cleaner remains the route generator. This planner exposes
+    its result as data, measures both the supplied and selected route, and decides whether
+    the selected route is acceptable under explicit readability thresholds. It does not
+    apply the operation and it does not move schematic parts implicitly.
+    """
+    config = config or SchematicWirePlannerConfig()
+    original_metrics = measure_schematic_wire_operation(document, snapshot, operation)
+    cleaned_operation = clean_schematic_wire_operation(document, snapshot, operation)
+    cleaned_metrics = measure_schematic_wire_operation(
+        document,
+        snapshot,
+        cleaned_operation,
+    )
+
+    original_key = tuple(original_metrics.quality_key)
+    cleaned_key = tuple(cleaned_metrics.quality_key)
+    if cleaned_key <= original_key:
+        selected_source: Literal["supplied", "cleaned"] = "cleaned"
+        selected_operation = cleaned_operation
+        selected_metrics = cleaned_metrics
+    else:
+        selected_source = "supplied"
+        selected_operation = operation
+        selected_metrics = original_metrics
+
+    original = SchematicWireCandidate(
+        source="supplied",
+        operation=operation,
+        metrics=original_metrics,
+    )
+    selected = SchematicWireCandidate(
+        source=selected_source,
+        operation=selected_operation,
+        metrics=selected_metrics,
+    )
+    feedback = _feedback(snapshot, selected_operation, selected_metrics, config)
+    improved = (
+        selected.operation.model_dump(mode="json")
+        != operation.model_dump(mode="json")
+    )
+    warnings: list[str] = []
+    if snapshot.schematic is None:
+        warnings.append("Snapshot has no normalized schematic model; route quality is partial.")
+    if math.isclose(selected_metrics.direct_distance_mm, 0.0, abs_tol=_EPS):
+        warnings.append(
+            "Wire endpoints collapse to the same point; detour ratio is not meaningful."
+        )
+
+    return SchematicWirePlan(
+        original=original,
+        selected=selected,
+        improved=improved,
+        accept_route=not feedback.required,
+        placement_feedback=feedback,
+        assumptions=[
+            "The existing deterministic wire cleaner is the route candidate generator.",
+            "Component and text bounds are conservative visual obstacles.",
+            "Placement feedback is advisory and never mutates symbol placement implicitly.",
+        ],
+        warnings=warnings,
+        limitations=[
+            "Exact schematic pin graphics and pin-facing geometry are not normalized.",
+            "Placement feedback identifies affected endpoint parts and repair intent, "
+            "not a final move coordinate.",
+            "The planner evaluates one authored connection at a time; sheet-level net "
+            "ordering is a later phase.",
+        ],
+    )

--- a/tests/test_schematic_wire_planner.py
+++ b/tests/test_schematic_wire_planner.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from diptrace_mcp.adapters import build_snapshot, stable_id
+from diptrace_mcp.domain import ObjectRecord
+from diptrace_mcp.operations import AddWireOperation
+from diptrace_mcp.schematic_wire_planner import plan_schematic_wire_candidate
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MAX_BYTES = 10_000_000
+
+
+def _load() -> DipTraceDocument:
+    return DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+
+
+def test_planner_is_non_mutating_and_routes_around_component_obstacles() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+    before_wire_count = len(document.container.findall(".//Wire"))
+    operation = AddWireOperation(
+        net="VCC",
+        sheet=0,
+        points=[{"x": 0.0, "y": 20.0}, {"x": 50.0, "y": 20.0}],
+        start={"type": "Free"},
+        end={"type": "Free"},
+    )
+
+    plan = plan_schematic_wire_candidate(document, snapshot, operation)
+
+    assert plan.original.metrics.obstacle_hits > 0
+    assert plan.selected.metrics.obstacle_hits == 0
+    assert plan.selected.metrics.diagonals == 0
+    assert plan.improved is True
+    assert plan.accept_route is True
+    assert len(document.container.findall(".//Wire")) == before_wire_count
+    assert snapshot.schematic is not None
+    assert snapshot.schematic.wires == []
+
+
+def test_planner_measures_and_removes_crossing_pressure() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+    assert snapshot.schematic is not None
+    snapshot.schematic.wires = [
+        ObjectRecord(
+            stable_id=stable_id("wire", "test", "existing"),
+            kind="wire",
+            net_name="SIGNAL",
+            attributes={
+                "sheet": 0,
+                "points": [
+                    {"x": 25.0, "y": 0.0},
+                    {"x": 25.0, "y": 40.0},
+                ],
+            },
+        )
+    ]
+    operation = AddWireOperation(
+        net="VCC",
+        sheet=0,
+        points=[{"x": 0.0, "y": 10.0}, {"x": 50.0, "y": 10.0}],
+        start={"type": "Free"},
+        end={"type": "Free"},
+    )
+
+    plan = plan_schematic_wire_candidate(document, snapshot, operation)
+
+    assert plan.original.metrics.crossings >= 1
+    assert plan.selected.metrics.crossings == 0
+    assert plan.selected.metrics.quality_key < plan.original.metrics.quality_key
+
+
+def test_clean_but_pathological_detour_returns_placement_feedback() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+    operation = AddWireOperation(
+        net="VCC",
+        sheet=0,
+        points=[
+            {"x": 0.0, "y": 50.0},
+            {"x": 0.0, "y": 100.0},
+            {"x": 50.0, "y": 100.0},
+            {"x": 50.0, "y": 50.0},
+        ],
+        start={"type": "Free"},
+        end={"type": "Free"},
+    )
+
+    plan = plan_schematic_wire_candidate(document, snapshot, operation)
+
+    assert plan.improved is False
+    assert plan.selected.metrics.detour_ratio == pytest.approx(3.0)
+    assert plan.accept_route is False
+    assert plan.placement_feedback.required is True
+    assert plan.placement_feedback.kind == "move_endpoint_blocks_closer"
+    assert any("detour ratio" in reason for reason in plan.placement_feedback.reasons)
+
+
+def test_feedback_resolves_multipart_pin_endpoints_to_stable_part_ids() -> None:
+    document = _load()
+    snapshot = build_snapshot(document)
+    assert snapshot.schematic is not None
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    u1_parts = [part for part in snapshot.schematic.parts if part.refdes == "U1"]
+    assert len(u1_parts) == 2
+    operation = AddWireOperation(
+        net="VCC",
+        sheet=0,
+        points=[
+            {"x": 10.0, "y": 20.0},
+            {"x": 10.0, "y": 100.0},
+            {"x": 30.0, "y": 100.0},
+            {"x": 30.0, "y": 20.0},
+        ],
+        start={"type": "Pin", "refdes": "R1", "pin": 0},
+        end={"type": "Pin", "refdes": "U1", "pin": 0},
+    )
+
+    plan = plan_schematic_wire_candidate(document, snapshot, operation)
+
+    assert plan.placement_feedback.required is True
+    assert plan.placement_feedback.endpoint_part_ids == sorted(
+        [r1.stable_id, *(part.stable_id for part in u1_parts)]
+    )


### PR DESCRIPTION
## What changed

- adds `src/diptrace_mcp/schematic_wire_planner.py` as the first Phase 29 placement/routing coupling layer;
- measures supplied and cleaned `AddWireOperation` candidates without applying them;
- reuses the existing bounded schematic wire cleaner as the route generator instead of duplicating routing logic;
- exposes obstacle hits, overlaps, crossings, self-intersections, diagonals, bends, route length, direct distance, detour ratio, and the existing lexicographic quality key;
- returns explicit advisory placement feedback when the best bounded route remains pathological;
- resolves Pin endpoints back to normalized stable part IDs, including multipart RefDes groups;
- adds regression coverage for non-mutation, obstacle avoidance, crossing pressure, pathological detour feedback, and multipart endpoint resolution;
- updates release allowlist and schematic-layout architecture documentation.

## Current feedback boundary

Feedback currently names the affected endpoint part IDs and repair intent (`open_routing_corridor`, `move_endpoint_blocks_closer`, or `repack_endpoint_blocks`). It deliberately does not invent final move coordinates before trustworthy schematic pin geometry is available.

## Safety / public surface

- no XML mutation occurs in the planner;
- no symbol movement occurs implicitly;
- no public MCP tool or tools/list contract changes;
- later application still goes through existing semantic operations and guarded transactions;
- all commits carry DCO sign-off.