### PR TITLE
Resolve schematic pin geometry from component libraries

### DIFF
--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -16,7 +16,9 @@ The current implementation lives in:
 - `src/diptrace_mcp/schematic_optimizer.py` for bounded multi-candidate placement search,
   estimated future-interconnect cost, candidate ranking, and safe operation planning;
 - `src/diptrace_mcp/schematic_wire_planner.py` for non-mutating route-candidate metrics and
-  explicit placement feedback on pathological schematic interconnect.
+  explicit placement feedback on pathological schematic interconnect;
+- `src/diptrace_mcp/schematic_pin_geometry.py` for conservative Component Library pin
+  resolution and pin-facing geometric evidence.
 
 ## Design intent
 
@@ -84,8 +86,8 @@ reported weights and terms. It is not an engineering certification or an ML-gene
 quality judgement.
 
 The first score intentionally does not claim exact symbol/pin graphics. Current schematic
-part bounds are conservative proxies, and exact pin coordinates are not normalized yet.
-This limitation is reported instead of being hidden behind guessed geometry.
+part bounds are conservative proxies. Pin geometry can now be resolved when a compatible
+Component Library model is available, but unresolved or ambiguous parts remain explicit.
 
 ## First placement planner
 
@@ -180,38 +182,75 @@ The exposed wire metrics include:
 Feedback is intentionally advisory. Current repair intents include opening a routing
 corridor, moving endpoint blocks closer, or repacking endpoint blocks. Pin endpoints are
 resolved back to normalized stable part IDs, including multipart RefDes groups where
-applicable, so the later joint optimizer has an explicit target set. The planner does not
-yet invent final move coordinates because trustworthy exact schematic pin geometry is not
-available.
+applicable, so the later joint optimizer has an explicit target set.
 
 This is the key boundary needed for co-optimization: a router is now allowed to say
 "this route is still bad; placement must change" instead of silently accepting a long or
 collision-prone wire.
+
+## Component Library pin geometry resolver
+
+Schematic instance XML identifies each part and its Pin indices, but current fixtures do not
+store absolute X/Y on each schematic Pin. Component Library XML does carry relative pin X/Y,
+orientation, electrical type, pin type, multipart ownership and ordered pin identity. The
+resolver joins those two typed models without reparsing XML.
+
+`resolve_schematic_pin_geometry` accepts a normalized schematic snapshot and a typed
+`LibraryModel`. A library component may be selected through:
+
+- an explicit caller binding from schematic `ComponentStyle` to library component stable ID;
+- a `CompTypeN` index hint, but only when the indexed component also passes structural
+  identity checks;
+- an exact unique component-name match that passes the same structural checks.
+
+Structural validation includes multipart index, pin count, component name where applicable,
+and RefDes prefix when both models provide one. Ambiguous or inconsistent matches remain
+unresolved. A `CompTypeN` token is therefore an index hint, not proof of identity.
+
+Within an accepted component part, normalized schematic Pin order is mapped to the existing
+ordered `LibraryPin` list. Each resolved result carries:
+
+- local pin position;
+- local pin orientation;
+- electrical and pin type;
+- matched library component/pin IDs;
+- match basis and confidence;
+- absolute position/orientation when the transform is trustworthy enough to apply.
+
+For unrotated parts, absolute position is the schematic part origin plus the library-relative
+pin position. Non-zero schematic part rotation is fail-closed by default: the project still
+keeps the live-host angle convention as an evidence boundary, so the resolver reports local
+geometry but withholds authoritative absolute geometry. An explicit opt-in mode exists for
+experiments and tests, but using it does not promote the angle convention to accepted host
+evidence.
+
+This resolver is read-only. It does not rotate symbols, move parts, write XML, search online
+libraries, or claim that a matched library revision is identical to the original project
+revision.
 
 Both placement planners still refuse an already-wired schematic by default. Moving symbols
 while leaving existing wire geometry behind would make the drawing worse. Existing-wire
 support belongs in the joint placement/routing optimizer, where affected wires can be
 rerouted atomically.
 
-Rotation is also preserved. Exact schematic pin geometry is required before automatic
-orientation can be scored reliably enough to justify rotating user-visible symbols.
-
 ## Next implementation steps
 
 The intended order is:
 
