### PR TITLE
Waive Claude Desktop restart gate on current main

### DIFF
--- a/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
+++ b/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
@@ -18,13 +18,13 @@ This is the merge of PR #68 (`Ponytail: aggressive repository cleanup`). The acc
 confirmed no relevant production-code drift through the COMMON, Q1 Component Angle, and Codex
 restart gates.
 
-Documentation-only commits made after this checkpoint do **not** invalidate that accepted
-production-code identity. When resuming acceptance, distinguish documentation drift from changes to
-`src/`, packaging/runtime code, plug-in code, or other files that can affect the tested behavior.
+Later repository development does not retroactively move those evidence identities. When resuming
+acceptance or starting a new product-quality validation, explicitly record the actual production
+candidate being tested rather than transferring PASS results to newer code by inference.
 
 ## Formal acceptance progress
 
-Eight of the twelve blocking manual gates are now complete.
+Eight of the twelve canonical blocking manual gates are PASS.
 
 | Gate | Result | Accepted identity / evidence note |
 | --- | --- | --- |
@@ -36,13 +36,18 @@ Eight of the twelve blocking manual gates are now complete.
 | `diptrace_mask_paste_courtyard_common_semantics` | **PASS** | MASK, PASTE, COURTYARD and COMMON all accepted. |
 | `diptrace_q1_component_angle` | **PASS** | Real DipTrace PCB Layout 5.3.0.3 angle/side semantics accepted on `0bb09b4...`. |
 | `codex_real_client_restart` | **PASS** | Real Codex Desktop restart/configuration/`get_capabilities` accepted on `0bb09b4...`. |
+| `claude_desktop_real_client_restart` | **WAIVED for current project campaign** | Not run and not PASS. The project accepts the residual interoperability risk after successful real Codex stdio MCP restart evidence and will not spend current validation time duplicating this client-specific check. |
 
-The remaining blocking formal gates are:
+The remaining project-required formal lifecycle gates are:
 
-1. `claude_desktop_real_client_restart` — **PENDING**.
-2. `windows_clean_install_repair_uninstall` — **PENDING**.
-3. `elevated_plugin_install_profile_preservation` — **PENDING**.
-4. `custom_state_preservation` — **PENDING**.
+1. `windows_clean_install_repair_uninstall` — **PENDING**.
+2. `elevated_plugin_install_profile_preservation` — **PENDING**.
+3. `custom_state_preservation` — **PENDING**.
+
+The canonical repository manual-acceptance validator still defines Claude Desktop as a required gate
+and does not currently encode project-level waivers. Therefore it may continue to report the full
+canonical matrix as incomplete. Do not convert the waiver to PASS and do not claim direct Claude
+Desktop validation unless that real-client gate is actually run later.
 
 Claim-specific optional work remains separate: public-redownload smoke for future changed release
 bytes, external legal/Novarm review when required for a planned claim/activity, and a real openEMS
@@ -123,21 +128,36 @@ Codex evidence ZIP SHA256:
 
 `931001886200eb928fd3a376f76bd14856b2f5dcffd9d023208285623887fbe8`
 
-## Intentional pause before the remaining formal gates
+## Claude Desktop waiver
 
-The formal acceptance campaign is intentionally **PAUSED** here. The formal resume point remains:
+`claude_desktop_real_client_restart` was deliberately **WAIVED for the current project campaign** on
+2026-08-10.
 
-`claude_desktop_real_client_restart`
+Rationale: the real Codex client demonstrated the current server's stdio MCP startup, tool exposure,
+restart lifecycle and stable `get_capabilities` behavior. The project chooses not to spend current
+manual-validation time duplicating that lifecycle check in Claude Desktop before core schematic
+quality is proven.
 
-Do not infer that Claude Desktop or any Windows lifecycle gate passed. They remain pending.
+This is a risk acceptance, not evidence. Specifically:
 
-Before resuming those infrastructure/lifecycle gates, the project will prioritize a separate
-real-world schematic authoring/readability validation. The reason is product confidence: the next
-question is not merely whether the server installs and restarts, but whether it can produce a
-normal, readable, useful schematic in real DipTrace.
+- Claude Desktop was not configured/restarted for this gate;
+- no Claude-specific process/configuration evidence exists;
+- the gate must not be recorded as PASS;
+- claims of direct Claude Desktop validation remain unsupported unless the gate is run later.
 
