### PR TITLE
Score schematic placement candidates with pin-aware routes

### DIFF
--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -17,8 +17,10 @@ The current implementation lives in:
   estimated future-interconnect cost, candidate ranking, and safe operation planning;
 - `src/diptrace_mcp/schematic_wire_planner.py` for non-mutating route-candidate metrics and
   explicit placement feedback on pathological schematic interconnect;
-- `src/diptrace_mcp/schematic_pin_geometry.py` for conservative Component Library pin
-  resolution and pin-facing geometric evidence.
+- `src/diptrace_mcp/schematic_pin_geometry.py` for conservative embedded Design Cache pin
+  resolution and pin-facing geometric evidence;
+- `src/diptrace_mcp/schematic_joint_optimizer.py` for non-mutating pin-aware routing of
+  hypothetical placement candidates and joint route/placement ranking.
 
 ## Design intent
 
@@ -86,8 +88,8 @@ reported weights and terms. It is not an engineering certification or an ML-gene
 quality judgement.
 
 The first score intentionally does not claim exact symbol/pin graphics. Current schematic
-part bounds are conservative proxies. Pin geometry can now be resolved when a compatible
-Component Library model is available, but unresolved or ambiguous parts remain explicit.
+part bounds are conservative proxies. Pin geometry can now be resolved from a compatible
+embedded Design Cache, but unresolved or ambiguous parts remain explicit.
 
 ## First placement planner
 
@@ -130,11 +132,12 @@ The current optimizer score includes:
   it feeds;
 - movement from the existing layout.
 
-Future interconnect is deliberately an estimate, not fake detailed routing. For each net the
-optimizer builds a deterministic minimum-spanning connection estimate between placed parts
-and compares the two Manhattan L-shape orientations while accumulating estimated crossings.
-Ground is excluded from this estimate and power may be down-weighted/configured separately.
-This makes placement route-aware before the full sheet router is coupled to it.
+Future interconnect in this first-stage score remains an estimate. For each net the optimizer
+builds a deterministic minimum-spanning connection estimate between placed parts and compares
+the two Manhattan L-shape orientations while accumulating estimated crossings. Ground is
+excluded from this estimate and power may be down-weighted/configured separately. The joint
+route scorer described below can now re-rank those candidates with bounded real wire
+candidates before any placement is applied.
 
 The selected candidate is the minimum ranked candidate under the disclosed score and stable
 tie-breakers. `plan_optimized_schematic_placement` then emits ordinary
@@ -153,7 +156,7 @@ The repository already has a bounded deterministic authored-wire quality layer i
 and text obstacles and strongly penalizes crossings and overlaps.
 
 The layout modules do not duplicate that router. The router remains the candidate generator;
-the planner layer measures and judges the resulting route.
+the planner and joint optimizer layers measure and judge the resulting routes.
 
 ## Non-mutating wire planner and placement feedback
 
@@ -190,13 +193,18 @@ collision-prone wire.
 
 ## Component Library pin geometry resolver
 
-Schematic instance XML identifies each part and its Pin indices, but current fixtures do not
-store absolute X/Y on each schematic Pin. Component Library XML does carry relative pin X/Y,
-orientation, electrical type, pin type, multipart ownership and ordered pin identity. The
-resolver joins those two typed models without reparsing XML.
+Schematic instance XML identifies each part and its Pin indices, while symbol pin geometry
+lives in the project's embedded Design Cache Component Library. Component Library XML carries
+relative pin X/Y, orientation, electrical type, pin type, multipart ownership and ordered pin
+identity. The resolver joins those two typed models without adding a second XML parser.
 
-`resolve_schematic_pin_geometry` accepts a normalized schematic snapshot and a typed
-`LibraryModel`. A library component may be selected through:
+`resolve_document_schematic_pin_geometry` prefers the schematic's own embedded Design Cache.
+A standalone Component Library can be supplied as a fallback only through explicit opt-in;
+it is not silently mixed into a project because it may represent a different library
+revision.
+
+The lower-level `resolve_schematic_pin_geometry` accepts a normalized schematic snapshot and
+a typed `LibraryModel`. A library component may be selected through:
 
 - an explicit caller binding from schematic `ComponentStyle` to library component stable ID;
 - a `CompTypeN` index hint, but only when the indexed component also passes structural
@@ -226,31 +234,78 @@ evidence.
 
 This resolver is read-only. It does not rotate symbols, move parts, write XML, search online
 libraries, or claim that a matched library revision is identical to the original project
