### PR TITLE
Raise aggregate coverage toward 90%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,15 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install -e ".[dev,geometry]"
+      - name: Configure portable coverage paths
+        shell: bash
+        run: |
+          printf '[run]\nrelative_files = true\nsource = src/diptrace_mcp\n' > .coveragerc
       - name: Prove exact GEOS geometry is active
         run: python scripts/verify_geometry_backend.py --expect shapely_geos
       - name: Run real headless bridge handshake
         run: python scripts/smoke_bridge_headless.py
-      - name: Run full tests with coverage gates
+      - name: Run full tests with Linux coverage gates
         shell: bash
         run: |
           set -o pipefail
@@ -69,6 +73,13 @@ jobs:
             --cov-fail-under=85 \
             2>&1 | tee pytest-3.12-geometry.log
           python scripts/check_coverage.py coverage.json
+          mv .coverage .coverage.linux-geometry
+      - name: Upload Linux geometry coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-linux-geometry
+          include-hidden-files: true
+          path: .coverage.linux-geometry
       - name: Upload failed test and coverage reports
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -90,17 +101,30 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install -e ".[dev]"
+      - name: Configure portable coverage paths
+        shell: bash
+        run: |
+          printf '[run]\nrelative_files = true\nsource = src/diptrace_mcp\n' > .coveragerc
       - name: Ensure Shapely is absent
         run: |
           python -m pip uninstall -y shapely
           python -c "import importlib.util; assert importlib.util.find_spec('shapely') is None"
       - name: Exercise the real pure-Python fallback
         run: python scripts/verify_geometry_backend.py --expect pure_python
-      - name: Run fallback-focused regression tests
+      - name: Run fallback-focused regression tests with coverage
         run: >-
           python -m pytest -q
+          --cov=src/diptrace_mcp
+          --cov-report=
           tests/test_geometry.py
           tests/test_copper_pour_obstacles.py
+      - run: mv .coverage .coverage.linux-fallback
+      - name: Upload Linux fallback coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-linux-fallback
+          include-hidden-files: true
+          path: .coverage.linux-fallback
 
   static-analysis:
     runs-on: ubuntu-latest
@@ -161,7 +185,18 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install -e ".[dev]"
-      - run: python -m pytest -q
+      - name: Configure portable coverage paths
+        shell: bash
+        run: |
+          printf '[run]\nrelative_files = true\nsource = src/diptrace_mcp\n' > .coveragerc
+      - run: python -m pytest -q --cov=src/diptrace_mcp --cov-report=
+      - run: mv .coverage .coverage.macos
+      - name: Upload macOS coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-macos
+          include-hidden-files: true
+          path: .coverage.macos
       - run: diptrace-mcp --help
       - name: Run real headless bridge handshake
         run: python scripts/smoke_bridge_headless.py
@@ -177,10 +212,65 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install -e ".[dev]"
-      - run: python -m pytest -q
+      - name: Configure portable coverage paths
+        shell: pwsh
+        run: |
+          @"
+          [run]
+          relative_files = true
+          source = src/diptrace_mcp
+          "@ | Set-Content -Encoding ascii .coveragerc
+      - run: python -m pytest -q --cov=src/diptrace_mcp --cov-report=
+      - shell: pwsh
+        run: Move-Item .coverage .coverage.windows
+      - name: Upload Windows coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-windows
+          include-hidden-files: true
+          path: .coverage.windows
       - run: diptrace-mcp --help
       - name: Run real headless bridge handshake
         run: python scripts/smoke_bridge_headless.py
+
+  combined-coverage:
+    name: combined supported-environment coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test-linux-geometry-and-coverage
+      - test-linux-no-shapely-fallback
+      - test-macos
+      - test-windows
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
+      - name: Configure portable coverage paths
+        shell: bash
+        run: |
+          printf '[run]\nrelative_files = true\nsource = src/diptrace_mcp\n' > .coveragerc
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: coverage-*
+          path: coverage-data
+          merge-multiple: true
+      - name: Combine supported-environment coverage
+        shell: bash
+        run: |
+          coverage combine coverage-data
+          coverage report --fail-under=85
+          coverage json -o coverage-combined.json
+          python scripts/check_coverage.py coverage-combined.json
+      - name: Upload combined coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-combined
+          path: coverage-combined.json
 
   build-windows-bridge:
     runs-on: windows-latest

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,10 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from diptrace_mcp.adapter_queries import _matches_selector
 from diptrace_mcp.adapters import build_snapshot
 from diptrace_mcp.capabilities import get_capabilities