-This validation is not a replacement for the formal matrix and must not silently mark any pending
-formal gate PASS.
+## Intentional pause before the remaining formal lifecycle gates
+
+The formal lifecycle campaign is intentionally **PAUSED** while the project validates core schematic
+authoring/readability. When lifecycle acceptance resumes, the next project-required gate is:
+
+`windows_clean_install_repair_uninstall`
+
+The Claude Desktop gate is skipped by explicit project waiver, not by inference.
+
+Before resuming the Windows/profile gates, the project will prioritize real-world schematic
+authoring/readability validation. The reason is product confidence: the next question is not merely
+whether the server installs and restarts, but whether it can produce a normal, readable, useful
+schematic in real DipTrace.
 
 ## Immediate validation priority — real schematic authoring/readability
 
@@ -146,8 +166,8 @@ subsequent Ponytail pass may have changed adjacent code. The historical
 `diptrace_ratline_and_wire_roundtrip` PASS proves its exact historical scope, but it does not prove
 that current higher-level schematic authoring produces good human-readable designs.
 
-The next project validation should exercise current post-Ponytail code on small real circuits, for
-example:
+The next project validation should exercise the explicitly selected current code candidate on small
+real circuits, for example:
 
 - resistor divider;
 - LED + resistor;
@@ -178,14 +198,13 @@ product-quality validation finds a new issue.
 When resuming work from this checkpoint:
 
 - do not restart completed gates;
-- treat `0bb09b4...` as the accepted production-code identity for the completed gates;
-- ignore later documentation-only commits when evaluating production candidate continuity;
-- if relevant production code changes, record the new candidate explicitly and rerun only the gates
-  plausibly affected by that code change;
+- treat `0bb09b4...` as the accepted production-code identity for the completed PASS gates;
+- treat Claude Desktop as WAIVED, not PASS;
+- if a later project decision requires direct Claude evidence, run it as a fresh gate rather than rewriting the waiver;
+- if relevant production code changes, record the new candidate explicitly and rerun only the evidence plausibly affected by that code change;
 - keep historical FAIL attempts immutable;
 - distinguish operator/path/seed mistakes from product defects;
-- Work may prepare files, hashes, XML comparisons and evidence automatically; ask the operator only
-  for meaningful real-GUI checkpoints;
+- Work may prepare files, hashes, XML comparisons and evidence automatically; ask the operator only for meaningful real-GUI checkpoints;
 - stop on a genuine blocking product FAIL and repair it separately;
 - do not silently expand the public MCP contract while performing acceptance or validation repairs.
 

--- a/docs/RELEASE_0_2_1_CHECKLIST.md
+++ b/docs/RELEASE_0_2_1_CHECKLIST.md
@@ -31,7 +31,7 @@ The repository continues to enforce:
 
 ## Post-publication manual acceptance progress — updated 2026-08-10
 
-The current accepted production-code candidate for the development-line manual campaign is:
+The accepted production-code candidate for the completed development-line manual gates is:
 
 `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba`
 
@@ -58,26 +58,27 @@ Q1 manual acceptance established real DipTrace angle semantics on the developmen
 
 Codex restart acceptance used Codex Desktop `26.803.5235.0`; both restarts exposed 159 tools and returned identical `get_capabilities` evidence. Production code remained unchanged.
 
-Overall blocking manual progress is now **8 of 12 gates complete**.
+The canonical matrix therefore has **8 of 12 gates PASS**.
 
-## Intentional pause before remaining lifecycle gates
+## Claude Desktop waiver and intentional pause
 
-The formal next gate is still:
+`claude_desktop_real_client_restart` has been deliberately **WAIVED for the current project campaign**.
 
-- [ ] `claude_desktop_real_client_restart`.
+It was not run and must not be represented as PASS. The project accepts the residual client-specific interoperability risk because the real Codex gate already demonstrated stdio MCP startup, tool exposure, actual process restart and stable `get_capabilities` behavior. No direct Claude Desktop evidence is claimed.
 
-It has not been run.
+The repository's canonical manual-acceptance validator still treats Claude Desktop as a required gate and does not encode this project-level waiver. It may therefore continue to report the canonical matrix as incomplete. Do not weaken the validator or fabricate a PASS solely to remove that warning.
 
-The project is intentionally pausing the formal client/Windows lifecycle sequence here to validate core product quality first: current post-Ponytail schematic authoring/readability in real DipTrace.
+The project is intentionally pausing the remaining Windows/profile lifecycle sequence to validate core product quality first: schematic authoring/readability in real DipTrace.
 
