### PR TITLE
Repair schematic placement from route feedback

### DIFF
--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -20,7 +20,9 @@ The current implementation lives in:
 - `src/diptrace_mcp/schematic_pin_geometry.py` for conservative embedded Design Cache pin
   resolution and pin-facing geometric evidence;
 - `src/diptrace_mcp/schematic_joint_optimizer.py` for non-mutating pin-aware routing of
-  hypothetical placement candidates and joint route/placement ranking.
+  hypothetical placement candidates and joint route/placement ranking;
+- `src/diptrace_mcp/schematic_placement_repair.py` for bounded non-mutating placement
+  repair driven by explicit route feedback and re-scored by the joint optimizer.
 
 ## Design intent
 
@@ -182,12 +184,12 @@ The exposed wire metrics include:
 - direct endpoint distance;
 - detour ratio.
 
-Feedback is intentionally advisory. Current repair intents include opening a routing
-corridor, moving endpoint blocks closer, or repacking endpoint blocks. Pin endpoints are
-resolved back to normalized stable part IDs, including multipart RefDes groups where
-applicable, so the later joint optimizer has an explicit target set.
+Feedback is intentionally advisory at the wire-planner boundary. Current repair intents
+include opening a routing corridor, moving endpoint blocks closer, or repacking endpoint
+blocks. Pin endpoints are resolved back to normalized stable part IDs, including multipart
+RefDes groups where applicable, so the placement-repair layer has an explicit target set.
 
-This is the key boundary needed for co-optimization: a router is now allowed to say
+This is the key boundary needed for co-optimization: a router is allowed to say
 "this route is still bad; placement must change" instead of silently accepting a long or
 collision-prone wire.
 
@@ -284,27 +286,68 @@ snapshot. Source XML, source normalized objects and candidate placement data are
 Same-net MST edges are still locally planned rather than globally junction-optimized, and
 text obstacles are not yet moved with placement candidates; both limitations are reported.
 
+## Bounded placement repair from route feedback
+
+`schematic_placement_repair.py` closes the first placement-routing feedback loop without
+crossing the write boundary. It starts from one placement candidate, runs the pin-aware joint
+route scorer, extracts only edges whose wire planner explicitly requests placement repair,
+and generates a bounded set of hypothetical placement changes.
+
+Current repair candidates include:
+
+- moving either endpoint group toward the other;
+- moving both endpoint groups toward each other;
+- aligning endpoint pin anchors to a common row or column;
+- opening a routing corridor perpendicular to the dominant endpoint direction;
+- splitting a corridor move across both endpoint groups.
+
+When feedback crosses two functional blocks, each affected block moves as a rigid group. If
+both endpoints are already inside one functional block, repair is local to the endpoint parts
+so internal packing can improve instead of translating the entire block. Locked or unresolved
+groups fail closed. Feedback whose two pins belong to the same part is not translated because
+a rigid translation cannot change relative pin geometry.
+
+All deltas are snapped to the placement grid and bounded by `max_translation_mm` using the
+actual Euclidean translation magnitude. Candidate geometry is deduplicated before expensive
+re-scoring. `max_candidates` is a strict evaluation budget: every unique geometry consumes
+one budget slot before overlap filtering or route scoring, so rejected candidates cannot make
+the search silently exceed its configured bound.
+
+Each unique candidate is fully re-scored with the first-stage layout/interconnect/movement
+metrics. By default, any candidate that introduces additional component overlap is rejected.
+Retained candidates are then re-scored through the same pin-aware joint route scorer used for
+the base placement. A repair is selected only when its lexicographic joint rank is strictly
+better than the base rank; otherwise the result explicitly reports that no bounded repair
+improved the design.
+
+This entire layer is non-mutating. It does not alter XML, apply component moves, replace
+wires, rotate symbols, or expose a new public MCP tool. Regression coverage includes strict
+candidate-budget enforcement even when every candidate is overlap-rejected, deterministic
+replay, Euclidean translation limits, locked/unresolved fail-closed behavior, no-feedback
+behavior, both corridor axes, one-sided mobility, proposal application guards, score
+recomputation, and source-document immutability. CI protects this module with a dedicated
+coverage floor in addition to the repository-wide floor.
+
 Both placement planners still refuse an already-wired schematic by default. Moving symbols
 while leaving existing wire geometry behind would make the drawing worse. Existing-wire
-support belongs in the later selective-reroute transaction layer, where affected wires can
-be replaced atomically with the placement change.
+support belongs in the selective-reroute transaction layer, where affected wires can be
+replaced atomically with the placement change.
 
 ## Next implementation steps
 
-The intended order is:
+The intended order is now:
 
-1. promote per-candidate scoring into bounded sheet-level net ordering and congestion-aware
-   route scheduling;
-2. turn advisory placement feedback into bounded candidate moves and re-score them through
-   the joint route scorer;
-3. re-route only affected nets after a placement repair and compose the selected placement +
+1. re-route only affected nets after a selected placement repair and compose the placement +
    wire edits into one guarded transaction plan;
-4. add reference-motif-driven placement candidate generation;
-5. validate schematic rotation semantics in the real host before enabling automatic
+2. promote route scheduling into bounded sheet-level net ordering and stronger congestion
+   awareness where the current joint scorer needs it;
+3. add reference-motif-driven placement candidate generation;
+4. validate schematic rotation semantics in the real host before enabling automatic
    pin-facing rotation decisions by default;
-6. run placement, routing and scoring in a bounded generate -> score -> improve loop;
-7. preserve the existing guarded transaction/review path for the selected candidate;
-8. expose only a small deliberate public MCP surface after the internal architecture is
+5. run placement, routing and scoring in a bounded generate -> score -> improve loop with
+   explicit stopping criteria and objective history;
+6. preserve the existing guarded transaction/review path for the selected candidate;
+7. expose only a small deliberate public MCP surface after the internal architecture is
    proven.
 
 The quality target is practical: a deliberately ugly but electrically correct schematic

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -21,6 +21,7 @@ FILE_FLOORS = {
     "src/diptrace_mcp/services/evidence.py": 75.0,
     "src/diptrace_mcp/services/transactions.py": 75.0,
     "src/diptrace_mcp/services/semantic_operations.py": 70.0,
+    "src/diptrace_mcp/schematic_placement_repair.py": 95.0,
 }
 
 

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -250,6 +250,7 @@ src/diptrace_mcp/schematic_joint_optimizer.py
 src/diptrace_mcp/schematic_layout.py
 src/diptrace_mcp/schematic_optimizer.py
 src/diptrace_mcp/schematic_pin_geometry.py