-revision.
+library revision.
+
+## Pin-aware joint placement/routing score
+
+`schematic_joint_optimizer.py` couples bounded placement candidates to the existing wire
+planner without applying either placement or routing.
+
+For each hypothetical placement candidate it:
+
+1. deep-copies the normalized schematic snapshot;
+2. translates part positions and their conservative bounding boxes to the candidate layout;
+3. translates resolved pin offsets with each moved part;
+4. marks unresolved pin geometry explicitly and uses the candidate part anchor only as a
+   fallback;
+5. groups connectivity per net and sheet;
+6. applies the shared design-intent net-role policy before creating wire candidates: ground
+   nets are excluded by default, power nets are included by default, and both choices are
+   explicit configuration;
+7. decomposes each included sheet-local net into a deterministic endpoint minimum-spanning
+   tree;
+8. invokes `plan_schematic_wire_candidate` for each bounded edge;
+9. exposes completed prior nets only inside the cloned snapshot so later nets see crossing
+   pressure;
+10. aggregates real route defects and route length;
+11. re-ranks placement candidates with hard route defects ahead of the first-stage placement
+    heuristic.
+
+The aggregate metrics disclose rejected routes, obstacle hits, overlaps, crossings,
+self-intersections, diagonals, bends, length, detour excess, exact pin endpoints, fallback
+anchor endpoints, and the count of sheet-local net groups intentionally skipped by routing
+policy. The edge budget is bounded and incomplete evaluation is reported instead of silently
+pretending that all included connectivity was scored.
+
+Ground is excluded from wire-MST scoring because global ground connectivity is commonly
+represented with power symbols or labels rather than page-spanning authored wires. Setting
+`include_ground_nets=True` opts back into explicit ground-wire scoring. Power remains included
+by default but can likewise be excluded with `include_power_nets=False`. These switches alter
+only scoring policy; they do not author power symbols or labels and they do not change the
+logical connectivity model.
+
+The joint rank is intentionally lexicographic. Rejected/colliding/overlapping/crossing routes
+are worse before the original placement score is considered; bends and route length are
+later tie-breakers. This lets a placement with a slightly worse first-stage Manhattan
+estimate win when the actual bounded router shows materially cleaner interconnect.
+
+The virtual routes receive ordinary canonical stable IDs and exist only in the cloned
+snapshot. Source XML, source normalized objects and candidate placement data are not mutated.
+Same-net MST edges are still locally planned rather than globally junction-optimized, and
+text obstacles are not yet moved with placement candidates; both limitations are reported.
 
 Both placement planners still refuse an already-wired schematic by default. Moving symbols
 while leaving existing wire geometry behind would make the drawing worse. Existing-wire
-support belongs in the joint placement/routing optimizer, where affected wires can be
-rerouted atomically.
+support belongs in the later selective-reroute transaction layer, where affected wires can
+be replaced atomically with the placement change.
 
 ## Next implementation steps
 
 The intended order is:
 
-1. feed resolved absolute pin endpoints into bounded route-candidate scoring when geometry
-   is available, with part-anchor estimation retained only as an explicit fallback;
-2. score placement candidates with real bounded wire candidates instead of only the
-   Manhattan anchor estimate;
-3. promote single-connection planning into bounded sheet-level net ordering;
-4. turn advisory placement feedback into bounded candidate moves and re-score them;
-5. re-route only affected nets after a placement repair;
-6. add reference-motif-driven placement candidate generation;
-7. validate schematic rotation semantics in the real host before enabling automatic
+1. promote per-candidate scoring into bounded sheet-level net ordering and congestion-aware
+   route scheduling;
+2. turn advisory placement feedback into bounded candidate moves and re-score them through
+   the joint route scorer;
+3. re-route only affected nets after a placement repair and compose the selected placement +
+   wire edits into one guarded transaction plan;
+4. add reference-motif-driven placement candidate generation;
+5. validate schematic rotation semantics in the real host before enabling automatic
    pin-facing rotation decisions by default;
-8. run placement, routing and scoring in a bounded generate -> score -> improve loop;
-9. preserve the existing guarded transaction/review path for the selected candidate;
-10. expose only a small deliberate public MCP surface after the internal architecture is
-    proven.
+6. run placement, routing and scoring in a bounded generate -> score -> improve loop;
+7. preserve the existing guarded transaction/review path for the selected candidate;
+8. expose only a small deliberate public MCP surface after the internal architecture is
+   proven.
 
 The quality target is practical: a deliberately ugly but electrically correct schematic
 should become materially easier for an engineer to read without routine manual cleanup.

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -246,6 +246,7 @@ src/diptrace_mcp/review.py
 src/diptrace_mcp/routing.py
 src/diptrace_mcp/routing_compiler.py
 src/diptrace_mcp/scaffolding.py
+src/diptrace_mcp/schematic_joint_optimizer.py
 src/diptrace_mcp/schematic_layout.py
 src/diptrace_mcp/schematic_optimizer.py
 src/diptrace_mcp/schematic_pin_geometry.py
@@ -388,6 +389,7 @@ tests/test_routing_4layer.py
 tests/test_routing_primitives.py
 tests/test_scaffolding.py
 tests/test_schematic_authoring.py
+tests/test_schematic_joint_optimizer.py
 tests/test_schematic_layout.py
 tests/test_schematic_optimizer.py
 tests/test_schematic_pcb_sync.py