-This separate validation should build small real circuits and inspect electrical correctness, component placement, wire routing, text/label collisions, junction clarity and native save/reopen/re-export behavior. It must not be treated as a substitute for the remaining formal gates.
+This separate validation should build small real circuits and inspect electrical correctness, component placement, wire routing, text/label collisions, junction clarity and native save/reopen/re-export behavior.
 
-Remaining blocking formal gates after the pause:
+Remaining project-required formal gates after the pause:
 
-- [ ] Real Claude Desktop restart/configuration/`get_capabilities`.
 - [ ] Clean Windows 11 install, repair and uninstall using the applicable release bytes.
 - [ ] Elevated Program Files plug-in install while retaining the original user profile.
 - [ ] Pre-existing custom-state preservation across install/repair/uninstall.
+
+If direct Claude Desktop validation becomes important later, run it as a fresh real-client gate and replace the waiver with real evidence at that time; do not retroactively label the current waiver PASS.
 
 Claim-specific optional work remains a future public-redownload smoke when release bytes change, external legal/Novarm review when required for a planned claim/activity, and a real openEMS run only if external-solver validation is claimed.
 
@@ -95,6 +96,6 @@ This does **not** mean that 0.2.1 contains public native-library write tools and
 - Never move or replace an existing published tag/file.
 - Never use `skip-existing` to hide a production publication mismatch.
 - Never publish a wheel/sdist different from the artifact that passed validation.