+src/diptrace_mcp/schematic_placement_repair.py
 src/diptrace_mcp/schematic_wire_planner.py
 src/diptrace_mcp/semantic_compiler.py
 src/diptrace_mcp/server.py
@@ -394,6 +395,7 @@ tests/test_schematic_layout.py
 tests/test_schematic_optimizer.py
 tests/test_schematic_pcb_sync.py
 tests/test_schematic_pin_geometry.py
+tests/test_schematic_placement_repair.py
 tests/test_schematic_wire_planner.py
 tests/test_schematic_wire_quality.py
 tests/test_semantic_dispatch.py

--- a/src/diptrace_mcp/schematic_placement_repair.py
+++ b/src/diptrace_mcp/schematic_placement_repair.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import Field
+
+from .adapters import DocumentSnapshot, build_snapshot
+from .domain import ObjectRecord, StrictModel
+from .geometry import Point
+from .schematic_joint_optimizer import (
+    SchematicJointRouteConfig,
+    SchematicPlacementRouteScore,
+    score_schematic_placement_candidate_routes,
+)
+from .schematic_layout import (
+    BoundReferenceMotif,
+    SchematicDesignIntent,
+    analyze_schematic_layout,
+    infer_schematic_design_intent,
+)
+from .schematic_optimizer import (
+    SchematicOptimizerConfig,
+    SchematicPlacementCandidate,
+    _backward_connector_flow,
+    _candidate_id,
+    _estimate_interconnect,
+    _movement,
+    _split_blocks_by_sheet,
+)
+from .schematic_pin_geometry import (
+    SchematicPinGeometryResolution,
+    resolve_document_schematic_pin_geometry,
+)
+from .schematic_wire_planner import FeedbackKind
+from .xml_document import DipTraceDocument
+
+_EPS = 1e-9
+RepairMoveKind = Literal[
+    "move_start_toward_end",
+    "move_end_toward_start",
+    "move_pair_toward",
+    "align_start_row",
+    "align_end_row",
+    "align_start_column",
+    "align_end_column",
+    "offset_start_corridor",
+    "offset_end_corridor",
+    "split_corridor",
+]
+
+
+class SchematicPlacementRepairConfig(StrictModel):
+    max_feedback_edges: int = Field(default=8, ge=1, le=128)
+    max_candidates: int = Field(default=24, ge=1, le=256)
+    translation_step_mm: float = Field(default=10.0, gt=0.0, le=500.0)
+    max_translation_mm: float = Field(default=80.0, gt=0.0, le=2_000.0)
+    reject_new_part_overlaps: bool = True
+    optimizer: SchematicOptimizerConfig = Field(default_factory=SchematicOptimizerConfig)
+    joint_route: SchematicJointRouteConfig = Field(default_factory=SchematicJointRouteConfig)
+
+
+class SchematicPlacementRepairAction(StrictModel):
+    feedback_kind: FeedbackKind
+    move_kind: RepairMoveKind
+    source_net_id: str
+    source_net_name: str = ""
+    source_start_pin_id: str
+    source_end_pin_id: str
+    moved_group_ids: list[str] = Field(default_factory=list)
+    moved_part_ids: list[str] = Field(default_factory=list)
+    group_deltas_mm: dict[str, dict[str, float]] = Field(default_factory=dict)
+
+
+class SchematicPlacementRepairCandidate(StrictModel):
+    candidate: SchematicPlacementCandidate
+    route_score: SchematicPlacementRouteScore
+    action: SchematicPlacementRepairAction
+    improves_base: bool
+
+
+class SchematicPlacementRepairResult(StrictModel):
+    base_candidate: SchematicPlacementCandidate
+    base_score: SchematicPlacementRouteScore
+    candidates: list[SchematicPlacementRepairCandidate] = Field(default_factory=list)
+    selected: SchematicPlacementRepairCandidate | None = None
+    improved: bool
+    feedback_edge_count: int = Field(ge=0)
+    generated_candidate_count: int = Field(ge=0)
+    rejected_overlap_candidate_count: int = Field(ge=0)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _RepairGroup:
+    group_id: str
+    part_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _RepairProposal:
+    feedback_kind: FeedbackKind
+    move_kind: RepairMoveKind
+    source_net_id: str
+    source_net_name: str
+    source_start_pin_id: str
+    source_end_pin_id: str
+    deltas: tuple[tuple[_RepairGroup, Point], ...]
+
+
+def _point_map(candidate: SchematicPlacementCandidate) -> dict[str, Point]:
+    return {
+        part_id: Point(float(raw["x"]), float(raw["y"]))
+        for part_id, raw in candidate.placements.items()
+    }
+
+
+def rescore_schematic_placement_candidate(
+    snapshot: DocumentSnapshot,
+    candidate: SchematicPlacementCandidate,
+    *,
+    intent: SchematicDesignIntent | None = None,
+    motifs: list[BoundReferenceMotif] | None = None,
+    config: SchematicOptimizerConfig | None = None,
+) -> SchematicPlacementCandidate:
+    """Recompute first-stage metrics after hypothetical placement geometry changes."""
+    if snapshot.schematic is None:
+        raise ValueError("Schematic placement candidate re-scoring requires a schematic")
+    config = config or SchematicOptimizerConfig()
+    intent = intent or infer_schematic_design_intent(snapshot, motifs=motifs)
+    placements = _point_map(candidate)
+    slices = _split_blocks_by_sheet(snapshot, intent)
+    layout = analyze_schematic_layout(
+        snapshot,
+        intent=intent,
+        placements=placements,
+        motifs=motifs,
+        weights=config.placement.weights,
+    )
+    estimated_length, estimated_crossings = _estimate_interconnect(
+        intent,
+        placements,
+        include_power=config.include_power_in_interconnect_estimate,
+    )
+    backward_flow = _backward_connector_flow(intent, slices, placements)
+    movement_mm = _movement(snapshot, placements)
+    terms = {
+        "layout": layout.metrics.score * config.optimizer_weights.layout_score,
+        "estimated_interconnect": estimated_length
+        * config.optimizer_weights.estimated_interconnect,
+        "estimated_crossing": estimated_crossings
+        * config.optimizer_weights.estimated_crossing,
+        "backward_connector_flow": backward_flow
+        * config.optimizer_weights.backward_connector_flow,
+        "movement": movement_mm * config.optimizer_weights.movement,
+    }
+    return SchematicPlacementCandidate(
+        candidate_id=_candidate_id(
+            candidate.order_strategy,
+            candidate.local_style,
+            candidate.row_width_mm,
+            placements,
+        ),
+        order_strategy=candidate.order_strategy,
+        local_style=candidate.local_style,
+        row_width_mm=candidate.row_width_mm,
+        placements={part_id: point.as_dict() for part_id, point in placements.items()},
+        estimated_interconnect_length_mm=estimated_length,
+        estimated_crossing_count=estimated_crossings,
+        backward_connector_flow_count=backward_flow,
+        movement_mm=movement_mm,
+        score_terms=terms,
+        total_score=sum(terms.values()),
+        layout=layout,
+        unresolved=list(candidate.unresolved),
+    )
+
+
+def _block_maps(
+    intent: SchematicDesignIntent,
+) -> tuple[dict[str, str], dict[str, tuple[str, ...]]]:
+    part_to_block: dict[str, str] = {}
+    block_members: dict[str, tuple[str, ...]] = {}
+    for block in intent.blocks:
+        members = tuple(sorted(set(block.member_part_ids)))
+        block_members[block.block_id] = members
+        for part_id in members:
+            part_to_block.setdefault(part_id, block.block_id)
+    return part_to_block, block_members
+
+
+def _repair_groups(
+    start_part_id: str,
+    end_part_id: str,
+    *,
+    part_to_block: dict[str, str],
+    block_members: dict[str, tuple[str, ...]],
+) -> tuple[_RepairGroup, _RepairGroup, bool]:
+    start_block = part_to_block.get(start_part_id)
+    end_block = part_to_block.get(end_part_id)
+    same_block = start_block is not None and start_block == end_block
+    if same_block:
+        return (
+            _RepairGroup(f"part:{start_part_id}", (start_part_id,)),
+            _RepairGroup(f"part:{end_part_id}", (end_part_id,)),
+            True,
+        )
+    start_members = (
+        block_members.get(start_block, (start_part_id,))
+        if start_block is not None
+        else (start_part_id,)
+    )
+    end_members = (
+        block_members.get(end_block, (end_part_id,))
+        if end_block is not None
+        else (end_part_id,)
+    )
+    return (
+        _RepairGroup(start_block or f"part:{start_part_id}", start_members),
+        _RepairGroup(end_block or f"part:{end_part_id}", end_members),
+        False,
+    )
+
+
+def _movable_group(
+    group: _RepairGroup,
+    *,
+    parts_by_id: dict[str, ObjectRecord],
+    placements: dict[str, Point],
+) -> bool:
+    if not group.part_ids:
+        return False
+    for part_id in group.part_ids:
+        part = parts_by_id.get(part_id)
+        if part is None or part.locked or part_id not in placements:
+            return False
+    return True
+
+
+def _snap_delta(value: float, grid: float) -> float:
+    snapped = round(value / grid) * grid
+    return 0.0 if math.isclose(snapped, 0.0, abs_tol=_EPS) else snapped
+
+
+def _bounded_delta(dx: float, dy: float, *, grid: float, maximum: float) -> Point | None:
+    delta = Point(_snap_delta(dx, grid), _snap_delta(dy, grid))
+    if math.isclose(delta.x, 0.0, abs_tol=_EPS) and math.isclose(
+        delta.y, 0.0, abs_tol=_EPS
+    ):
+        return None
+    if math.hypot(delta.x, delta.y) > maximum + _EPS:
+        return None
+    return delta
+
+
+def _step_toward(
+    start: Point,
+    end: Point,
+    step: float,
+    grid: float,
+    maximum: float,
+) -> Point | None:
+    dx = (
+        0.0
+        if math.isclose(start.x, end.x, abs_tol=_EPS)
+        else math.copysign(step, end.x - start.x)
+    )
+    dy = (
+        0.0
+        if math.isclose(start.y, end.y, abs_tol=_EPS)
+        else math.copysign(step, end.y - start.y)
+    )
+    return _bounded_delta(dx, dy, grid=grid, maximum=maximum)
+
+
+def _append_single(
+    proposals: list[_RepairProposal],
+    *,
+    feedback_kind: FeedbackKind,
+    move_kind: RepairMoveKind,
+    net_id: str,
+    net_name: str,
+    start_pin_id: str,
+    end_pin_id: str,
+    group: _RepairGroup,
+    delta: Point | None,
+) -> None:
+    if delta is None:
+        return
+    proposals.append(
+        _RepairProposal(
+            feedback_kind=feedback_kind,
+            move_kind=move_kind,
+            source_net_id=net_id,
+            source_net_name=net_name,
+            source_start_pin_id=start_pin_id,
+            source_end_pin_id=end_pin_id,
+            deltas=((group, delta),),
+        )
+    )
+
+
+def _append_pair(
+    proposals: list[_RepairProposal],
+    *,
+    feedback_kind: FeedbackKind,
+    move_kind: RepairMoveKind,
+    net_id: str,
+    net_name: str,
+    start_pin_id: str,
+    end_pin_id: str,
+    start_group: _RepairGroup,
+    start_delta: Point | None,
+    end_group: _RepairGroup,
+    end_delta: Point | None,
+) -> None:
+    if start_delta is None or end_delta is None:
+        return
+    proposals.append(
+        _RepairProposal(
+            feedback_kind=feedback_kind,
+            move_kind=move_kind,
+            source_net_id=net_id,
+            source_net_name=net_name,
+            source_start_pin_id=start_pin_id,
+            source_end_pin_id=end_pin_id,
+            deltas=((start_group, start_delta), (end_group, end_delta)),
+        )
+    )
+
+
+def _edge_proposals(
+    *,
+    feedback_kind: FeedbackKind,
+    net_id: str,
+    net_name: str,
+    start_pin_id: str,
+    end_pin_id: str,
+    start_anchor: Point,
+    end_anchor: Point,
+    start_group: _RepairGroup,
+    end_group: _RepairGroup,
+    start_movable: bool,
+    end_movable: bool,
+    config: SchematicPlacementRepairConfig,
+) -> list[_RepairProposal]:
+    proposals: list[_RepairProposal] = []
+    grid = config.optimizer.placement.grid_mm
+    step = max(grid, _snap_delta(config.translation_step_mm, grid))
+    maximum = config.max_translation_mm
+    align_start_row = _bounded_delta(
+        0.0,
+        end_anchor.y - start_anchor.y,
+        grid=grid,
+        maximum=maximum,
+    )
+    align_end_row = _bounded_delta(
+        0.0,
+        start_anchor.y - end_anchor.y,
+        grid=grid,
+        maximum=maximum,
+    )
+    align_start_column = _bounded_delta(
+        end_anchor.x - start_anchor.x,
+        0.0,
+        grid=grid,
+        maximum=maximum,
+    )
+    align_end_column = _bounded_delta(
+        start_anchor.x - end_anchor.x,
+        0.0,
+        grid=grid,
+        maximum=maximum,
+    )
+    start_alignment_moves: tuple[tuple[RepairMoveKind, Point | None], ...] = (
+        ("align_start_row", align_start_row),
+        ("align_start_column", align_start_column),
+    )
+    end_alignment_moves: tuple[tuple[RepairMoveKind, Point | None], ...] = (
+        ("align_end_row", align_end_row),
+        ("align_end_column", align_end_column),
+    )
+
+    if feedback_kind in {"move_endpoint_blocks_closer", "repack_endpoint_blocks"}:
+        if start_movable:
+            _append_single(
+                proposals,
+                feedback_kind=feedback_kind,
+                move_kind="move_start_toward_end",
+                net_id=net_id,
+                net_name=net_name,
+                start_pin_id=start_pin_id,
+                end_pin_id=end_pin_id,
+                group=start_group,
+                delta=_step_toward(
+                    start_anchor,
+                    end_anchor,
+                    step,
+                    grid,
+                    maximum,
+                ),
+            )
+            for move_kind, delta in start_alignment_moves:
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind=move_kind,
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=start_group,
+                    delta=delta,
+                )
+        if end_movable:
+            _append_single(
+                proposals,
+                feedback_kind=feedback_kind,
+                move_kind="move_end_toward_start",
+                net_id=net_id,
+                net_name=net_name,
+                start_pin_id=start_pin_id,
+                end_pin_id=end_pin_id,
+                group=end_group,
+                delta=_step_toward(
+                    end_anchor,
+                    start_anchor,
+                    step,
+                    grid,
+                    maximum,
+                ),
+            )
+            for move_kind, delta in end_alignment_moves:
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind=move_kind,
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=end_group,
+                    delta=delta,
+                )
+        if start_movable and end_movable:
+            _append_pair(
+                proposals,
+                feedback_kind=feedback_kind,
+                move_kind="move_pair_toward",
+                net_id=net_id,
+                net_name=net_name,
+                start_pin_id=start_pin_id,
+                end_pin_id=end_pin_id,
+                start_group=start_group,
+                start_delta=_step_toward(
+                    start_anchor,
+                    end_anchor,
+                    step,
+                    grid,
+                    maximum,
+                ),
+                end_group=end_group,
+                end_delta=_step_toward(
+                    end_anchor,
+                    start_anchor,
+                    step,
+                    grid,
+                    maximum,
+                ),
+            )
+
+    if feedback_kind == "open_routing_corridor":
+        separation_x = end_anchor.x - start_anchor.x
+        separation_y = end_anchor.y - start_anchor.y
+        if abs(separation_x) >= abs(separation_y):
+            positive = _bounded_delta(0.0, step, grid=grid, maximum=maximum)
+            negative = _bounded_delta(0.0, -step, grid=grid, maximum=maximum)
+        else:
+            positive = _bounded_delta(step, 0.0, grid=grid, maximum=maximum)
+            negative = _bounded_delta(-step, 0.0, grid=grid, maximum=maximum)
+        if start_movable:
+            for delta in (positive, negative):
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind="offset_start_corridor",
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=start_group,
+                    delta=delta,
+                )
+        if end_movable:
+            for delta in (positive, negative):
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind="offset_end_corridor",
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=end_group,
+                    delta=delta,
+                )
+        if start_movable and end_movable:
+            for start_delta, end_delta in (
+                (positive, negative),
+                (negative, positive),
+            ):
+                _append_pair(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind="split_corridor",
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    start_group=start_group,
+                    start_delta=start_delta,
+                    end_group=end_group,
+                    end_delta=end_delta,
+                )
+        if start_movable:
+            for move_kind, delta in start_alignment_moves:
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind=move_kind,
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=start_group,
+                    delta=delta,
+                )
+        if end_movable:
+            for move_kind, delta in end_alignment_moves:
+                _append_single(
+                    proposals,
+                    feedback_kind=feedback_kind,
+                    move_kind=move_kind,
+                    net_id=net_id,
+                    net_name=net_name,
+                    start_pin_id=start_pin_id,
+                    end_pin_id=end_pin_id,
+                    group=end_group,
+                    delta=delta,
+                )
+    return proposals
+
+
+def _apply_proposal(
+    base: SchematicPlacementCandidate,
+    proposal: _RepairProposal,
+    *,
+    grid: float,
+) -> tuple[dict[str, dict[str, float]], list[str]] | None:
+    placements = _point_map(base)
+    moved: set[str] = set()
+    for group, delta in proposal.deltas:
+        for part_id in group.part_ids:
+            current = placements.get(part_id)
+            if current is None:
+                return None
+            placements[part_id] = Point(
+                round((current.x + delta.x) / grid) * grid,
+                round((current.y + delta.y) / grid) * grid,
+            )
+            moved.add(part_id)
+    if not moved:
+        return None
+    raw = {part_id: point.as_dict() for part_id, point in placements.items()}
+    if raw == base.placements:
+        return None
+    return raw, sorted(moved)
+
+
+def _placement_identity(
+    placements: dict[str, dict[str, float]],
+) -> tuple[tuple[str, float, float], ...]:
+    return tuple(
+        (part_id, round(float(raw["x"]), 9), round(float(raw["y"]), 9))
+        for part_id, raw in sorted(placements.items())
+    )
+
+
+def _proposal_action(
+    proposal: _RepairProposal,
+    moved_part_ids: list[str],
+) -> SchematicPlacementRepairAction:
+    return SchematicPlacementRepairAction(
+        feedback_kind=proposal.feedback_kind,
+        move_kind=proposal.move_kind,
+        source_net_id=proposal.source_net_id,
+        source_net_name=proposal.source_net_name,
+        source_start_pin_id=proposal.source_start_pin_id,
+        source_end_pin_id=proposal.source_end_pin_id,
+        moved_group_ids=sorted(group.group_id for group, _delta in proposal.deltas),
+        moved_part_ids=moved_part_ids,
+        group_deltas_mm={
+            group.group_id: delta.as_dict() for group, delta in proposal.deltas
+        },
+    )
+
+
+def repair_schematic_placement_from_route_feedback(
+    document: DipTraceDocument,
+    base_candidate: SchematicPlacementCandidate,
+    *,
+    pin_geometry: SchematicPinGeometryResolution | None = None,
+    intent: SchematicDesignIntent | None = None,
+    motifs: list[BoundReferenceMotif] | None = None,
+    config: SchematicPlacementRepairConfig | None = None,
+) -> SchematicPlacementRepairResult:
+    """Generate and score one bounded, non-mutating placement-repair iteration."""
+    config = config or SchematicPlacementRepairConfig()
+    snapshot = build_snapshot(document)
+    if snapshot.schematic is None:
+        raise ValueError("Schematic placement repair requires a schematic document")
+    intent = intent or infer_schematic_design_intent(snapshot, motifs=motifs)
+    pin_geometry = pin_geometry or resolve_document_schematic_pin_geometry(document)
+    base_candidate = rescore_schematic_placement_candidate(
+        snapshot,
+        base_candidate,
+        intent=intent,
+        motifs=motifs,
+        config=config.optimizer,
+    )
+    base_score = score_schematic_placement_candidate_routes(
+        document,
+        base_candidate,
+        pin_geometry=pin_geometry,
+        config=config.joint_route,
+    )
+    feedback_edges = sorted(
+        (
+            edge
+            for edge in base_score.edges
+            if edge.plan.placement_feedback.required
+        ),
+        key=lambda edge: (
+            tuple(-value for value in edge.plan.selected.metrics.quality_key),
+            edge.net_id,
+            edge.start_pin_id,
+            edge.end_pin_id,
+        ),
+    )[: config.max_feedback_edges]
+
+    parts_by_id = {part.stable_id: part for part in snapshot.schematic.parts}
+    part_to_block, block_members = _block_maps(intent)
+    base_points = _point_map(base_candidate)
+    proposals: list[_RepairProposal] = []
+    warnings: list[str] = []
+    locked_feedback = 0
+
+    for edge in feedback_edges:
+        operation = edge.plan.selected.operation
+        start_part_id = operation.start.part_id
+        end_part_id = operation.end.part_id
+        if start_part_id is None or end_part_id is None or len(operation.points) < 2:
+            warnings.append(
+                f"Feedback edge {edge.net_id}:{edge.start_pin_id}->{edge.end_pin_id} "
+                "has no stable endpoint part IDs or route anchors."
+            )
+            continue
+        if start_part_id == end_part_id:
+            warnings.append(
+                f"Feedback edge {edge.net_id}:{edge.start_pin_id}->{edge.end_pin_id} "
+                "has both endpoints on one part; translation cannot improve relative "
+                "pin geometry."
+            )
+            continue
+        start_group, end_group, _same_block = _repair_groups(
+            start_part_id,
+            end_part_id,
+            part_to_block=part_to_block,
+            block_members=block_members,
+        )
+        start_movable = _movable_group(
+            start_group,
+            parts_by_id=parts_by_id,
+            placements=base_points,
+        )
+        end_movable = _movable_group(
+            end_group,
+            parts_by_id=parts_by_id,
+            placements=base_points,
+        )
+        if not start_movable and not end_movable:
+            locked_feedback += 1
+            continue
+        proposals.extend(
+            _edge_proposals(
+                feedback_kind=edge.plan.placement_feedback.kind,
+                net_id=edge.net_id,
+                net_name=edge.net_name,
+                start_pin_id=edge.start_pin_id,
+                end_pin_id=edge.end_pin_id,
+                start_anchor=Point(operation.points[0].x, operation.points[0].y),
+                end_anchor=Point(operation.points[-1].x, operation.points[-1].y),
+                start_group=start_group,
+                end_group=end_group,
+                start_movable=start_movable,
+                end_movable=end_movable,
+                config=config,
+            )
+        )
+
+    if locked_feedback:
+        warnings.append(
+            f"Skipped {locked_feedback} feedback edge(s) because both candidate repair "
+            "groups contain locked or unresolved parts."
+        )
+    if not feedback_edges:
+        warnings.append("Base route score requires no placement repair.")
+
+    seen: set[tuple[tuple[str, float, float], ...]] = {
+        _placement_identity(base_candidate.placements)
+    }
+    repair_candidates: list[SchematicPlacementRepairCandidate] = []
+    rejected_overlaps = 0
+    generated = 0
+    grid = config.optimizer.placement.grid_mm
+    base_overlap_count = base_candidate.layout.metrics.part_overlap_count
+
+    for proposal in proposals:
+        if generated >= config.max_candidates:
+            break
+        applied = _apply_proposal(base_candidate, proposal, grid=grid)
+        if applied is None:
+            continue
+        placements, moved_part_ids = applied
+        identity = _placement_identity(placements)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        generated += 1
+        draft = base_candidate.model_copy(deep=True)
+        draft.placements = placements
+        candidate = rescore_schematic_placement_candidate(
+            snapshot,
+            draft,
+            intent=intent,
+            motifs=motifs,
+            config=config.optimizer,
+        )
+        if (
+            config.reject_new_part_overlaps
+            and candidate.layout.metrics.part_overlap_count > base_overlap_count
+        ):
+            rejected_overlaps += 1
+            continue
+        route_score = score_schematic_placement_candidate_routes(
+            document,
+            candidate,
+            pin_geometry=pin_geometry,
+            config=config.joint_route,
+        )
+        repair_candidates.append(
+            SchematicPlacementRepairCandidate(
+                candidate=candidate,
+                route_score=route_score,
+                action=_proposal_action(proposal, moved_part_ids),
+                improves_base=(
+                    tuple(route_score.joint_rank_key) < tuple(base_score.joint_rank_key)
+                ),
+            )
+        )
+
+    repair_candidates = sorted(
+        repair_candidates,
+        key=lambda item: (
+            tuple(item.route_score.joint_rank_key),
+            item.candidate.candidate_id,
+            item.action.move_kind,
+        ),
+    )
+    selected = next((item for item in repair_candidates if item.improves_base), None)
+    if feedback_edges and not repair_candidates:
+        warnings.append("No bounded non-overlapping placement repair candidate was produced.")
+    elif feedback_edges and selected is None:
+        warnings.append(
+            "Bounded placement repair candidates did not improve the joint route rank."
+        )
+
+    return SchematicPlacementRepairResult(
+        base_candidate=base_candidate,
+        base_score=base_score,
+        candidates=repair_candidates,
+        selected=selected,
+        improved=selected is not None,
+        feedback_edge_count=len(feedback_edges),
+        generated_candidate_count=generated,
+        rejected_overlap_candidate_count=rejected_overlaps,
+        assumptions=[
+            "Repair proposals are generated only from explicit wire-planner placement "
+            "feedback.",
+            "Different functional blocks move as rigid groups; feedback within one block "
+            "uses endpoint-part local moves so internal packing can improve.",
+            "Axis-alignment repairs use the actual routed pin anchors when available.",
+            "Every unique repair geometry counts against max_candidates before placement "
+            "and route scoring, including candidates later rejected for overlap.",
+            "Every retained repair candidate is re-scored by both placement metrics and "
+            "the joint pin-aware route scorer before selection.",
+        ],
+        warnings=sorted(set(warnings)),
+        limitations=[
+            "One repair iteration changes geometry for one feedback edge at a time; "
+            "multi-edge compound repair belongs in the later bounded improve loop.",
+            "Rigid block translation does not yet re-pack all members of a functional block.",
+            "The repair search does not rotate symbols while host angle semantics remain "
+            "evidence-gated.",
+            "This layer is non-mutating and does not yet compose placement moves with "
+            "selective wire replacement in a transaction.",
+        ],
+    )