--- a/src/diptrace_mcp/schematic_joint_optimizer.py
+++ b/src/diptrace_mcp/schematic_joint_optimizer.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import copy
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import Field
+
+from .adapters import DocumentSnapshot, build_snapshot, stable_id
+from .domain import ObjectRecord, StrictModel
+from .errors import CapabilityUnavailableError
+from .geometry import BBox, Point, distance
+from .operations import AddWireOperation, WireEndpoint, WirePathPoint
+from .schematic_layout import NetRole, infer_schematic_design_intent
+from .schematic_optimizer import SchematicPlacementCandidate
+from .schematic_pin_geometry import (
+    ResolvedSchematicPinGeometry,
+    SchematicPinGeometryResolution,
+    resolve_document_schematic_pin_geometry,
+)
+from .schematic_wire_planner import (
+    SchematicWirePlan,
+    SchematicWirePlannerConfig,
+    plan_schematic_wire_candidate,
+)
+from .xml_document import DipTraceDocument
+
+_EPS = 1e-9
+EndpointGeometrySource = Literal[
+    "embedded_pin",
+    "provided_pin",
+    "external_pin",
+    "fallback_part_anchor",
+]
+
+
+class SchematicJointRouteConfig(StrictModel):
+    max_edges: int = Field(default=128, ge=1, le=2_048)
+    append_completed_nets_as_obstacles: bool = True
+    allow_existing_wires: bool = False
+    include_ground_nets: bool = False
+    include_power_nets: bool = True
+    wire_planner: SchematicWirePlannerConfig = Field(
+        default_factory=SchematicWirePlannerConfig
+    )
+
+
+class SchematicJointRouteMetrics(StrictModel):
+    routed_edge_count: int = Field(ge=0)
+    accepted_route_count: int = Field(ge=0)
+    rejected_route_count: int = Field(ge=0)
+    skipped_net_group_count: int = Field(ge=0)
+    exact_pin_endpoint_count: int = Field(ge=0)
+    fallback_anchor_endpoint_count: int = Field(ge=0)
+    obstacle_hits: int = Field(ge=0)
+    overlaps: int = Field(ge=0)
+    crossings: int = Field(ge=0)
+    self_intersections: int = Field(ge=0)
+    diagonals: int = Field(ge=0)
+    bends: int = Field(ge=0)
+    length_mm: float = Field(ge=0.0)
+    detour_excess: float = Field(ge=0.0)
+    rank_key: list[float] = Field(min_length=8, max_length=8)
+
+
+class SchematicJointRouteEdge(StrictModel):
+    net_id: str
+    net_name: str = ""
+    sheet: int = Field(ge=0)
+    start_pin_id: str
+    end_pin_id: str
+    start_geometry_source: EndpointGeometrySource
+    end_geometry_source: EndpointGeometrySource
+    plan: SchematicWirePlan
+
+
+class SchematicPlacementRouteScore(StrictModel):
+    candidate_id: str
+    placement_total_score: float = Field(ge=0.0)
+    metrics: SchematicJointRouteMetrics
+    edges: list[SchematicJointRouteEdge] = Field(default_factory=list)
+    joint_rank_key: list[float] = Field(min_length=10, max_length=10)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _VirtualEndpoint:
+    pin: ObjectRecord
+    part: ObjectRecord
+    pin_index: int
+    point: Point
+    source: EndpointGeometrySource
+
+
+def _pin_index(pin: ObjectRecord) -> int | None:
+    raw = pin.xml_id or ""
+    _, separator, suffix = raw.rpartition(":")
+    if not separator:
+        return None
+    try:
+        value = int(suffix)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _sheet(part: ObjectRecord) -> int | None:
+    raw = str(part.attributes.get("sheet", "0"))
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _translate_bbox(box: dict[str, float], dx: float, dy: float) -> dict[str, float]:
+    bbox = BBox(**box)
+    return BBox(
+        bbox.min_x + dx,
+        bbox.min_y + dy,
+        bbox.max_x + dx,
+        bbox.max_y + dy,
+    ).as_dict()
+
+
+def _virtualize_snapshot(
+    snapshot: DocumentSnapshot,
+    placements: dict[str, dict[str, float]],
+) -> tuple[DocumentSnapshot, list[str]]:
+    virtual = copy.deepcopy(snapshot)
+    warnings: list[str] = []
+    if virtual.schematic is None:
+        return virtual, ["Snapshot has no schematic model."]
+    parts = {part.stable_id: part for part in virtual.schematic.parts}
+    for part_id, raw_target in sorted(placements.items()):
+        part = parts.get(part_id)
+        if part is None:
+            warnings.append(f"Placement references missing part {part_id}.")
+            continue
+        target = Point(float(raw_target["x"]), float(raw_target["y"]))
+        previous = Point(**part.position) if part.position is not None else None
+        if previous is not None and part.bbox is not None:
+            part.bbox = _translate_bbox(
+                part.bbox,
+                target.x - previous.x,
+                target.y - previous.y,
+            )
+        elif previous is None and part.bbox is not None:
+            warnings.append(
+                f"Part {part_id} has a bounding box but no source position; its virtual "
+                "obstacle could not be translated."
+            )
+        part.position = target.as_dict()
+        object_record = virtual.objects.get(part_id)
+        if object_record is not None and object_record is not part:
+            object_record.position = dict(part.position)
+            object_record.bbox = dict(part.bbox) if part.bbox is not None else None
+    return virtual, warnings
+
+
+def _resolution_source(
+    geometry: ResolvedSchematicPinGeometry,
+    resolution: SchematicPinGeometryResolution,
+) -> EndpointGeometrySource:
+    if resolution.library_source == "embedded_design_cache":
+        return "embedded_pin"
+    if resolution.library_source == "external_fallback":
+        return "external_pin"
+    return "provided_pin"
+
+
+def _endpoint_point(
+    pin: ObjectRecord,
+    part: ObjectRecord,
+    original_part: ObjectRecord,
+    resolved: ResolvedSchematicPinGeometry | None,
+    resolution: SchematicPinGeometryResolution,
+) -> tuple[Point | None, EndpointGeometrySource]:
+    if part.position is None:
+        return None, "fallback_part_anchor"
+    candidate_center = Point(**part.position)
+    if (
+        resolved is not None
+        and resolved.absolute_position is not None
+        and original_part.position is not None
+    ):
+        original_center = Point(**original_part.position)
+        original_pin = Point(**resolved.absolute_position)
+        return (
+            Point(
+                candidate_center.x + original_pin.x - original_center.x,
+                candidate_center.y + original_pin.y - original_center.y,
+            ),
+            _resolution_source(resolved, resolution),
+        )
+    return candidate_center, "fallback_part_anchor"
+
+
+def _virtual_endpoints(
+    original: DocumentSnapshot,
+    virtual: DocumentSnapshot,
+    resolution: SchematicPinGeometryResolution,
+) -> tuple[dict[tuple[str, int], list[_VirtualEndpoint]], list[str]]:
+    assert original.schematic is not None
+    assert virtual.schematic is not None
+    original_parts = {part.stable_id: part for part in original.schematic.parts}
+    virtual_parts = {part.stable_id: part for part in virtual.schematic.parts}
+    resolved_by_pin = {item.pin_id: item for item in resolution.pins}
+    groups: dict[tuple[str, int], list[_VirtualEndpoint]] = defaultdict(list)
+    warnings: list[str] = []
+    for pin in sorted(virtual.schematic.pins, key=lambda item: item.stable_id):
+        if pin.net_id is None or pin.parent_id is None:
+            continue
+        pin_index = _pin_index(pin)
+        original_part = original_parts.get(pin.parent_id)
+        part = virtual_parts.get(pin.parent_id)
+        if pin_index is None or original_part is None or part is None:
+            warnings.append(f"Pin {pin.stable_id} could not be mapped to a virtual endpoint.")
+            continue
+        sheet = _sheet(part)
+        if sheet is None:
+            warnings.append(f"Part {part.stable_id} has an invalid schematic sheet index.")
+            continue
+        point, source = _endpoint_point(
+            pin,
+            part,
+            original_part,
+            resolved_by_pin.get(pin.stable_id),
+            resolution,
+        )
+        if point is None:
+            warnings.append(f"Pin {pin.stable_id} has no usable virtual coordinate.")
+            continue
+        groups[(pin.net_id, sheet)].append(
+            _VirtualEndpoint(
+                pin=pin,
+                part=part,
+                pin_index=pin_index,
+                point=point,
+                source=source,
+            )
+        )
+    return groups, warnings
+
+
+def _mst_endpoint_edges(
+    endpoints: list[_VirtualEndpoint],
+) -> list[tuple[_VirtualEndpoint, _VirtualEndpoint]]:
+    ordered = sorted(endpoints, key=lambda item: item.pin.stable_id)
+    if len(ordered) < 2:
+        return []
+    by_id = {item.pin.stable_id: item for item in ordered}
+    remaining = set(by_id)
+    first_id = min(remaining)
+    remaining.remove(first_id)
+    connected = {first_id}
+    edges: list[tuple[_VirtualEndpoint, _VirtualEndpoint]] = []
+    while remaining:
+        first_pin_id, second_pin_id = min(
+            (
+                (connected_id, remaining_id)
+                for connected_id in sorted(connected)
+                for remaining_id in sorted(remaining)
+            ),
+            key=lambda pair: (
+                distance(by_id[pair[0]].point, by_id[pair[1]].point),
+                pair[0],
+                pair[1],
+            ),
+        )
+        edges.append((by_id[first_pin_id], by_id[second_pin_id]))
+        connected.add(second_pin_id)
+        remaining.remove(second_pin_id)
+    return edges
+
+
+def _initial_points(start: Point, end: Point) -> list[WirePathPoint]:
+    if math.isclose(start.x, end.x, abs_tol=_EPS) or math.isclose(
+        start.y, end.y, abs_tol=_EPS
+    ):
+        return [WirePathPoint(x=start.x, y=start.y), WirePathPoint(x=end.x, y=end.y)]
+    return [
+        WirePathPoint(x=start.x, y=start.y),
+        WirePathPoint(x=end.x, y=start.y),
+        WirePathPoint(x=end.x, y=end.y),
+    ]
+
+
+def _net_names(snapshot: DocumentSnapshot) -> dict[str, str]:
+    assert snapshot.schematic is not None
+    result: dict[str, str] = {}
+    for net in snapshot.schematic.nets:
+        key = net.net_id or net.xml_id
+        if key is not None:
+            result[key] = net.net_name or net.name or net.label or ""
+    return result
+
+
+def _net_roles(snapshot: DocumentSnapshot) -> dict[str, NetRole]:
+    assert snapshot.schematic is not None
+    intent = infer_schematic_design_intent(snapshot)
+    by_stable_id = {item.net_id: item.role for item in intent.nets}
+    result: dict[str, NetRole] = {}
+    for net in snapshot.schematic.nets:
+        key = net.net_id or net.xml_id
+        role = by_stable_id.get(net.stable_id)
+        if key is not None and role is not None:
+            result[key] = role
+    return result
+
+
+def _append_completed_net_routes(
+    snapshot: DocumentSnapshot,
+    edge_plans: list[tuple[str, int, SchematicWirePlan]],
+) -> None:
+    if snapshot.schematic is None:
+        return
+    for index, (net_id, sheet, plan) in enumerate(edge_plans):
+        operation = plan.selected.operation
+        stable = stable_id(
+            "wire",
+            "virtual-schematic-route",
+            net_id,
+            str(sheet),
+            str(len(snapshot.schematic.wires)),
+            str(index),
+            operation.net,
+        )
+        record = ObjectRecord(
+            stable_id=stable,
+            kind="wire",
+            label=f"virtual {operation.net} route",
+            net_id=net_id,
+            net_name=operation.net,
+            attributes={
+                "sheet": str(sheet),
+                "points": [point.model_dump(mode="json") for point in operation.points],
+            },
+            relationships={"net": []},
+            geometry_source="virtual-route-candidate",
+            confidence=0.8,
+        )
+        snapshot.schematic.wires.append(record)
+        snapshot.objects[stable] = record
+
+
+def _route_rank_key(
+    *,
+    rejected: int,
+    obstacle_hits: int,
+    overlaps: int,
+    crossings: int,
+    self_intersections: int,
+    diagonals: int,
+    bends: int,
+    length_mm: float,
+) -> list[float]:
+    return [
+        float(rejected),
+        float(obstacle_hits),
+        float(overlaps),
+        float(crossings),
+        float(self_intersections),
+        float(diagonals),
+        float(bends),
+        length_mm,
+    ]
+
+
+def score_schematic_placement_candidate_routes(
+    document: DipTraceDocument,
+    candidate: SchematicPlacementCandidate,
+    *,
+    pin_geometry: SchematicPinGeometryResolution | None = None,
+    config: SchematicJointRouteConfig | None = None,
+) -> SchematicPlacementRouteScore:
+    """Score one placement candidate with bounded pin-aware wire candidates.
+
+    This function never writes XML. It clones the normalized snapshot, translates part
+    positions/bounds to the candidate placement, derives virtual pin endpoints, and asks the
+    existing wire planner to score deterministic MST connections on each included sheet-local
+    net. Completed nets may be added only to the cloned snapshot so later nets see crossing
+    pressure from already selected candidates.
+    """
+    config = config or SchematicJointRouteConfig()
+    original = build_snapshot(document)
+    if original.schematic is None:
+        raise CapabilityUnavailableError("Joint schematic route scoring requires a schematic")
+    if original.schematic.wires and not config.allow_existing_wires:
+        raise CapabilityUnavailableError(
+            "Joint placement route scoring currently requires an unwired schematic"
+        )
+    pin_geometry = pin_geometry or resolve_document_schematic_pin_geometry(document)
+    virtual, warnings = _virtualize_snapshot(original, candidate.placements)
+    groups, endpoint_warnings = _virtual_endpoints(original, virtual, pin_geometry)
+    warnings.extend(endpoint_warnings)
+    net_names = _net_names(original)
+    net_roles = _net_roles(original)
+
+    route_groups: list[
+        tuple[tuple[str, int], list[tuple[_VirtualEndpoint, _VirtualEndpoint]]]
+    ] = []
+    skipped_net_groups = 0
+    for key, endpoints in sorted(groups.items(), key=lambda item: item[0]):
+        net_id, _sheet_index = key
+        role = net_roles.get(net_id, "unknown")
+        if role == "ground" and not config.include_ground_nets:
+            skipped_net_groups += 1
+            continue
+        if role == "power" and not config.include_power_nets:
+            skipped_net_groups += 1
+            continue
+        route_groups.append((key, _mst_endpoint_edges(endpoints)))
+    planned_edge_total = sum(len(edges) for _key, edges in route_groups)
+    if skipped_net_groups:
+        warnings.append(
+            f"Skipped {skipped_net_groups} sheet-local net group(s) by configured "
+            "ground/power routing policy."
+        )
+
+    edge_results: list[SchematicJointRouteEdge] = []
+    exact_endpoints = 0
+    fallback_endpoints = 0
+    accepted = 0
+    rejected = 0
+    obstacle_hits = 0
+    overlaps = 0
+    crossings = 0
+    self_intersections = 0
+    diagonals = 0
+    bends = 0
+    length_mm = 0.0
+    detour_excess = 0.0
+    edge_budget = config.max_edges
+
+    for (net_id, sheet), endpoint_edges in route_groups:
+        net_edge_plans: list[tuple[str, int, SchematicWirePlan]] = []
+        for start, end in endpoint_edges:
+            if edge_budget <= 0:
+                break
+            edge_budget -= 1
+            net_name = net_names.get(net_id, net_id)
+            operation = AddWireOperation(
+                net=net_name,
+                sheet=sheet,
+                points=_initial_points(start.point, end.point),
+                start=WireEndpoint(
+                    type="Pin",
+                    part_id=start.part.stable_id,
+                    pin=start.pin_index,
+                ),
+                end=WireEndpoint(
+                    type="Pin",
+                    part_id=end.part.stable_id,
+                    pin=end.pin_index,
+                ),
+            )
+            plan = plan_schematic_wire_candidate(
+                document,
+                virtual,
+                operation,
+                config=config.wire_planner,
+            )
+            wire_metrics = plan.selected.metrics
+            edge_results.append(
+                SchematicJointRouteEdge(
+                    net_id=net_id,
+                    net_name=net_name,
+                    sheet=sheet,
+                    start_pin_id=start.pin.stable_id,
+                    end_pin_id=end.pin.stable_id,
+                    start_geometry_source=start.source,
+                    end_geometry_source=end.source,
+                    plan=plan,
+                )
+            )
+            for source in (start.source, end.source):
+                if source == "fallback_part_anchor":
+                    fallback_endpoints += 1
+                else:
+                    exact_endpoints += 1
+            accepted += int(plan.accept_route)
+            rejected += int(not plan.accept_route)
+            obstacle_hits += wire_metrics.obstacle_hits
+            overlaps += wire_metrics.overlaps
+            crossings += wire_metrics.crossings
+            self_intersections += wire_metrics.self_intersections
+            diagonals += wire_metrics.diagonals
+            bends += wire_metrics.bends
+            length_mm += wire_metrics.length_mm
+            detour_excess += max(0.0, wire_metrics.detour_ratio - 1.0)
+            net_edge_plans.append((net_id, sheet, plan))
+        if config.append_completed_nets_as_obstacles:
+            _append_completed_net_routes(virtual, net_edge_plans)
+        if edge_budget <= 0:
+            break
+
+    if len(edge_results) < planned_edge_total:
+        warnings.append(
+            f"Route scoring stopped at max_edges={config.max_edges}; remaining "
+            "connections were not evaluated."
+        )
+
+    rank_key = _route_rank_key(
+        rejected=rejected,
+        obstacle_hits=obstacle_hits,
+        overlaps=overlaps,
+        crossings=crossings,
+        self_intersections=self_intersections,
+        diagonals=diagonals,
+        bends=bends,
+        length_mm=length_mm,
+    )
+    joint_metrics = SchematicJointRouteMetrics(
+        routed_edge_count=len(edge_results),
+        accepted_route_count=accepted,
+        rejected_route_count=rejected,
+        skipped_net_group_count=skipped_net_groups,
+        exact_pin_endpoint_count=exact_endpoints,
+        fallback_anchor_endpoint_count=fallback_endpoints,
+        obstacle_hits=obstacle_hits,
+        overlaps=overlaps,
+        crossings=crossings,
+        self_intersections=self_intersections,
+        diagonals=diagonals,
+        bends=bends,
+        length_mm=length_mm,
+        detour_excess=detour_excess,
+        rank_key=rank_key,
+    )
+    joint_rank_key = [
+        *rank_key[:6],
+        candidate.total_score,
+        rank_key[6],
+        rank_key[7],
+        float(fallback_endpoints),
+    ]
+    return SchematicPlacementRouteScore(
+        candidate_id=candidate.candidate_id,
+        placement_total_score=candidate.total_score,
+        metrics=joint_metrics,
+        edges=edge_results,
+        joint_rank_key=joint_rank_key,
+        assumptions=[
+            "Candidate movement is simulated in a deep-copied normalized snapshot only.",
+            "Resolved pin offsets are translated with the part; part rotation is preserved.",
+            "Each included sheet-local net is decomposed into deterministic endpoint MST edges.",
+            "Ground nets are excluded from wire-MST scoring by default; power nets are "
+            "included unless configured otherwise.",
+            "Completed prior nets may be exposed as virtual wire obstacles to later nets.",
+            "Hard route-quality terms are ranked before the existing placement score.",
+        ],
+        warnings=sorted(set(warnings + pin_geometry.warnings)),
+        limitations=[
+            "Unresolved pin geometry falls back explicitly to the candidate part anchor.",
+            "Same-net MST edges are planned independently before that net is added as a "
+            "virtual obstacle, so same-net junction topology is not globally optimized.",
+            "Text obstacles still come from the source document and are not repositioned.",
+            "Net-role policy controls wire scoring only; it does not author power symbols "
+            "or net labels.",
+            "This layer scores candidates only; it does not apply placement or wire edits.",
+        ],
+    )
+
+
+def rank_schematic_placement_candidates_with_routes(
+    document: DipTraceDocument,
+    candidates: list[SchematicPlacementCandidate],
+    *,
+    pin_geometry: SchematicPinGeometryResolution | None = None,
+    config: SchematicJointRouteConfig | None = None,
+) -> list[SchematicPlacementRouteScore]:
+    """Return placement candidates re-ranked by bounded real route evidence."""
+    if not candidates:
+        return []
+    pin_geometry = pin_geometry or resolve_document_schematic_pin_geometry(document)
+    scores = [
+        score_schematic_placement_candidate_routes(
+            document,
+            candidate,
+            pin_geometry=pin_geometry,
+            config=config,
+        )
+        for candidate in candidates
+    ]
+    return sorted(
+        scores,
+        key=lambda item: (tuple(item.joint_rank_key), item.candidate_id),
+    )