-- Never claim signing, production readiness, universal DipTrace compatibility, real-client acceptance or real DipTrace acceptance without corresponding evidence.
+- Never claim signing, production readiness, universal DipTrace compatibility, direct Claude Desktop validation, real-client acceptance or real DipTrace acceptance without corresponding evidence.
 
 Git history contains the original pre-publication checklist state if historical reconstruction is needed.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,15 +12,15 @@ Implementation never implies universal DipTrace compatibility. Runtime `get_capa
 
 The current source/package version is `0.2.1`. Annotated tag `v0.2.1`, the GitHub development prerelease and `diptrace-mcp==0.2.1` on PyPI are already published.
 
-The accepted production-code candidate for the latest manual campaign is:
+The production-code candidate accepted through the latest completed manual gates is:
 
 `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba`
 
-That commit includes the post-PR #65/#66 Ponytail pass (PR #68). Later documentation-only commits do not invalidate this production-code identity.
+That commit includes the post-PR #65/#66 Ponytail pass (PR #68). Later development may move `main`; completed evidence remains bound to the candidate on which it was captured unless a later gate explicitly adopts a new production identity.
 
 The durable recovery record is [MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md](MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md), updated on 2026-08-10. Resume from that checkpoint instead of repeating already accepted gates.
 
-A new product-development track also starts at this checkpoint: **intelligent schematic and PCB design quality**. Formal acceptance remains paused at its existing resume point while the project first proves that it can produce schematics that are not only electrically correct, but compact, readable, intentionally structured and comparable in presentation quality to strong professional reference designs. The schematic track comes first because its geometry is primarily a readability/layout problem; the PCB track follows after the same generate/score/improve architecture is established.
+A new product-development track also starts at this checkpoint: **intelligent schematic and PCB design quality**. Formal lifecycle acceptance is paused while the project first proves that it can produce schematics that are not only electrically correct, but compact, readable, intentionally structured and comparable in presentation quality to strong professional reference designs. The schematic track comes first because its geometry is primarily a readability/layout problem; the PCB track follows after the same generate/score/improve architecture is established.
 
 ## Completed real-host / real-client acceptance
 
@@ -35,7 +35,11 @@ The following blocking manual gates are complete:
 - Q1 Component Angle GUI/re-export;
 - real Codex Desktop configuration/restart/`get_capabilities`.
 
-This is **8 of 12 blocking manual gates complete**.
+The canonical matrix therefore has **8 of 12 blocking manual gates PASS**.
+
+`claude_desktop_real_client_restart` is **WAIVED for the current project campaign**. It was not run and is not PASS. The project accepts the residual client-specific interoperability risk because the real Codex gate already demonstrated stdio MCP startup, actual process restart, tool exposure and stable `get_capabilities` behavior. No direct Claude Desktop validation is claimed.
+
+The canonical repository manual-acceptance validator still treats Claude Desktop as required and does not encode this project-level waiver. It may continue to report the canonical matrix as incomplete; do not weaken the validator or fabricate a PASS merely to remove that warning.
 
 ### Mask / paste / courtyard / Common
 
@@ -66,7 +70,7 @@ The private/manual campaign PASS is distinct from any future source-controlled p
 
 ### Codex real-client restart
 
-`codex_real_client_restart = PASS` on the same production candidate.
+`codex_real_client_restart = PASS` on the same accepted production candidate.
 
 - Codex Desktop: `26.803.5235.0`;
 - DipTrace MCP: `0.2.1`;
@@ -75,17 +79,15 @@ The private/manual campaign PASS is distinct from any future source-controlled p
 - new process IDs confirmed actual Codex/MCP restart;
 - production code remained unchanged.
 
-## Intentional pause in formal acceptance
+## Intentional pause in formal lifecycle acceptance
 
-The next formal gate remains:
+The next project-required lifecycle gate, when formal acceptance resumes, is:
 
-`claude_desktop_real_client_restart`
+`windows_clean_install_repair_uninstall`
 
-It is **PENDING** and has not been run.
+The Claude Desktop gate is skipped by explicit project waiver, not by inference and not as PASS.
 
-The formal campaign is intentionally paused before that gate. Before spending more time on client/installer lifecycle checks, the project will validate and improve the core product behavior: can the current MCP author a normal, readable, useful schematic in real DipTrace, and can it evolve from bounded authoring into an intentional schematic-layout engine?
-
-This pause does not cancel or waive the remaining formal gates.
+Before spending more time on installer/profile lifecycle checks, the project will validate and improve the core product behavior: can the current MCP author a normal, readable, useful schematic in real DipTrace, and can it evolve from bounded authoring into an intentional schematic-layout engine?
 
 ## New development track — intelligent schematic and PCB design
 
@@ -136,9 +138,11 @@ The same generate -> score -> improve loop should be reusable for PCB work later
 
 **Status: active checkpoint / first task.**
 
-PR #66 added deterministic bounded readability routing for newly authored schematic wires. Its automated goals include component avoidance, text/label avoidance, crossing and overlap avoidance, Manhattan routing, self-intersection avoidance and fewer unnecessary bends. The subsequent Ponytail pass may have modified adjacent behavior.
+PR #66 added deterministic bounded readability routing for newly authored schematic wires. Its automated goals include component avoidance, text/label avoidance, crossing and overlap avoidance, Manhattan routing, self-intersection avoidance and fewer unnecessary bends. The subsequent Ponytail pass and later development may have modified adjacent behavior.
 
 The historical `diptrace_ratline_and_wire_roundtrip` PASS remains valid for its original scope. It proves wire connectivity and native round-trip behavior, but it does **not** prove that higher-level current schematic authoring consistently produces a schematic a human would consider clean and usable.
+
+Before the first Phase 26 real-world experiment, record the actual local production candidate. Do not assume that the historical `0bb09b4...` identity is still the code being tested if later production changes are present.
 
 Build small real circuits from clean starting points and preserve them as regression/quality cases where licensing and provenance allow. Suggested cases:
 
@@ -301,18 +305,18 @@ Combine placement, routing candidates, power/ground strategy, DRC/review, SI/ret
 
 Benchmark against deliberately poor layouts, hand-improved layouts and legally usable reference boards. Do not claim "optimal PCB" or fabrication sign-off; report measurable improvements and remaining unsupported categories.
 
-## Remaining blocking formal acceptance
+## Remaining formal lifecycle acceptance
 
-When the schematic authoring/readability validation and the chosen development checkpoint are intentionally finished or paused, resume formal acceptance in this order:
+When schematic authoring/readability validation and the chosen development checkpoint are intentionally finished or paused, resume project-required formal acceptance in this order:
 
 | Order | Gate | Status |
 | --- | --- | --- |
-| 1 | `claude_desktop_real_client_restart` | **PENDING** |
-| 2 | `windows_clean_install_repair_uninstall` | **PENDING** |
-| 3 | `elevated_plugin_install_profile_preservation` | **PENDING** |
-| 4 | `custom_state_preservation` | **PENDING** |
+| — | `claude_desktop_real_client_restart` | **WAIVED — not PASS; no direct Claude evidence** |
+| 1 | `windows_clean_install_repair_uninstall` | **PENDING** |
+| 2 | `elevated_plugin_install_profile_preservation` | **PENDING** |
+| 3 | `custom_state_preservation` | **PENDING** |
 
-Generate the exact evidence worksheet with:
+Generate the canonical evidence worksheet with:
 
 ```bash
 python scripts/prepare_manual_acceptance.py acceptance \