--- a/tests/test_schematic_placement_repair.py
+++ b/tests/test_schematic_placement_repair.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+import diptrace_mcp.schematic_placement_repair as repair_module
+from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.geometry import Point
+from diptrace_mcp.schematic_joint_optimizer import SchematicJointRouteConfig
+from diptrace_mcp.schematic_optimizer import generate_schematic_placement_candidates
+from diptrace_mcp.schematic_placement_repair import (
+    SchematicPlacementRepairConfig,
+    _apply_proposal,
+    _bounded_delta,
+    _edge_proposals,
+    _movable_group,
+    _repair_groups,
+    _RepairGroup,
+    _RepairProposal,
+    _step_toward,
+    repair_schematic_placement_from_route_feedback,
+    rescore_schematic_placement_candidate,
+)
+from diptrace_mcp.schematic_wire_planner import SchematicWirePlannerConfig
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MAX_BYTES = 10_000_000
+
+
+def _document_with_embedded_library() -> DipTraceDocument:
+    schematic = DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+    library = DipTraceDocument.load(FIXTURES / "component_library.xml", MAX_BYTES)
+    root = ET.fromstring(schematic.raw_bytes)
+    existing = root.find("./Library[@Type='DipTrace-ComponentLibrary']")
+    assert existing is not None
+    index = list(root).index(existing)
+    root.remove(existing)
+    root.insert(index, ET.fromstring(library.raw_bytes))
+    raw = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return DipTraceDocument.from_bytes(schematic.path, raw)
+
+
+def _document_with_all_parts_locked() -> DipTraceDocument:
+    document = _document_with_embedded_library()
+    root = ET.fromstring(document.raw_bytes)
+    parts = root.findall("./Schematic/Components/Part")
+    assert parts
+    for part in parts:
+        part.set("Locked", "Y")
+    raw = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return DipTraceDocument.from_bytes(document.path, raw)
+
+
+def _diagonal_signal_candidate(document: DipTraceDocument):
+    snapshot = build_snapshot(document)
+    candidate = generate_schematic_placement_candidates(snapshot)[0].model_copy(deep=True)
+    assert snapshot.schematic is not None
+    signal_net = next(
+        net for net in snapshot.schematic.nets if (net.net_name or net.name) == "SIGNAL"
+    )
+    pin_by_id = {pin.stable_id: pin for pin in snapshot.schematic.pins}
+    owners = sorted(
+        {
+            pin_by_id[endpoint_id].parent_id
+            for endpoint_id in signal_net.relationships.get("endpoints", [])
+            if endpoint_id in pin_by_id and pin_by_id[endpoint_id].parent_id is not None
+        }
+    )
+    assert len(owners) == 2
+    candidate.placements[owners[0]] = {"x": 200.0, "y": 200.0}
+    candidate.placements[owners[1]] = {"x": 280.0, "y": 240.0}
+    return rescore_schematic_placement_candidate(snapshot, candidate)
+
+
+def _repair_config(*, max_candidates: int = 24) -> SchematicPlacementRepairConfig:
+    return SchematicPlacementRepairConfig(
+        max_candidates=max_candidates,
+        translation_step_mm=10.0,
+        max_translation_mm=100.0,
+        joint_route=SchematicJointRouteConfig(
+            include_power_nets=False,
+            wire_planner=SchematicWirePlannerConfig(max_bends=0),
+        ),
+    )
+
+
+def _permissive_repair_config() -> SchematicPlacementRepairConfig:
+    return SchematicPlacementRepairConfig(
+        joint_route=SchematicJointRouteConfig(
+            include_power_nets=False,
+            wire_planner=SchematicWirePlannerConfig(
+                max_detour_ratio=100.0,
+                max_bends=1_000,
+                require_zero_obstacle_hits=False,
+                require_zero_overlaps=False,
+                require_zero_crossings=False,
+                require_zero_self_intersections=False,
+                require_orthogonal=False,
+            ),
+        )
+    )
+
+
+def test_rescore_recomputes_candidate_metrics_without_mutating_inputs() -> None:
+    document = _document_with_embedded_library()
+    snapshot = build_snapshot(document)
+    candidate = generate_schematic_placement_candidates(snapshot)[0]
+    draft = candidate.model_copy(deep=True)
+    part_id = sorted(draft.placements)[0]
+    before_document = snapshot.document.raw_bytes
+    assert snapshot.schematic is not None
+    before_schematic = snapshot.schematic.model_dump(mode="json")
+    before_objects = {
+        object_id: record.model_dump(mode="json")
+        for object_id, record in snapshot.objects.items()
+    }
+    before_candidate = draft.model_dump(mode="json")
+    draft.placements[part_id] = {
+        "x": float(draft.placements[part_id]["x"]) + 100.0,
+        "y": float(draft.placements[part_id]["y"]) + 75.0,
+    }
+    before_rescore = draft.model_dump(mode="json")
+
+    rescored = rescore_schematic_placement_candidate(snapshot, draft)
+
+    assert rescored.candidate_id != candidate.candidate_id
+    assert rescored.placements == draft.placements
+    assert rescored.total_score == sum(rescored.score_terms.values())
+    assert rescored.movement_mm != candidate.movement_mm
+    assert snapshot.document.raw_bytes == before_document
+    assert snapshot.schematic.model_dump(mode="json") == before_schematic
+    assert {
+        object_id: record.model_dump(mode="json")
+        for object_id, record in snapshot.objects.items()
+    } == before_objects
+    assert draft.model_dump(mode="json") == before_rescore
+    assert before_candidate != before_rescore
+
+
+def test_rescore_rejects_non_schematic_snapshot() -> None:
+    document = _document_with_embedded_library()
+    candidate = generate_schematic_placement_candidates(build_snapshot(document))[0]
+    pcb = DipTraceDocument.load(FIXTURES / "pcb.xml", MAX_BYTES)
+
+    with pytest.raises(ValueError, match="requires a schematic"):
+        rescore_schematic_placement_candidate(build_snapshot(pcb), candidate)
+
+
+def test_repair_rejects_non_schematic_document() -> None:
+    document = _document_with_embedded_library()
+    candidate = generate_schematic_placement_candidates(build_snapshot(document))[0]
+    pcb = DipTraceDocument.load(FIXTURES / "pcb.xml", MAX_BYTES)
+
+    with pytest.raises(ValueError, match="requires a schematic document"):
+        repair_schematic_placement_from_route_feedback(pcb, candidate)
+
+
+def test_feedback_repair_finds_better_axis_aligned_candidate() -> None:
+    document = _document_with_embedded_library()
+    before_raw = document.raw_bytes
+    base = _diagonal_signal_candidate(document)
+
+    result = repair_schematic_placement_from_route_feedback(
+        document,
+        base,
+        config=_repair_config(),
+    )
+
+    assert result.base_score.metrics.routed_edge_count == 1
+    assert result.base_score.metrics.rejected_route_count == 1
+    assert result.feedback_edge_count == 1
+    assert result.candidates
+    assert result.improved is True
+    assert result.selected is not None
+    assert result.selected.improves_base is True
+    assert tuple(result.selected.route_score.joint_rank_key) < tuple(
+        result.base_score.joint_rank_key
+    )
+    assert result.selected.route_score.metrics.rejected_route_count == 0
+    assert result.selected.action.move_kind in {
+        "align_start_row",
+        "align_end_row",
+        "align_start_column",
+        "align_end_column",
+    }
+    assert document.raw_bytes == before_raw
+
+
+def test_feedback_repair_is_deterministic_and_strictly_bounded() -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+    config = _repair_config(max_candidates=5)
+
+    first = repair_schematic_placement_from_route_feedback(document, base, config=config)
+    second = repair_schematic_placement_from_route_feedback(document, base, config=config)
+
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+    assert len(first.candidates) <= 5
+    assert len(first.candidates) <= first.generated_candidate_count <= 5
+
+
+def test_candidate_budget_counts_overlap_rejections(monkeypatch: pytest.MonkeyPatch) -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+    config = _repair_config(max_candidates=2)
+    real_rescore = repair_module.rescore_schematic_placement_candidate
+    calls = 0
+
+    def force_repair_overlap(*args, **kwargs):
+        nonlocal calls
+        rescored = real_rescore(*args, **kwargs)
+        calls += 1
+        if calls > 1:
+            rescored.layout.metrics.part_overlap_count += 1
+        return rescored
+
+    monkeypatch.setattr(
+        repair_module,
+        "rescore_schematic_placement_candidate",
+        force_repair_overlap,
+    )
+
+    result = repair_schematic_placement_from_route_feedback(document, base, config=config)
+
+    assert result.generated_candidate_count == 2
+    assert result.rejected_overlap_candidate_count == 2
+    assert result.candidates == []
+    assert any("No bounded non-overlapping" in warning for warning in result.warnings)
+
+
+def test_repair_action_deltas_respect_configured_translation_bound() -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+    config = _repair_config()
+    config.translation_step_mm = 7.5
+    config.max_translation_mm = 12.0
+
+    result = repair_schematic_placement_from_route_feedback(document, base, config=config)
+
+    assert result.candidates
+    for candidate in result.candidates:
+        for raw_delta in candidate.action.group_deltas_mm.values():
+            assert math.hypot(float(raw_delta["x"]), float(raw_delta["y"])) <= 12.0 + 1e-9
+
+
+def test_repair_reports_when_no_feedback_is_required() -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+
+    result = repair_schematic_placement_from_route_feedback(
+        document,
+        base,
+        config=_permissive_repair_config(),
+    )
+
+    assert result.feedback_edge_count == 0
+    assert result.generated_candidate_count == 0
+    assert result.candidates == []
+    assert result.improved is False
+    assert "Base route score requires no placement repair." in result.warnings
+
+
+def test_repair_reports_when_candidates_do_not_improve_joint_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+    config = _repair_config(max_candidates=4)
+    fixed_score = repair_module.score_schematic_placement_candidate_routes(
+        document,
+        base,
+        config=config.joint_route,
+    )
+    assert any(edge.plan.placement_feedback.required for edge in fixed_score.edges)
+
+    monkeypatch.setattr(
+        repair_module,
+        "score_schematic_placement_candidate_routes",
+        lambda *args, **kwargs: fixed_score.model_copy(deep=True),
+    )
+
+    result = repair_schematic_placement_from_route_feedback(document, base, config=config)
+
+    assert result.candidates
+    assert result.selected is None
+    assert result.improved is False
+    assert all(not candidate.improves_base for candidate in result.candidates)
+    assert any("did not improve the joint route rank" in warning for warning in result.warnings)
+
+
+def test_repair_reports_when_both_endpoint_groups_are_locked() -> None:
+    document = _document_with_all_parts_locked()
+    base = _diagonal_signal_candidate(document)
+
+    result = repair_schematic_placement_from_route_feedback(
+        document,
+        base,
+        config=_repair_config(),
+    )
+
+    assert result.feedback_edge_count == 1
+    assert result.generated_candidate_count == 0
+    assert result.candidates == []
+    assert any("locked or unresolved parts" in warning for warning in result.warnings)
+
+
+def test_group_and_delta_helpers_cover_fail_closed_boundaries() -> None:
+    same_start, same_end, same_block = _repair_groups(
+        "A",
+        "B",
+        part_to_block={"A": "block", "B": "block"},
+        block_members={"block": ("A", "B")},
+    )
+    assert same_block is True
+    assert same_start == _RepairGroup("part:A", ("A",))
+    assert same_end == _RepairGroup("part:B", ("B",))
+
+    start, end, same_block = _repair_groups(
+        "A",
+        "B",
+        part_to_block={"A": "left"},
+        block_members={"left": ("A", "A2")},
+    )
+    assert same_block is False
+    assert start == _RepairGroup("left", ("A", "A2"))
+    assert end == _RepairGroup("part:B", ("B",))
+
+    assert _bounded_delta(0.1, 0.1, grid=1.0, maximum=10.0) is None
+    assert _bounded_delta(10.0, 10.0, grid=1.0, maximum=12.0) is None
+    bounded = _bounded_delta(4.6, 0.0, grid=1.0, maximum=10.0)
+    assert bounded is not None and bounded.as_dict() == {"x": 5.0, "y": 0.0}
+    toward = _step_toward(Point(0.0, 0.0), Point(0.0, 20.0), 5.0, 1.0, 10.0)
+    assert toward is not None and toward.as_dict() == {"x": 0.0, "y": 5.0}
+
+    snapshot = build_snapshot(_document_with_embedded_library())
+    assert snapshot.schematic is not None
+    parts_by_id = {part.stable_id: part for part in snapshot.schematic.parts}
+    placements = {
+        part.stable_id: Point(**part.position)
+        for part in snapshot.schematic.parts
+        if part.position is not None
+    }
+    first_part_id = sorted(parts_by_id)[0]
+    assert _movable_group(
+        _RepairGroup("empty", ()),
+        parts_by_id=parts_by_id,
+        placements=placements,
+    ) is False
+    assert _movable_group(
+        _RepairGroup("missing", ("missing",)),
+        parts_by_id=parts_by_id,
+        placements=placements,
+    ) is False
+    assert _movable_group(
+        _RepairGroup("placed", (first_part_id,)),
+        parts_by_id=parts_by_id,
+        placements=placements,
+    ) is True
+    placements.pop(first_part_id)
+    assert _movable_group(
+        _RepairGroup("unplaced", (first_part_id,)),
+        parts_by_id=parts_by_id,
+        placements=placements,
+    ) is False
+
+
+def test_corridor_proposals_cover_both_axes_and_mobility_sides() -> None:
+    config = _repair_config()
+    config.translation_step_mm = 5.0
+    start_group = _RepairGroup("start", ("A",))
+    end_group = _RepairGroup("end", ("B",))
+
+    horizontal = _edge_proposals(
+        feedback_kind="open_routing_corridor",
+        net_id="N1",
+        net_name="SIGNAL",
+        start_pin_id="PA",
+        end_pin_id="PB",
+        start_anchor=Point(0.0, 0.0),
+        end_anchor=Point(20.0, 5.0),
+        start_group=start_group,
+        end_group=end_group,
+        start_movable=True,
+        end_movable=True,
+        config=config,
+    )
+    horizontal_kinds = {proposal.move_kind for proposal in horizontal}
+    assert {
+        "offset_start_corridor",
+        "offset_end_corridor",
+        "split_corridor",
+        "align_start_row",
+        "align_end_row",
+    } <= horizontal_kinds
+    split = next(proposal for proposal in horizontal if proposal.move_kind == "split_corridor")
+    assert all(math.isclose(delta.x, 0.0) for _group, delta in split.deltas)
+
+    vertical = _edge_proposals(
+        feedback_kind="open_routing_corridor",
+        net_id="N2",
+        net_name="SIGNAL2",
+        start_pin_id="PC",
+        end_pin_id="PD",
+        start_anchor=Point(0.0, 0.0),
+        end_anchor=Point(5.0, 20.0),
+        start_group=start_group,
+        end_group=end_group,
+        start_movable=False,
+        end_movable=True,
+        config=config,
+    )
+    assert vertical
+    assert all(
+        proposal.move_kind in {
+            "offset_end_corridor",
+            "align_end_row",
+            "align_end_column",
+        }
+        for proposal in vertical
+    )
+    offset = next(
+        proposal for proposal in vertical if proposal.move_kind == "offset_end_corridor"
+    )
+    assert all(math.isclose(delta.y, 0.0) for _group, delta in offset.deltas)
+
+    assert (
+        _edge_proposals(
+            feedback_kind="none",
+            net_id="N3",
+            net_name="QUIET",
+            start_pin_id="PE",
+            end_pin_id="PF",
+            start_anchor=Point(0.0, 0.0),
+            end_anchor=Point(10.0, 10.0),
+            start_group=start_group,
+            end_group=end_group,
+            start_movable=True,
+            end_movable=True,
+            config=config,
+        )
+        == []
+    )
+
+
+def test_apply_proposal_fails_closed_for_missing_or_noop_groups() -> None:
+    document = _document_with_embedded_library()
+    base = _diagonal_signal_candidate(document)
+    part_id = sorted(base.placements)[0]
+
+    missing = _RepairProposal(
+        feedback_kind="open_routing_corridor",
+        move_kind="offset_start_corridor",
+        source_net_id="N",
+        source_net_name="SIGNAL",
+        source_start_pin_id="P1",
+        source_end_pin_id="P2",
+        deltas=((_RepairGroup("missing", ("missing",)), Point(1.0, 0.0)),),
+    )
+    assert _apply_proposal(base, missing, grid=1.0) is None
+
+    empty = missing.__class__(
+        feedback_kind="open_routing_corridor",
+        move_kind="offset_start_corridor",
+        source_net_id="N",
+        source_net_name="SIGNAL",
+        source_start_pin_id="P1",
+        source_end_pin_id="P2",
+        deltas=((_RepairGroup("empty", ()), Point(1.0, 0.0)),),
+    )
+    assert _apply_proposal(base, empty, grid=1.0) is None
+
+    noop = missing.__class__(
+        feedback_kind="open_routing_corridor",
+        move_kind="offset_start_corridor",
+        source_net_id="N",
+        source_net_name="SIGNAL",
+        source_start_pin_id="P1",
+        source_end_pin_id="P2",
+        deltas=((_RepairGroup("part", (part_id,)), Point(0.0, 0.0)),),
+    )
+    assert _apply_proposal(base, noop, grid=1.0) is None