--- a/tests/test_schematic_joint_optimizer.py
+++ b/tests/test_schematic_joint_optimizer.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.schematic_joint_optimizer import (
+    SchematicJointRouteConfig,
+    rank_schematic_placement_candidates_with_routes,
+    score_schematic_placement_candidate_routes,
+)
+from diptrace_mcp.schematic_optimizer import generate_schematic_placement_candidates
+from diptrace_mcp.schematic_pin_geometry import resolve_document_schematic_pin_geometry
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MAX_BYTES = 10_000_000
+
+
+def _document_with_embedded_library() -> DipTraceDocument:
+    schematic = DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+    library = DipTraceDocument.load(FIXTURES / "component_library.xml", MAX_BYTES)
+    root = ET.fromstring(schematic.raw_bytes)
+    existing = root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert existing is not None
+    index = list(root).index(existing)
+    root.remove(existing)
+    root.insert(index, ET.fromstring(library.raw_bytes))
+    raw = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return DipTraceDocument.from_bytes(schematic.path, raw)
+
+
+def _document_with_ground_net() -> DipTraceDocument:
+    document = _document_with_embedded_library()
+    root = ET.fromstring(document.raw_bytes)
+    name = root.find("./Schematic/Nets/Net[@Id='0']/Name")
+    assert name is not None
+    name.text = "GND"
+    raw = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return DipTraceDocument.from_bytes(document.path, raw)
+
+
+def _candidates(document: DipTraceDocument):
+    snapshot = build_snapshot(document)
+    return generate_schematic_placement_candidates(snapshot)
+
+
+def test_joint_route_score_uses_exact_pins_and_explicit_anchor_fallback() -> None:
+    document = _document_with_embedded_library()
+    candidates = _candidates(document)
+    assert candidates
+
+    score = score_schematic_placement_candidate_routes(document, candidates[0])
+
+    assert score.metrics.routed_edge_count == 2
+    assert score.metrics.exact_pin_endpoint_count == 2
+    assert score.metrics.fallback_anchor_endpoint_count == 2
+    assert {edge.net_name for edge in score.edges} == {"VCC", "SIGNAL"}
+    assert any(
+        source == "embedded_pin"
+        for edge in score.edges
+        for source in (edge.start_geometry_source, edge.end_geometry_source)
+    )
+    assert any(
+        source == "fallback_part_anchor"
+        for edge in score.edges
+        for source in (edge.start_geometry_source, edge.end_geometry_source)
+    )
+
+
+def test_ground_net_wire_mst_is_opt_in() -> None:
+    document = _document_with_ground_net()
+    candidate = _candidates(document)[0]
+
+    default_score = score_schematic_placement_candidate_routes(document, candidate)
+
+    assert default_score.metrics.routed_edge_count == 1
+    assert default_score.metrics.skipped_net_group_count == 1
+    assert {edge.net_name for edge in default_score.edges} == {"SIGNAL"}
+    assert any("ground/power routing policy" in warning for warning in default_score.warnings)
+
+    included_score = score_schematic_placement_candidate_routes(
+        document,
+        candidate,
+        config=SchematicJointRouteConfig(include_ground_nets=True),
+    )
+
+    assert included_score.metrics.routed_edge_count == 2
+    assert included_score.metrics.skipped_net_group_count == 0
+    assert {edge.net_name for edge in included_score.edges} == {"GND", "SIGNAL"}
+
+
+def test_joint_route_scoring_does_not_mutate_document_or_normalized_snapshot() -> None:
+    document = _document_with_embedded_library()
+    before_raw = document.raw_bytes
+    before_snapshot = build_snapshot(document)
+    before_positions = {
+        part.stable_id: dict(part.position or {})
+        for part in before_snapshot.schematic.parts
+    }
+    candidate = _candidates(document)[0]
+    before_placements = {
+        part_id: dict(position) for part_id, position in candidate.placements.items()
+    }
+
+    score_schematic_placement_candidate_routes(document, candidate)
+
+    after_snapshot = build_snapshot(document)
+    after_positions = {
+        part.stable_id: dict(part.position or {})
+        for part in after_snapshot.schematic.parts
+    }
+    assert document.raw_bytes == before_raw
+    assert after_positions == before_positions
+    assert candidate.placements == before_placements
+
+
+def test_joint_route_score_is_deterministic_for_fixed_candidate() -> None:
+    document = _document_with_embedded_library()
+    candidate = _candidates(document)[0]
+    geometry = resolve_document_schematic_pin_geometry(document)
+
+    first = score_schematic_placement_candidate_routes(
+        document,
+        candidate,
+        pin_geometry=geometry,
+    )
+    second = score_schematic_placement_candidate_routes(
+        document,
+        candidate,
+        pin_geometry=geometry,
+    )
+
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+
+
+def test_joint_route_edge_budget_is_bounded_and_reported() -> None:
+    document = _document_with_embedded_library()
+    candidate = _candidates(document)[0]
+
+    score = score_schematic_placement_candidate_routes(
+        document,
+        candidate,
+        config=SchematicJointRouteConfig(max_edges=1),
+    )
+
+    assert score.metrics.routed_edge_count == 1
+    assert any("max_edges=1" in warning for warning in score.warnings)
+
+
+def test_real_route_length_responds_to_virtual_placement_distance() -> None:
+    document = _document_with_embedded_library()
+    snapshot = build_snapshot(document)
+    base = _candidates(document)[0]
+    r1 = next(part for part in snapshot.schematic.parts if part.refdes == "R1")
+    u1_parts = sorted(
+        (part for part in snapshot.schematic.parts if part.refdes == "U1"),
+        key=lambda part: part.stable_id,
+    )
+
+    near = base.model_copy(deep=True)
+    near.candidate_id = "near"
+    near.placements[r1.stable_id] = {"x": 10.0, "y": 20.0}
+    near.placements[u1_parts[0].stable_id] = {"x": 18.0, "y": 20.0}
+    near.placements[u1_parts[1].stable_id] = {"x": 18.0, "y": 30.0}
+
+    far = base.model_copy(deep=True)
+    far.candidate_id = "far"
+    far.placements[r1.stable_id] = {"x": 10.0, "y": 20.0}
+    far.placements[u1_parts[0].stable_id] = {"x": 100.0, "y": 20.0}
+    far.placements[u1_parts[1].stable_id] = {"x": 100.0, "y": 50.0}
+
+    near_score = score_schematic_placement_candidate_routes(document, near)
+    far_score = score_schematic_placement_candidate_routes(document, far)
+
+    assert near_score.metrics.length_mm < far_score.metrics.length_mm
+
+
+def test_candidate_ranking_is_stable_and_uses_joint_rank_key() -> None:
+    document = _document_with_embedded_library()
+    candidates = _candidates(document)[:3]
+    assert len(candidates) >= 2
+
+    first = rank_schematic_placement_candidates_with_routes(document, candidates)
+    second = rank_schematic_placement_candidates_with_routes(document, candidates)
+
+    assert [item.candidate_id for item in first] == [item.candidate_id for item in second]
+    assert first == sorted(
+        first,
+        key=lambda item: (tuple(item.joint_rank_key), item.candidate_id),
+    )