-from diptrace_mcp.domain import QueryRequest, QuerySelector
+from diptrace_mcp.domain import ObjectRecord, QueryRequest, QuerySelector
 from diptrace_mcp.xml_document import DipTraceDocument
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -208,3 +209,78 @@ def test_nested_52_pattern_cache_and_legacy_testpoint_are_normalized() -> None:
     assert polygon_pad.geometry is not None
     assert polygon_pad.geometry.kind == "polygon"
     assert len(polygon_pad.geometry.points) == 4
+
+
+def test_query_selector_matches_all_supported_predicates_and_rejects_each_mismatch() -> None:
+    item = ObjectRecord(
+        stable_id="component_0123456789abcdef",
+        kind="component",
+        refdes="R1",
+        name="Resistor",
+        value="10k",
+        label="main resistor",
+        net_name="VCC",
+        net_id="net-vcc",
+        layer="Top",
+        side="Top",
+        selected=True,
+        locked=False,
+        position={"x": 10.0, "y": 20.0},
+        bbox={"min_x": 9.0, "min_y": 19.0, "max_x": 11.0, "max_y": 21.0},
+        attributes={"additional_fields": {"MPN": "ABC"}, "note": "precision"},
+    )
+    matching = QuerySelector(
+        ids=[item.stable_id],
+        kinds=["component"],
+        refdes=["r1"],
+        refdes_glob="r*",
+        refdes_regex=r"^R\d+$",
+        names=["resistor"],
+        name_regex="sist",
+        values=["10K"],
+        fields={"MPN": "ABC"},
+        nets=["vcc"],
+        layers=["Top"],
+        sides=["Top"],
+        selected=True,
+        locked=False,
+        text="precision",
+        bbox={"min_x": 8.0, "min_y": 18.0, "max_x": 12.0, "max_y": 22.0},
+        near={"x": 10.0, "y": 20.0},
+        max_distance=0.1,
+    )
+    assert _matches_selector(item, matching) is True
+
+    mismatches = [
+        QuerySelector(ids=["component_ffffffffffffffff"]),
+        QuerySelector(kinds=["via"]),
+        QuerySelector(refdes=["R2"]),
+        QuerySelector(refdes_glob="C*"),
+        QuerySelector(refdes_regex=r"^C"),
+        QuerySelector(names=["Capacitor"]),
+        QuerySelector(name_regex="capacitor"),
+        QuerySelector(values=["1uF"]),
+        QuerySelector(fields={"MPN": "XYZ"}),
+        QuerySelector(nets=["GND"]),
+        QuerySelector(layers=["Bottom"]),
+        QuerySelector(sides=["Bottom"]),
+        QuerySelector(selected=False),
+        QuerySelector(locked=True),
+        QuerySelector(text="absent"),
+        QuerySelector(bbox={"min_x": 30.0, "min_y": 30.0, "max_x": 40.0, "max_y": 40.0}),
+        QuerySelector(near={"x": 100.0, "y": 100.0}, max_distance=1.0),
+    ]
+    assert all(not _matches_selector(item, selector) for selector in mismatches)
+
+    no_geometry = item.model_copy(update={"position": None, "bbox": None})
+    assert not _matches_selector(
+        no_geometry,
+        QuerySelector(bbox={"min_x": 0.0, "min_y": 0.0, "max_x": 1.0, "max_y": 1.0}),
+    )
+    assert not _matches_selector(
+        no_geometry,
+        QuerySelector(near={"x": 0.0, "y": 0.0}, max_distance=1.0),
+    )
+
+    malformed_fields = item.model_copy(update={"attributes": {"additional_fields": "bad"}})
+    assert not _matches_selector(malformed_fields, QuerySelector(fields={"MPN": "ABC"}))