@@ -326,7 +330,7 @@ After recording observations and evidence files, validate it with:
 python scripts/prepare_manual_acceptance.py acceptance --check
 ```
 
-The validator must not call the blocking acceptance complete while a required gate remains pending.
+The canonical validator does not currently encode the Claude waiver and therefore must not call the full canonical matrix complete while that required gate remains pending internally. The project-level waiver is documented separately rather than disguised as PASS.
 
 ## Claim-specific or optional manual work
 
@@ -394,7 +398,7 @@ The acceptance campaign and the new optimizer roadmap do not implicitly add or r
 | 22 | candidate complete | Windows installer/portable/configurator pipeline; clean-machine acceptance remains manual |
 | 23 | baseline complete | deterministic pattern recommendation and privacy-bounded feedback/evaluation |
 | 24 | host-verified internal core | Component/Pattern mutation core has real editor evidence; public registration is deferred |
-| 25 | manual acceptance paused at 8/12 | Through Codex restart PASS; formal resume point is Claude Desktop |
+| 25 | manual acceptance paused | 8 canonical PASS gates; Claude explicitly WAIVED for current project campaign; project resume point is Windows lifecycle |
 | 26 | **active checkpoint** | Establish real-world schematic readability baseline and benchmark cases |
 | 27 | planned — schematic | Design intent, functional blocks and datasheet/reference motifs |
 | 28 | planned — schematic | Hierarchical component placement, orientation, compactness and routeability scoring |
@@ -417,4 +421,4 @@ The acceptance campaign and the new optimizer roadmap do not implicitly add or r
 - Generic fabrication/assembly manifests are not native Gerber, NC Drill, ODB++, IPC-2581 or assembler sign-off packages.
 - The ngspice adapter runs user-provided netlists; it does not generate a complete simulation netlist from a DipTrace design.
 - Native manufacturing generation remains unavailable because no verified DipTrace output API is claimed.
-- The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review, production readiness or globally optimal schematic/PCB layout.
+- The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review, production readiness, direct Claude Desktop validation or globally optimal schematic/PCB layout.

--- a/docs/SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md
+++ b/docs/SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md
@@ -6,9 +6,11 @@ The formal manual acceptance campaign is intentionally paused after
 `codex_real_client_restart = PASS` on production candidate
 `0bb09b4b3af40a5a3d1a875fab885430a2d251ba`.
 
-The formal resume point remains `claude_desktop_real_client_restart`, but before continuing with client and Windows lifecycle gates the project is validating the core product behavior more deeply: can DipTrace MCP author a normal, electrically correct, human-readable schematic in real DipTrace without routine manual cleanup?
+The project has explicitly waived `claude_desktop_real_client_restart` for the current campaign. That gate was not run and is not PASS; no direct Claude Desktop validation is claimed. The current priority is deeper product validation: can DipTrace MCP author a normal, electrically correct, human-readable schematic in real DipTrace without routine manual cleanup?
 
-This is not a replacement for the formal manual matrix and must not mark Claude/Windows gates PASS.
+When formal lifecycle acceptance resumes, the next project-required gate is `windows_clean_install_repair_uninstall`.
+
+The canonical repository manual-acceptance validator still treats Claude Desktop as required and does not encode this project-level waiver. Do not rewrite the waiver as PASS merely to satisfy the canonical matrix.
 
 ## Relevant implementation history
 
@@ -24,7 +26,9 @@ PR #66 added deterministic bounded readability routing for newly authored schema
 - minimize unnecessary bends and path length within bounded search limits;
 - preserve intentional wire-to-wire endpoint connections.
 
-The subsequent Ponytail pass was merged in PR #68. The accepted production candidate for this validation is therefore the post-Ponytail code at `0bb09b4...`, unless a later production-code change is explicitly adopted as a new candidate.
+The subsequent Ponytail pass was merged in PR #68. The historical accepted production candidate for the completed manual gates is therefore the post-Ponytail code at `0bb09b4...`.
+
+For this new schematic-quality validation, do not assume that historical identity is still the current code candidate. Before the first experiment, record the actual local production checkout being tested and treat it as a new validation identity if relevant production code has changed since `0bb09b4...`.
 
 The historical `diptrace_ratline_and_wire_roundtrip` gate remains PASS for its original scope. This validation is stronger and product-oriented: it evaluates complete authored schematic quality rather than only wire serialization/connectivity round-trip.
 
@@ -145,10 +149,12 @@ Check:
 
 ## Stop / resume point
 
-This validation may generate focused repair work. Complete or pause it deliberately before returning to the formal matrix.
+This validation may generate focused repair work. Complete or pause it deliberately before returning to the formal lifecycle matrix.
 
-Formal acceptance resumes at:
+Project-required formal acceptance resumes at:
 
-`claude_desktop_real_client_restart`
+`windows_clean_install_repair_uninstall`
+
+`claude_desktop_real_client_restart` remains WAIVED for the current project campaign, not PASS. If direct Claude Desktop evidence becomes important later, run it as a fresh gate.
 
 Do not repeat already accepted PCB, schematic round-trip, library writer, ratline/wire, mask/paste/courtyard/Common, Q1, or Codex restart gates unless a later production-code change plausibly affects their exact tested path.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -40,14 +40,15 @@ The accepted production-code identity through those gates is
 
 ## Remaining formal manual evidence debt
 
-Four blocking formal gates remain:
+The project has explicitly waived `claude_desktop_real_client_restart` for the current campaign. This is not PASS evidence: Claude Desktop was not independently configured/restarted, and no Claude-specific runtime evidence exists. The waiver is a project-level risk acceptance based on successful real Codex stdio MCP restart evidence and does not change the conservative canonical manual-acceptance validator.
 
-- `claude_desktop_real_client_restart`;
+Three project-required lifecycle gates remain:
+
 - `windows_clean_install_repair_uninstall`;
 - `elevated_plugin_install_profile_preservation`;
 - `custom_state_preservation`.
 
-The formal campaign is intentionally paused before Claude Desktop while core schematic authoring quality is validated more deeply.
+The formal lifecycle campaign is intentionally paused before those Windows/profile gates while core schematic authoring quality is validated more deeply.
 
 Claim-specific optional evidence remains external legal/Novarm review when required, a real openEMS integration run only when solver validation is claimed, and public-redownload smoke when a future release changes published bytes.
 
@@ -55,9 +56,9 @@ Claim-specific optional evidence remains external legal/Novarm review when requi
 
 PR #66 added deterministic bounded wire-quality routing for newly authored schematic wires. Automated tests cover component-region avoidance, schematic text avoidance, crossing avoidance, collinear overlap avoidance, Manhattan paths and bounded deterministic search.
 
-That automated coverage and the historical authored-wire round-trip PASS do not prove that the current post-Ponytail system can author a complete schematic that is clean and understandable to a human.
+That automated coverage and the historical authored-wire round-trip PASS do not prove that the current system can author a complete schematic that is clean and understandable to a human.
 
-Before resuming the remaining client/Windows lifecycle gates, validate representative small real schematics in DipTrace. At minimum include:
+Before resuming the remaining Windows/profile lifecycle gates, validate representative small real schematics in DipTrace. At minimum include:
 
 - resistor divider;
 - LED + resistor;
@@ -85,4 +86,6 @@ This is a stronger product-quality validation, not a rewrite of the historical `
 
 Use `scripts/prepare_manual_acceptance.py` for the canonical manual-only matrix. Historical FAIL attempts remain immutable; repairs get fresh retest attempts.
 