-1. score placement candidates with real bounded wire candidates instead of only the
-   Manhattan estimate;
-2. promote single-connection planning into bounded sheet-level net ordering;
-3. turn advisory placement feedback into bounded candidate moves and re-score them;
-4. re-route only affected nets after a placement repair;
-5. add reference-motif-driven placement candidate generation;
-6. normalize or otherwise obtain trustworthy symbol/pin geometry where DipTrace evidence
-   permits orientation scoring;
-7. run placement, routing and scoring in a bounded generate -> score -> improve loop;
-8. preserve the existing guarded transaction/review path for the selected candidate;
-9. expose only a small deliberate public MCP surface after the internal architecture is
-   proven.
+1. feed resolved absolute pin endpoints into bounded route-candidate scoring when geometry
+   is available, with part-anchor estimation retained only as an explicit fallback;
+2. score placement candidates with real bounded wire candidates instead of only the
+   Manhattan anchor estimate;
+3. promote single-connection planning into bounded sheet-level net ordering;
+4. turn advisory placement feedback into bounded candidate moves and re-score them;
+5. re-route only affected nets after a placement repair;
+6. add reference-motif-driven placement candidate generation;
+7. validate schematic rotation semantics in the real host before enabling automatic
+   pin-facing rotation decisions by default;
+8. run placement, routing and scoring in a bounded generate -> score -> improve loop;
+9. preserve the existing guarded transaction/review path for the selected candidate;
+10. expose only a small deliberate public MCP surface after the internal architecture is
+    proven.
 
 The quality target is practical: a deliberately ugly but electrically correct schematic
 should become materially easier for an engineer to read without routine manual cleanup.

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -248,6 +248,7 @@ src/diptrace_mcp/routing_compiler.py
 src/diptrace_mcp/scaffolding.py
 src/diptrace_mcp/schematic_layout.py
 src/diptrace_mcp/schematic_optimizer.py
+src/diptrace_mcp/schematic_pin_geometry.py
 src/diptrace_mcp/schematic_wire_planner.py
 src/diptrace_mcp/semantic_compiler.py
 src/diptrace_mcp/server.py
@@ -390,6 +391,7 @@ tests/test_schematic_authoring.py
 tests/test_schematic_layout.py
 tests/test_schematic_optimizer.py
 tests/test_schematic_pcb_sync.py
+tests/test_schematic_pin_geometry.py
 tests/test_schematic_wire_planner.py
 tests/test_schematic_wire_quality.py
 tests/test_semantic_dispatch.py