--- a/tests/test_schematic_layout.py
+++ b/tests/test_schematic_layout.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+import diptrace_mcp.schematic_layout as layout
 from diptrace_mcp.adapters import DocumentSnapshot, build_snapshot, stable_id
 from diptrace_mcp.domain import ObjectRecord
 from diptrace_mcp.errors import CapabilityUnavailableError
+from diptrace_mcp.geometry import Point
 from diptrace_mcp.operations import AddWireOperation
 from diptrace_mcp.schematic_layout import (
     BoundReferenceMotif,
@@ -192,3 +194,135 @@ def test_layout_analysis_counts_crossing_between_different_nets() -> None:
 
     assert analysis.metrics.wire_crossing_count == 1
     assert analysis.metrics.diagonal_segment_count == 2
+
+
+def _synthetic_part(refdes: str, *, name: str = "", value: str = "") -> ObjectRecord:
+    return ObjectRecord(
+        stable_id=stable_id("part", "role", refdes, name, value),
+        kind="part",
+        refdes=refdes,
+        name=name or None,
+        value=value or None,
+    )
+
+
+def _synthetic_net(name: str) -> ObjectRecord:
+    return ObjectRecord(
+        stable_id=stable_id("net", "role", name or "unnamed"),
+        kind="net",
+        name=name or None,
+    )
+
+
+def test_role_inference_covers_supported_part_and_net_classes() -> None:
+    part_cases = {
+        "J1": ("connector", ""),
+        "U1": ("power_control", "BUCK REGULATOR"),
+        "IC2": ("active", "MCU"),
+        "Q1": ("active", "MOSFET"),
+        "Y1": ("timing", "CRYSTAL"),
+        "D1": ("protection", "TVS"),
+        "SW1": ("control", "BUTTON"),
+        "R1": ("support", ""),
+        "Z1": ("other", "mystery"),
+    }
+    for refdes, (expected, name) in part_cases.items():
+        assert layout._part_role(_synthetic_part(refdes, name=name)).role == expected
+
+    net_cases = {
+        "": "unknown",
+        "GND": "ground",
+        "+3V3": "power",
+        "SYS_CLK": "clock",
+        "NRST": "reset",
+        "USB_D+": "interface",
+        "DATA": "signal",
+    }
+    for name, expected in net_cases.items():
+        assert layout._net_role(_synthetic_net(name), []).role == expected
+
+    assert layout._block_role({"connector", "active"}) == "connector"
+    assert layout._block_role({"power_control"}) == "power"
+    assert layout._block_role({"active"}) == "functional"
+    assert layout._block_role(set()) == "generic"
+
+
+def test_reference_motif_constraint_validation_rejects_invalid_shapes() -> None:
+    with pytest.raises(ValueError, match="endpoints must be different"):
+        ReferenceMotifConstraint(
+            first_key="same",
+            second_key="same",
+            relation="left_of",
+        )
+    with pytest.raises(ValueError, match="requires max_distance_mm"):
+        ReferenceMotifConstraint(
+            first_key="a",
+            second_key="b",
+            relation="near",
+        )
+
+
+def test_motif_relation_error_covers_every_supported_relation() -> None:
+    first = Point(10.0, 20.0)
+    second = Point(20.0, 30.0)
+    cases = [
+        ("near", {"max_distance_mm": 5.0}, pytest.approx(9.1421356237)),
+        ("left_of", {"tolerance_mm": 0.0}, 0.0),
+        ("right_of", {"tolerance_mm": 0.0}, 10.0),
+        ("above", {"tolerance_mm": 0.0}, 0.0),
+        ("below", {"tolerance_mm": 0.0}, 10.0),
+        ("same_row", {"tolerance_mm": 2.0}, 8.0),
+        ("same_column", {"tolerance_mm": 2.0}, 8.0),
+    ]
+    for relation, extra, expected in cases:
+        constraint = ReferenceMotifConstraint(
+            first_key="a",
+            second_key="b",
+            relation=relation,
+            **extra,
+        )
+        assert layout._motif_relation_error(first, second, constraint) == expected
+
+
+def test_wire_metric_helpers_cover_overlap_bends_shared_endpoints_and_same_net() -> None:
+    wires = [
+        ObjectRecord(
+            stable_id=stable_id("wire", "metrics", "a"),
+            kind="wire",
+            net_name="A",
+            attributes={"points": [{"x": 0, "y": 0}, {"x": 10, "y": 0}, {"x": 10, "y": 10}]},
+        ),
+        ObjectRecord(
+            stable_id=stable_id("wire", "metrics", "b"),
+            kind="wire",
+            net_name="B",
+            attributes={"points": [{"x": 5, "y": 0}, {"x": 15, "y": 0}]},
+        ),
+        ObjectRecord(
+            stable_id=stable_id("wire", "metrics", "c"),
+            kind="wire",
+            net_name="A",
+            attributes={"points": [{"x": 0, "y": 10}, {"x": 10, "y": 0}]},
+        ),
+        ObjectRecord(
+            stable_id=stable_id("wire", "metrics", "d"),
+            kind="wire",
+            net_name="D",
+            attributes={"points": [{"x": 10, "y": 10}, {"x": 20, "y": 20}]},
+        ),
+    ]
+    overlap, crossings, diagonals, bends, total, points = layout._wire_metrics(wires)
+    assert overlap >= 1
+    assert crossings == 2
+    assert diagonals == 2
+    assert bends == 1
+    assert total > 0
+    assert points
+
+    assert layout._wire_points(
+        ObjectRecord(
+            stable_id=stable_id("wire", "metrics", "invalid"),
+            kind="wire",
+            attributes={"points": "not-a-list"},
+        )
+    ) == []

--- a/tests/test_server_bundle.py
+++ b/tests/test_server_bundle.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from datetime import timedelta
 from pathlib import Path
+from typing import Any
 
-from diptrace_mcp import __version__
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from diptrace_mcp import __version__, server_runtime
+from diptrace_mcp.config import Settings
 
 ROOT = Path(__file__).parents[1]
 
@@ -59,3 +65,162 @@ def test_skill_data_destinations_are_directories_without_filename_duplication() 
 
     assert "relative.parent" in spec
     assert "relative_to(directory).as_posix()" not in spec
+
+
+def _resolve_schema(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    ref = schema.get("$ref")
+    if not isinstance(ref, str):
+        return schema
+    assert ref.startswith("#/")
+    value: Any = root
+    for token in ref[2:].split("/"):
+        token = token.replace("~1", "/").replace("~0", "~")
+        value = value[token]
+    assert isinstance(value, dict)
+    return value
+
+
+def _schema_sample(schema: dict[str, Any], root: dict[str, Any]) -> Any:
+    schema = _resolve_schema(schema, root)
+    if "const" in schema:
+        return schema["const"]
+    enum = schema.get("enum")
+    if isinstance(enum, list) and enum:
+        return next((value for value in enum if value is not None), enum[0])
+    for union_key in ("anyOf", "oneOf"):
+        branches = schema.get(union_key)
+        if isinstance(branches, list) and branches:
+            branch = next(
+                (
+                    item
+                    for item in branches
+                    if isinstance(item, dict) and item.get("type") != "null"
+                ),
+                branches[0],
+            )
+            assert isinstance(branch, dict)
+            return _schema_sample(branch, root)
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), schema_type[0])
+    if schema_type == "object" or "properties" in schema:
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        assert isinstance(properties, dict)
+        assert isinstance(required, list)
+        return {
+            name: _schema_sample(properties[name], root)
+            for name in required
+            if name in properties and isinstance(properties[name], dict)
+        }
+    if schema_type == "array":
+        minimum = int(schema.get("minItems", 0))
+        item_schema = schema.get("items", {})
+        assert isinstance(item_schema, dict)
+        return [_schema_sample(item_schema, root) for _ in range(minimum)]
+    if schema_type == "boolean":
+        return False
+    if schema_type == "integer":
+        if "minimum" in schema:
+            return int(schema["minimum"])
+        if "exclusiveMinimum" in schema:
+            return int(schema["exclusiveMinimum"]) + 1
+        return 1
+    if schema_type == "number":
+        if "minimum" in schema:
+            return float(schema["minimum"])
+        if "exclusiveMinimum" in schema:
+            return float(schema["exclusiveMinimum"]) + 1.0
+        return 1.0
+    if schema_type == "string" or schema_type is None:
+        pattern = str(schema.get("pattern", ""))
+        if "0-9a-f" in pattern and "64" in pattern:
+            return "0" * 64
+        minimum = max(1, int(schema.get("minLength", 1)))
+        return "x" * minimum
+    raise AssertionError(f"Unsupported JSON schema shape: {schema!r}")
+
+
+def _minimal_tool_payload(schema: dict[str, Any]) -> dict[str, Any]:
+    value = _schema_sample(schema, schema)
+    assert isinstance(value, dict)
+    return value
+
+
+class _RecordingService:
+    instance: _RecordingService | None = None
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.calls: list[str] = []
+        type(self).instance = self
+
+    def __getattr__(self, name: str) -> Any:
+        def call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(name)
+            if name == "finish_live_session":
+                return {
+                    "session_id": "session",
+                    "requested_action": "apply",
+                    "requested_at": "2026-08-10T00:00:00Z",
+                    "expected_sha256": "0" * 64,
+                    "outcome": "not_acknowledged",
+                    "local_bridge_status": "active",
+                    "written": False,
+                    "diptrace_host_acknowledged": False,
+                    "acknowledgement_scope": "local_bridge_exchange_only",
+                    "message": "synthetic delegation probe",
+                }
+            if name == "abandon_live_session":
+                return {
+                    "session_id": "session",
+                    "outcome": "abandoned",
+                    "local_bridge_status": "abandoned",
+                    "written": False,
+                    "reason": "synthetic",
+                    "diptrace_host_acknowledged": False,
+                    "acknowledgement_scope": "local_session_state_only",
+                    "message": "synthetic delegation probe",
+                }
+            return {"ok": True, "method": name}
+
+        return call
+
+
+def test_every_public_tool_wrapper_reaches_the_service_with_schema_valid_input(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Exercise the real FastMCP/Pydantic wrapper surface without domain side effects."""
+
+    async def verify() -> None:
+        monkeypatch.setattr(server_runtime, "DipTraceService", _RecordingService)
+        settings = Settings(
+            workspace=tmp_path,
+            allowed_roots=(tmp_path,),
+            state_dir=tmp_path / "state",
+        )
+        server = server_runtime.create_server(settings)
+        service = _RecordingService.instance
+        assert service is not None
+
+        async with create_connected_server_and_client_session(
+            server,
+            read_timeout_seconds=timedelta(seconds=10),
+        ) as session:
+            listed = await session.list_tools()
+            exercised: list[str] = []
+            not_delegated: list[str] = []
+            for tool in listed.tools:
+                before = len(service.calls)
+                payload = _minimal_tool_payload(tool.inputSchema)
+                await session.call_tool(tool.name, payload)
+                if len(service.calls) > before:
+                    exercised.append(tool.name)
+                else:
+                    not_delegated.append(tool.name)
+
+        assert len(listed.tools) >= 150
+        assert len(exercised) >= 150, not_delegated
+
+    asyncio.run(verify())


### PR DESCRIPTION
## Goal

Raise the repository-wide coverage target to 90% without excluding platform-specific production code or adding artificial tests.

## First step

- collect coverage from Linux + Shapely;
- collect focused pure-Python geometry fallback coverage;
- collect full macOS coverage;
- collect full Windows coverage, including native Windows-only paths;
- combine the platform/configuration coverage databases in a dedicated CI job;
- keep the existing Linux 85% gate while measuring the honest aggregate baseline;
- use relative source paths so cross-platform coverage data can be combined safely.

After the first aggregate run, the remaining uncovered statements will be prioritized by real test value and coverage yield, then the combined gate will be raised to 90%.