### PR DESCRIPTION
## What changed

- adds a non-mutating bounded placement-repair search driven only by explicit wire-planner feedback;
- re-scores every retained repair geometry with the existing layout/interconnect/movement metrics and then the pin-aware joint route scorer;
- moves different functional blocks as rigid groups and uses endpoint-part-local moves when feedback is inside one block;
- generates pin-anchor-aware align, move-toward, pair-toward, corridor-offset and split-corridor repair proposals;
- enforces `max_translation_mm` on Euclidean translation after grid snapping;
- makes `max_candidates` a strict evaluation budget: every unique geometry consumes budget before overlap rejection or route scoring;
- rejects repairs that introduce additional component overlap by default;
- selects a repair only when its lexicographic joint rank strictly improves over the base candidate;
- documents the repair loop and its safety/limitations in `docs/SCHEMATIC_LAYOUT_ENGINE.md`;
- adds a dedicated 95% coverage floor for `schematic_placement_repair.py`.

## Regression coverage

Coverage now exercises deterministic replay, strict candidate-budget enforcement including overlap-rejected candidates, score recomputation and source immutability, Euclidean translation bounds, locked/unresolved groups, no-feedback behavior, non-improving candidate behavior, non-schematic fail-closed behavior, both routing-corridor axes, one-sided mobility, proposal application guards, and axis-alignment improvement.

The measured module coverage before the final terminal-branch additions was 97% (263 statements / 9 missed), up from 82%. The final exact value is verified by CI and protected by the new 95% per-file floor.

## Safety boundary

This PR only generates and scores hypothetical placement repairs. It does not mutate XML, apply component moves, replace existing wires, rotate symbols, or expose a new public MCP tool.

## Next boundary

The next layer is selective affected-net reroute plus one guarded atomic placement+wire transaction plan.