--- a/src/diptrace_mcp/schematic_pin_geometry.py
+++ b/src/diptrace_mcp/schematic_pin_geometry.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import copy
+import math
+import re
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from typing import Any, Literal
+
+from pydantic import Field
+
+from .adapters import DocumentSnapshot, build_snapshot
+from .domain import LibraryComponent, LibraryModel, LibraryPin, ObjectRecord, StrictModel
+from .geometry import Point, Transform
+from .library_adapters import get_library_model
+from .xml_document import DipTraceDocument
+
+_EPS = 1e-9
+MatchBasis = Literal["explicit_binding", "component_style_index", "unique_component_name"]
+LibrarySource = Literal["provided", "embedded_design_cache", "external_fallback"]
+
+
+class SchematicPinGeometryConfig(StrictModel):
+    allow_component_style_index_match: bool = True
+    allow_unique_component_name_match: bool = True
+    allow_unverified_part_rotation: bool = False
+    allow_external_library_fallback: bool = False
+
+
+class ResolvedSchematicPinGeometry(StrictModel):
+    pin_id: str
+    part_id: str
+    refdes: str | None = None
+    pin_index: int = Field(ge=0)
+    library_component_id: str
+    library_pin_id: str
+    library_part_index: int = Field(ge=0)
+    local_position: dict[str, float]
+    absolute_position: dict[str, float] | None = None
+    local_orientation_deg: float
+    absolute_orientation_deg: float | None = None
+    electrical_type: str
+    pin_type: str
+    match_basis: MatchBasis
+    confidence: float = Field(ge=0.0, le=1.0)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class SchematicPinGeometryResolution(StrictModel):
+    pins: list[ResolvedSchematicPinGeometry] = Field(default_factory=list)
+    unresolved: list[dict[str, Any]] = Field(default_factory=list)
+    component_matches: dict[str, str] = Field(default_factory=dict)
+    library_source: LibrarySource = "provided"
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+def _pin_index(pin: ObjectRecord) -> int | None:
+    raw = pin.xml_id or ""
+    _, separator, suffix = raw.rpartition(":")
+    if not separator:
+        return None
+    try:
+        value = int(suffix)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _component_part_index(part: ObjectRecord) -> int | None:
+    raw = str(part.attributes.get("component_part", "")).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _part_pins(snapshot: DocumentSnapshot) -> dict[str, list[ObjectRecord]]:
+    assert snapshot.schematic is not None
+    result: dict[str, list[ObjectRecord]] = defaultdict(list)
+    for pin in snapshot.schematic.pins:
+        if pin.parent_id is not None:
+            result[pin.parent_id].append(pin)
+    return result
+
+
+def _component_pins(component: LibraryComponent, part_index: int) -> list[LibraryPin]:
+    return [pin for pin in component.pins if pin.part_index == part_index]
+
+
+def _refdes_prefix(refdes: str | None) -> str:
+    if not refdes:
+        return ""
+    match = re.match(r"[A-Za-z]+", refdes)
+    return match.group(0).casefold() if match else ""
+
+
+def _validate_component_match(
+    part: ObjectRecord,
+    schematic_pin_count: int,
+    component: LibraryComponent,
+    component_part: int,
+    *,
+    require_name: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if component_part >= component.part_count:
+        reasons.append(
+            f"component part index {component_part} is outside library part_count "
+            f"{component.part_count}"
+        )
+        return reasons
+    library_pins = _component_pins(component, component_part)
+    if len(library_pins) != schematic_pin_count:
+        reasons.append(
+            f"schematic pin count {schematic_pin_count} does not match library part pin "
+            f"count {len(library_pins)}"
+        )
+    part_name = (part.name or "").strip().casefold()
+    component_name = component.name.strip().casefold()
+    if require_name and part_name and component_name and part_name != component_name:
+        reasons.append(
+            f"schematic name {part.name!r} does not match library component "
+            f"name {component.name!r}"
+        )
+    schematic_prefix = _refdes_prefix(part.refdes)
+    library_prefix = component.refdes.strip().casefold()
+    if schematic_prefix and library_prefix and schematic_prefix != library_prefix:
+        reasons.append(
+            f"schematic RefDes prefix {schematic_prefix!r} does not match library "
+            f"prefix {library_prefix!r}"
+        )
+    return reasons
+
+
+def _style_index(component_style: str) -> int | None:
+    match = re.fullmatch(r"CompType([0-9]+)", component_style.strip(), flags=re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _match_component(
+    part: ObjectRecord,
+    schematic_pin_count: int,
+    library: LibraryModel,
+    bindings: dict[str, str],
+    config: SchematicPinGeometryConfig,
+) -> tuple[LibraryComponent | None, MatchBasis | None, list[str]]:
+    component_part = _component_part_index(part)
+    if component_part is None:
+        return None, None, ["schematic component_part is missing or invalid"]
+
+    component_style = str(part.attributes.get("component_style", "")).strip()
+    by_id = {component.stable_id: component for component in library.components}
+    if component_style in bindings:
+        component = by_id.get(bindings[component_style])
+        if component is None:
+            return None, None, ["explicit binding points to a missing library component"]
+        problems = _validate_component_match(
+            part,
+            schematic_pin_count,
+            component,
+            component_part,
+            require_name=False,
+        )
+        if problems:
+            return None, None, problems
+        return component, "explicit_binding", []
+
+    if config.allow_component_style_index_match:
+        style_index = _style_index(component_style)
+        if style_index is not None:
+            indexed = [
+                component
+                for component in library.components
+                if component.index == style_index
+            ]
+            if len(indexed) == 1:
+                problems = _validate_component_match(
+                    part,
+                    schematic_pin_count,
+                    indexed[0],
+                    component_part,
+                    require_name=True,
+                )
+                if not problems:
+                    return indexed[0], "component_style_index", []
+
+    if config.allow_unique_component_name_match and part.name:
+        name = part.name.strip().casefold()
+        candidates = [
+            component
+            for component in library.components
+            if component.name.strip().casefold() == name
+            and not _validate_component_match(
+                part,
+                schematic_pin_count,
+                component,
+                component_part,
+                require_name=True,
+            )
+        ]
+        if len(candidates) == 1:
+            return candidates[0], "unique_component_name", []
+        if len(candidates) > 1:
+            return None, None, [
+                f"{len(candidates)} library components match schematic name {part.name!r}"
+            ]
+
+    return None, None, [
+        "no unique structurally compatible library component could be resolved"
+    ]
+
+
+def _absolute_geometry(
+    part: ObjectRecord,
+    pin: LibraryPin,
+    config: SchematicPinGeometryConfig,
+) -> tuple[dict[str, float] | None, float | None, list[str]]:
+    warnings: list[str] = []
+    if part.position is None or pin.position is None:
+        return None, None, ["part or library pin position is unavailable"]
+    local = Point(**pin.position)
+    origin = Point(**part.position)
+    angle = part.rotation_deg
+    if not math.isclose(angle, 0.0, abs_tol=_EPS) and not config.allow_unverified_part_rotation:
+        return None, None, [
+            "non-zero schematic part rotation is not applied because the live DipTrace "
+            "angle convention is not yet trusted for pin geometry"
+        ]
+    if math.isclose(angle, 0.0, abs_tol=_EPS):
+        absolute = Point(origin.x + local.x, origin.y + local.y)
+    else:
+        absolute = Transform(
+            translate_x=origin.x,
+            translate_y=origin.y,
+            rotation_deg=angle,
+        ).apply_point(local)
+        warnings.append(
+            "absolute pin geometry uses the currently parsed schematic rotation convention"
+        )
+    orientation = (pin.orientation_deg + angle) % 360.0
+    return absolute.as_dict(), orientation, warnings
+
+
+def get_embedded_schematic_component_library(
+    document: DipTraceDocument,
+) -> LibraryModel | None:
+    """Return the schematic's embedded design-cache Component Library model.
+
+    DipTrace stores the project design cache as a sibling ``Library`` element under the
+    schematic ``Source`` root.  Reusing ``get_library_model`` keeps component/pin parsing in
+    one typed adapter rather than introducing a second XML interpretation here.
+    """
+    if document.source_type != "DipTrace-Schematic":
+        return None
+    library_root = document.root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    if library_root is None:
+        return None
+    root = copy.deepcopy(library_root)
+    root.set("Type", "DipTrace-ComponentLibrary")
+    root.set("Version", root.get("Version", document.version))
+    root.set("Units", root.get("Units", document.units))
+    embedded = DipTraceDocument(
+        path=document.path,
+        root=root,
+        raw_bytes=ET.tostring(root, encoding="utf-8"),
+    )
+    return get_library_model(embedded)
+
+
+def resolve_schematic_pin_geometry(
+    snapshot: DocumentSnapshot,
+    library: LibraryModel,
+    *,
+    bindings: dict[str, str] | None = None,
+    config: SchematicPinGeometryConfig | None = None,
+) -> SchematicPinGeometryResolution:
+    """Resolve schematic Pin records against a component-library geometry model.
+
+    Resolution is intentionally conservative. Opaque component styles are never treated as
+    sufficient evidence by themselves. A CompTypeN index hint is accepted only when the
+    indexed library component also matches the schematic component name, RefDes prefix,
+    multipart index and pin count. Otherwise an exact unique component-name match or an
+    explicit caller binding is required.
+    """
+    config = config or SchematicPinGeometryConfig()
+    bindings = dict(bindings or {})
+    if snapshot.schematic is None:
+        return SchematicPinGeometryResolution(
+            unresolved=[{"reason": "snapshot_has_no_schematic"}],
+            limitations=["Schematic pin geometry requires a normalized schematic snapshot."],
+        )
+    if not library.components:
+        return SchematicPinGeometryResolution(
+            unresolved=[{"reason": "component_library_has_no_components"}],
+            limitations=["A Component Library model with symbol pins is required."],
+        )
+
+    pins_by_part = _part_pins(snapshot)
+    resolved: list[ResolvedSchematicPinGeometry] = []
+    unresolved: list[dict[str, Any]] = []
+    component_matches: dict[str, str] = {}
+    aggregate_warnings: list[str] = []
+
+    for part in sorted(snapshot.schematic.parts, key=lambda item: item.stable_id):
+        schematic_pins = pins_by_part.get(part.stable_id, [])
+        component_part = _component_part_index(part)
+        component, basis, match_problems = _match_component(
+            part,
+            len(schematic_pins),
+            library,
+            bindings,
+            config,
+        )
+        if component is None or basis is None or component_part is None:
+            unresolved.append(
+                {
+                    "part_id": part.stable_id,
+                    "refdes": part.refdes,
+                    "component_style": part.attributes.get("component_style"),
+                    "reasons": match_problems,
+                }
+            )
+            continue
+        component_matches[part.stable_id] = component.stable_id
+        library_pins = _component_pins(component, component_part)
+        for schematic_pin in schematic_pins:
+            pin_index = _pin_index(schematic_pin)
+            if pin_index is None or pin_index >= len(library_pins):
+                unresolved.append(
+                    {
+                        "pin_id": schematic_pin.stable_id,
+                        "part_id": part.stable_id,
+                        "reason": "pin_index_cannot_be_mapped_to_library_part",
+                    }
+                )
+                continue
+            library_pin = library_pins[pin_index]
+            if library_pin.position is None:
+                unresolved.append(
+                    {
+                        "pin_id": schematic_pin.stable_id,
+                        "part_id": part.stable_id,
+                        "reason": "library_pin_has_no_position",
+                    }
+                )
+                continue
+            absolute, absolute_orientation, geometry_warnings = _absolute_geometry(
+                part,
+                library_pin,
+                config,
+            )
+            aggregate_warnings.extend(geometry_warnings)
+            confidence = {
+                "explicit_binding": 0.98,
+                "component_style_index": 0.95,
+                "unique_component_name": 0.9,
+            }[basis]
+            if absolute is None:
+                confidence = min(confidence, 0.7)
+            resolved.append(
+                ResolvedSchematicPinGeometry(
+                    pin_id=schematic_pin.stable_id,
+                    part_id=part.stable_id,
+                    refdes=part.refdes,
+                    pin_index=pin_index,
+                    library_component_id=component.stable_id,
+                    library_pin_id=library_pin.stable_id,
+                    library_part_index=component_part,
+                    local_position=dict(library_pin.position),
+                    absolute_position=absolute,
+                    local_orientation_deg=library_pin.orientation_deg,
+                    absolute_orientation_deg=absolute_orientation,
+                    electrical_type=library_pin.electrical_type,
+                    pin_type=library_pin.pin_type,
+                    match_basis=basis,
+                    confidence=confidence,
+                    warnings=geometry_warnings,
+                )
+            )
+
+    return SchematicPinGeometryResolution(
+        pins=resolved,
+        unresolved=unresolved,
+        component_matches=component_matches,
+        assumptions=[
+            "Schematic pin order is matched to library pin order within the resolved "
+            "component part, consistent with the current normalized Pin indexing model.",
+            "CompTypeN is only an index hint; structural identity checks are mandatory.",
+            "Non-zero part rotation is fail-closed by default until its live-host angle "
+            "convention is accepted for pin geometry.",
+        ],
+        warnings=sorted(set(aggregate_warnings)),
+        limitations=[
+            "This resolver does not search external libraries or download datasheets.",
+            "Mirroring and arbitrary rotated schematic symbols require verified host "
+            "semantics before they can be authoritative.",
+            "A resolved pin coordinate is geometric evidence, not proof that the chosen "
+            "library revision exactly matches the original project library revision.",
+        ],
+    )
+
+
+def resolve_document_schematic_pin_geometry(
+    document: DipTraceDocument,
+    *,
+    bindings: dict[str, str] | None = None,
+    fallback_library: LibraryModel | None = None,
+    config: SchematicPinGeometryConfig | None = None,
+) -> SchematicPinGeometryResolution:
+    """Resolve pin geometry using the schematic's own embedded design cache first.
+
+    A standalone Component Library may be supplied as a fallback, but it is ignored unless
+    ``allow_external_library_fallback`` is explicitly enabled.  This avoids silently mixing
+    a project with a different library revision when the authoritative design cache is
+    missing or incomplete.
+    """
+    config = config or SchematicPinGeometryConfig()
+    if document.source_type != "DipTrace-Schematic":
+        return SchematicPinGeometryResolution(
+            unresolved=[{"reason": "document_is_not_schematic"}],
+            limitations=["Document-level pin geometry requires DipTrace-Schematic XML."],
+        )
+
+    snapshot = build_snapshot(document)
+    embedded = get_embedded_schematic_component_library(document)
+    if embedded is not None and embedded.components:
+        resolution = resolve_schematic_pin_geometry(
+            snapshot,
+            embedded,
+            bindings=bindings,
+            config=config,
+        )
+        resolution.library_source = "embedded_design_cache"
+        resolution.assumptions.append(
+            "Component geometry was resolved from the schematic's embedded design cache."
+        )
+        return resolution
+
+    if fallback_library is not None and config.allow_external_library_fallback:
+        resolution = resolve_schematic_pin_geometry(
+            snapshot,
+            fallback_library,
+            bindings=bindings,
+            config=config,
+        )
+        resolution.library_source = "external_fallback"
+        resolution.warnings.append(
+            "Embedded design-cache component geometry was unavailable; an explicitly "
+            "enabled external Component Library fallback was used."
+        )
+        return resolution
+
+    limitations = [
+        "The schematic has no usable embedded design-cache component geometry.",
+    ]
+    if fallback_library is not None and not config.allow_external_library_fallback:
+        limitations.append(
+            "An external Component Library was supplied but fallback is disabled by default."
+        )
+    return SchematicPinGeometryResolution(
+        unresolved=[{"reason": "embedded_design_cache_has_no_components"}],
+        library_source="embedded_design_cache",
+        limitations=limitations,
+    )

--- a/tests/test_schematic_pin_geometry.py
+++ b/tests/test_schematic_pin_geometry.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.library_adapters import get_library_model
+from diptrace_mcp.schematic_pin_geometry import (
+    SchematicPinGeometryConfig,
+    get_embedded_schematic_component_library,
+    resolve_document_schematic_pin_geometry,
+    resolve_schematic_pin_geometry,
+)
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MAX_BYTES = 10_000_000
+
+
+def _schematic_document() -> DipTraceDocument:
+    return DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+
+
+def _schematic_snapshot():
+    return build_snapshot(_schematic_document())
+
+
+def _library_document() -> DipTraceDocument:
+    return DipTraceDocument.load(FIXTURES / "component_library.xml", MAX_BYTES)
+
+
+def _library_model():
+    return get_library_model(_library_document())
+
+
+def _schematic_document_with_embedded_library() -> DipTraceDocument:
+    schematic = _schematic_document()
+    library = _library_document()
+    root = ET.fromstring(schematic.raw_bytes)
+    existing = root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert existing is not None
+    index = list(root).index(existing)
+    root.remove(existing)
+    root.insert(index, ET.fromstring(library.raw_bytes))
+    raw = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return DipTraceDocument.from_bytes(schematic.path, raw)
+
+
+def test_comp_type_index_resolves_verified_resistor_pin_geometry() -> None:
+    resolution = resolve_schematic_pin_geometry(_schematic_snapshot(), _library_model())
+
+    r1_pins = sorted(
+        (pin for pin in resolution.pins if pin.refdes == "R1"),
+        key=lambda pin: pin.pin_index,
+    )
+    assert len(r1_pins) == 2
+    assert [pin.match_basis for pin in r1_pins] == [
+        "component_style_index",
+        "component_style_index",
+    ]
+    assert r1_pins[0].local_position == {"x": -1.0, "y": 0.0}
+    assert r1_pins[1].local_position == {"x": 1.0, "y": 0.0}
+    assert r1_pins[0].absolute_position == pytest.approx({"x": 9.0, "y": 20.0})
+    assert r1_pins[1].absolute_position == pytest.approx({"x": 11.0, "y": 20.0})
+    assert [pin.local_orientation_deg for pin in r1_pins] == [0.0, 180.0]
+    assert [pin.electrical_type for pin in r1_pins] == ["Passive", "Passive"]
+
+
+def test_unavailable_library_component_fails_closed_for_mcu_parts() -> None:
+    resolution = resolve_schematic_pin_geometry(_schematic_snapshot(), _library_model())
+
+    unresolved_u1 = [item for item in resolution.unresolved if item.get("refdes") == "U1"]
+    assert len(unresolved_u1) == 2
+    assert all(
+        "no unique structurally compatible library component" in " ".join(item["reasons"])
+        for item in unresolved_u1
+    )
+    assert all(pin.refdes != "U1" for pin in resolution.pins)
+
+
+def test_component_style_index_is_only_a_hint_when_name_does_not_match() -> None:
+    snapshot = _schematic_snapshot()
+    assert snapshot.schematic is not None
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    r1.name = "WRONG_COMPONENT"
+
+    resolution = resolve_schematic_pin_geometry(snapshot, _library_model())
+
+    assert all(pin.refdes != "R1" for pin in resolution.pins)
+    unresolved = next(item for item in resolution.unresolved if item.get("refdes") == "R1")
+    assert "no unique structurally compatible library component" in " ".join(
+        unresolved["reasons"]
+    )
+
+
+def test_explicit_binding_can_override_name_but_not_structural_mismatch() -> None:
+    snapshot = _schematic_snapshot()
+    library = _library_model()
+    assert snapshot.schematic is not None
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    r1.name = "PROJECT_ALIAS"
+    component = library.components[0]
+
+    resolution = resolve_schematic_pin_geometry(
+        snapshot,
+        library,
+        bindings={"CompType0": component.stable_id},
+    )
+
+    r1_pins = [pin for pin in resolution.pins if pin.refdes == "R1"]
+    assert len(r1_pins) == 2
+    assert {pin.match_basis for pin in r1_pins} == {"explicit_binding"}
+
+    snapshot.schematic.pins = [
+        pin
+        for pin in snapshot.schematic.pins
+        if not (pin.parent_id == r1.stable_id and pin.label == "pin-1")
+    ]
+    mismatched = resolve_schematic_pin_geometry(
+        snapshot,
+        library,
+        bindings={"CompType0": component.stable_id},
+    )
+    assert all(pin.refdes != "R1" for pin in mismatched.pins)
+    unresolved = next(item for item in mismatched.unresolved if item.get("refdes") == "R1")
+    assert "pin count" in " ".join(unresolved["reasons"])
+
+
+def test_nonzero_part_rotation_is_fail_closed_by_default() -> None:
+    snapshot = _schematic_snapshot()
+    assert snapshot.schematic is not None
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    r1.rotation_deg = 90.0
+
+    resolution = resolve_schematic_pin_geometry(snapshot, _library_model())
+
+    r1_pins = [pin for pin in resolution.pins if pin.refdes == "R1"]
+    assert len(r1_pins) == 2
+    assert all(pin.absolute_position is None for pin in r1_pins)
+    assert all(pin.absolute_orientation_deg is None for pin in r1_pins)
+    assert all(pin.confidence <= 0.7 for pin in r1_pins)
+    assert any("angle convention" in warning for warning in resolution.warnings)
+
+
+def test_rotation_transform_is_opt_in_until_host_semantics_are_verified() -> None:
+    snapshot = _schematic_snapshot()
+    assert snapshot.schematic is not None
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    r1.rotation_deg = 90.0
+
+    resolution = resolve_schematic_pin_geometry(
+        snapshot,
+        _library_model(),
+        config=SchematicPinGeometryConfig(allow_unverified_part_rotation=True),
+    )
+
+    r1_pins = sorted(
+        (pin for pin in resolution.pins if pin.refdes == "R1"),
+        key=lambda pin: pin.pin_index,
+    )
+    assert r1_pins[0].absolute_position == pytest.approx({"x": 10.0, "y": 19.0})
+    assert r1_pins[1].absolute_position == pytest.approx({"x": 10.0, "y": 21.0})
+    assert r1_pins[0].absolute_orientation_deg == pytest.approx(90.0)
+    assert r1_pins[1].absolute_orientation_deg == pytest.approx(270.0)
+    assert any("parsed schematic rotation" in warning for warning in resolution.warnings)
+
+
+def test_embedded_design_cache_is_primary_document_geometry_source() -> None:
+    document = _schematic_document_with_embedded_library()
+
+    embedded = get_embedded_schematic_component_library(document)
+    assert embedded is not None
+    assert [component.name for component in embedded.components] == ["RES_0603"]
+
+    resolution = resolve_document_schematic_pin_geometry(document)
+
+    assert resolution.library_source == "embedded_design_cache"
+    r1_pins = sorted(
+        (pin for pin in resolution.pins if pin.refdes == "R1"),
+        key=lambda pin: pin.pin_index,
+    )
+    assert [pin.absolute_position for pin in r1_pins] == pytest.approx(
+        [{"x": 9.0, "y": 20.0}, {"x": 11.0, "y": 20.0}]
+    )
+    assert any("embedded design cache" in item for item in resolution.assumptions)
+
+
+def test_external_library_fallback_is_disabled_by_default() -> None:
+    document = _schematic_document()
+
+    resolution = resolve_document_schematic_pin_geometry(
+        document,
+        fallback_library=_library_model(),
+    )
+
+    assert not resolution.pins
+    assert resolution.library_source == "embedded_design_cache"
+    assert any("fallback is disabled" in item for item in resolution.limitations)
+
+
+def test_external_library_fallback_requires_explicit_opt_in() -> None:
+    document = _schematic_document()
+
+    resolution = resolve_document_schematic_pin_geometry(
+        document,
+        fallback_library=_library_model(),
+        config=SchematicPinGeometryConfig(allow_external_library_fallback=True),
+    )
+
+    assert resolution.library_source == "external_fallback"
+    assert len([pin for pin in resolution.pins if pin.refdes == "R1"]) == 2
+    assert any("external Component Library fallback" in item for item in resolution.warnings)


### PR DESCRIPTION
## What changed

- adds `src/diptrace_mcp/schematic_pin_geometry.py` as a conservative resolver from normalized schematic Pin records to typed Component Library pin geometry;
- resolves relative pin X/Y, orientation, electrical type and pin type without adding a second XML parser;
- adds a document-level resolver that extracts and prefers the schematic's own embedded Design Cache Component Library;
- keeps standalone/external Component Library use behind an explicit opt-in fallback instead of silently mixing library revisions;
- supports explicit component-style bindings, structurally verified `CompTypeN` index hints, and unique exact component-name matching;
- validates multipart index, schematic/library pin count, component name and RefDes prefix before accepting inferred matches;
- maps schematic pin order to library pin order within the resolved component part, consistent with DipTrace's positional Pin indexing;
- produces absolute pin coordinates for unrotated schematic parts;
- fails closed for non-zero schematic part rotation by default because the live-host acceptance gate for angle-dependent geometry is still intentionally separate;
- provides an explicit opt-in transform mode for experiments without upgrading that evidence to authoritative behavior;
- adds regression coverage for embedded Design Cache resolution, external fallback policy, structural identity checks and rotation boundaries.

## Why

Schematic instance Pin records carry connectivity and positional pin identity, while symbol pin geometry lives in the embedded project library. The placement optimizer currently falls back to part-anchor interconnect estimates. This resolver supplies the missing pin-facing geometry layer needed for real bounded pin-to-pin route scoring.

## Safety / evidence boundary

- no XML is mutated;
- no symbols are rotated or moved;
- the project's embedded Design Cache is preferred over an arbitrary standalone library;
- external library fallback requires explicit opt-in;
- ambiguous or structurally inconsistent library matches are unresolved rather than guessed;
- non-zero part rotation remains fail-closed by default;
- no public MCP tool or tools/list contract changes.

## CI / merge discipline

Intermediate connector commits are intentionally being consolidated after functional checks. Before merge the branch will be rebuilt as one DCO-signed commit on current `main`, then the complete CI matrix will be rerun on that exact head.