### PR DESCRIPTION
## What changed

- adds `src/diptrace_mcp/schematic_joint_optimizer.py` as a non-mutating placement↔routing scoring layer;
- virtualizes candidate part positions and bounding boxes in a deep-copied normalized snapshot;
- translates resolved embedded Design Cache pin offsets to each hypothetical placement;
- falls back explicitly to part anchors when pin geometry is unresolved;
- decomposes included sheet-local nets into deterministic endpoint MST edges;
- reuses the existing bounded wire planner/cleaner for real route candidates and metrics;
- uses the shared design-intent `NetRole` policy: ground wire-MST scoring is opt-in, while power scoring remains enabled by default and can be disabled explicitly;
- reports skipped net groups separately so policy filtering is visible rather than silent;
- gives completed prior nets canonical virtual wire records only inside the cloned snapshot so later nets see crossing pressure;
- ranks rejected/colliding/overlapping/crossing routes before the existing placement score, then bends and route length;
- reports exact-pin vs fallback-anchor endpoint coverage and bounded edge-budget truncation;
- adds determinism, mixed exact/fallback geometry, distance sensitivity, bounded-budget, GND-policy and no-mutation regression coverage;
- updates release allowlist and schematic layout architecture documentation.

## Safety boundary

This PR only scores hypothetical candidates. It does not mutate XML, move parts, add wires to the source document, rotate symbols, author power symbols/labels, or expose a new public MCP tool. Existing wired schematics remain fail-closed by default until placement changes and affected-wire replacement can be composed atomically.

## Merge discipline

PR #73 is already merged into `main`; this PR targets `main` directly. Intermediate connector commits will be replaced by one DCO-signed commit on the current `main` head after functional CI is green, followed by a complete exact-head CI rerun before merge.