-Documentation-only commits after the accepted production candidate do not create production-code drift. If relevant production code changes, explicitly identify the new candidate and rerun only the evidence plausibly affected by that change.
+A project-level waiver must not be rewritten as PASS merely to satisfy the canonical matrix. The validator may continue to report incomplete while Claude remains unrun; that is an explicit known difference between the canonical matrix and the current project campaign.
+
+Documentation-only commits after an accepted production candidate do not create production-code drift. If relevant production code changes, explicitly identify the new candidate and rerun only the evidence plausibly affected by that change.


### PR DESCRIPTION
## Summary

Carry the previously reviewed project decision forward onto the current `main@fceebb69043c571162f0dbc14f152ffd7edb032b` without bringing the stale merge history from the closed PR #79.

## Decision

- `claude_desktop_real_client_restart` is **WAIVED for the current project campaign**, not PASS;
- no direct Claude Desktop validation is claimed;
- successful real Codex stdio MCP restart evidence is accepted as sufficient for the project's current risk posture;
- the canonical repository manual-acceptance validator remains conservative and is not weakened;
- when lifecycle acceptance resumes, the next project-required gate is `windows_clean_install_repair_uninstall`;
- the immediate validation priority remains real-world schematic authoring/readability.

## Scope

Docs only: checkpoint, roadmap, technical debt, historical 0.2.1 checklist, and schematic-authoring validation note. No production code, MCP contract, canonical gate implementation, or historical evidence is changed.

This PR is rebuilt as one signed-off commit directly on current main to avoid the DCO failure caused by the old branch merge commit.