### PR TITLE
Implement PCB Generation C routing intelligence

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -16,7 +16,11 @@ This temporary development record avoids rewriting the immutable `0.2.1` release
 - internal PCB Generation B physical-context analysis that reuses exported stackup, return-path and normalized via evidence without promoting analytic results to field-solver trust;
 - conservative PDN rail/source/load/decoupling and regulator hot-loop candidates with explicit unknown-current/current-density/voltage-drop boundaries;
 - timing-gated aggressor/victim physical triage and semantic signal/power/ground/return-transition/differential/thermal via roles;
-- PCB Generation B regression coverage for stackup provenance, PDN unknown preservation, explicit current facts, reference-sensitive return paths, timing-gated noise analysis and bounded via-role classification.
+- PCB Generation B regression coverage for stackup provenance, PDN unknown preservation, explicit current facts, reference-sensitive return paths, timing-gated noise analysis and bounded via-role classification;
+- internal PCB Generation C routing-policy compiler with deterministic engineering route order, explicit layer/via/length/skew/impedance/reference/stub/shield constraints and unknown-width preservation;
+- observed-route SI checks for length, via budget, forbidden layers, reference continuity, impedance, skew and stubs, with no invented universal crosstalk threshold;
+- conservative trace/local-copper/plane/pour strategy and bounded endpoint-placement feedback while native routing/pour edits remain on the existing guarded semantic path;
+- PCB Generation C regression coverage for constraint propagation, route ordering, SI failure/unknown behavior, copper evidence boundaries and wrong-net rejection.
 
 ## Documentation
 
@@ -24,8 +28,9 @@ This temporary development record avoids rewriting the immutable `0.2.1` release
 - expanded the intelligent PCB roadmap through Generations A-D: intent/placement, stackup/PDN/return paths/vias, engineering-aware routing/SI/copper strategy, and joint whole-board optimization/acceptance;
 - documented the internal EDA architecture, PCB design-intent domain models and the split between low-level placement legalization and intent-aware placement v2;
 - documented Generation B stackup/reference, PDN, return-path, timing-gated noise and via-intelligence evidence boundaries;
+- documented Generation C routing-policy, observed-route SI, copper/refill and placement-feedback boundaries;
 - clarified that the private/manual Q1 Component Angle campaign is PASS while package-owned public evidence/trust promotion remains a separate reviewed contract.
 
-The Generation A/B work intentionally leaves the 159-tool public MCP surface unchanged. It is internal EDA capability until a separate, deliberate public API decision is made.
+The Generation A-C work intentionally leaves the 159-tool public MCP surface unchanged. It is internal EDA capability until a separate, deliberate public API decision is made.
 
 This file should be folded into the normal `CHANGELOG.md` when the next version is selected.

--- a/docs/PCB_DESIGN_ENGINE.md
+++ b/docs/PCB_DESIGN_ENGINE.md
@@ -38,204 +38,97 @@ joint score and bounded repair             Generation D
 guarded semantic plan -> preview -> SHA-bound apply -> review
 ```
 
-Physical facts are never invented to make the model look complete. Unknown edge rate, current, impedance, stackup or datasheet facts remain unknown until they are supplied or supported by authoritative project data.
+Physical facts are never invented to make the model look complete. Unknown edge rate, current, impedance, stackup or datasheet facts remain unknown until supplied or supported by authoritative project data.
 
 ## Generation A — PCB understands electronics
 
 **Status: implemented, regression-tested and merged to `main` in PR #81.**
 
-Generation A establishes the engineering-intent layer that must exist before a global placer can make useful decisions.
+`pcb_design_intent.py` builds a typed engineering view of component roles, functional blocks, multi-role nets, electrical criticality, explicit physical constraints and conservative power/ground topology intent. `pcb_placement.py` adds deterministic bounded placement above the existing geometry legalizer and emits ordinary `MoveComponentsOperation` objects instead of writing XML directly.
 
-### Design intent
-
-`pcb_design_intent.py` builds a typed engineering view of the board:
-
-- component roles: controller, power converter, connector, interface, sensor, timing, protection, support and mechanical anchor;
-- deterministic functional blocks with principal anchors and support members;
-- explicit confidence/reasons for inferred roles;
-- operator overrides for facts that cannot be recovered safely from XML/naming;
-- noise-emission/noise-sensitivity placement intent;
-- thermal role metadata used as intent only, not as a temperature prediction;
-- deterministic placement priority.
-
-Automatic classification is conservative. It uses exported connectivity, RefDes/name/value metadata and the normalized differential-pair model. An override that does not resolve uniquely becomes a warning instead of being guessed.
-
-### Net intelligence and criticality
-
-Nets may carry multiple roles because real electrical behavior is not a single enum. Generation A recognizes, where evidence exists:
-
-- ground and chassis/shield domains;
-- ordinary power and explicit high-current power;
-- switching nodes;
-- clock/timing nets;
-- exported or strongly named differential nets;
-- reset/control/digital nets;
-- analog, precision-reference, feedback and current-sense nets;
-- RF/antenna-like nets.
-
-Each net receives a decomposed electrical intent record containing:
-
-- component membership;
-- criticality;
-- noise emission and sensitivity;
-- via penalty;
-- whether a continuous reference is expected;
-- optional edge rate, frequency, current, target impedance/tolerance, max length/skew, via limit, layer preferences, reference net, spacing and stub/shielding constraints.
-
-Only supplied/exported values populate physical constraints. Criticality may become more conservative when explicit edge rate/current/length/impedance data is available, but the engine does not manufacture missing electrical values.
-
-### Power and ground strategy
-
-Generation A models topology intent without pretending to perform full PI/return-current simulation.
-
-The deterministic defaults are deliberately conservative:
-
-- ordinary ground -> `continuous_plane_preferred`;
-- chassis/shield -> separate `chassis_or_shield` domain;
-- switch node -> `local_copper_minimized`;
-- current/sense naming -> `kelvin_candidate`;
-- power rail -> `local_plane_or_pour_candidate`;
-- star grounding -> **never inferred automatically**; it requires explicit project/operator intent.
-
-This prevents the common but unsafe rule "analog + digital means split the ground plane" from entering the engine as a default.
-
-### Placement v2
-
-`pcb_placement.py` sits above the existing `placement.py` local legalizer/scorer. The original engine remains the source of hard placement legality for outline, keepout and overlap behavior.
-
-Generation A placement:
-
-1. fixes locked/mechanically anchored components;
-2. identifies functional anchors before support members;
-3. derives desired regions from support relationships and critical connectivity;
-4. generates deterministic bounded board-level candidates around those targets;
-5. refuses candidates that increase hard geometry penalties;
-6. scores candidates using a decomposed objective;
-7. emits ordinary `MoveComponentsOperation` objects rather than writing XML directly.
-
-The v2 score exposes separate terms for existing geometry/ratsnest legality, functional-block cohesion, support-to-anchor adjacency, critical-net connection distance and intent-level aggressor/victim proximity.
-
-The Generation A noise term remains only a placement proxy. Generation B adds timing-gated physical-context triage without claiming EMC sign-off.
+Generation A deliberately preserves unknown physics. Ordinary ground defaults to `continuous_plane_preferred`; switch nodes to `local_copper_minimized`; sense nets to `kelvin_candidate`; power rails to `local_plane_or_pour_candidate`; star grounding is never inferred automatically.
 
 ## Generation B — PCB understands fields and current paths
 
-**Status: implemented internally on `pcb_physical.py`; CI/PR acceptance is the gate before merge.**
+**Status: implemented internally on `pcb_physical.py`; PR #83 is the merge gate.**
 
-Generation B consumes the Generation A intent plus existing normalized stackup, geometry, via and return-path evidence. It is non-mutating and emits analysis only.
+`analyze_pcb_physics()` consumes Generation A intent plus existing normalized stackup, geometry, via and return-path evidence. It is non-mutating and provides:
 
-### Stackup and reference structure
+- typed microstrip/stripline reference candidates from exported stackup;
+- conservative PDN rail source/load/decoupling candidates;
+- regulator hot-loop candidates without pretending pad-level current direction is proven;
+- bounded reuse of `analyze_return_path()` for reference-sensitive nets;
+- aggressor/victim triage only when explicit edge-rate/frequency evidence exists;
+- semantic signal/power/ground/return-transition/differential/thermal via roles.
 
-`analyze_pcb_physics()` reuses the existing stackup/impedance analysis and exposes typed microstrip/stripline reference candidates with:
-
-- signal layer and adjacent reference layer(s);
-- exported dielectric/copper geometry when available;
-- reference-plane confidence from the normalized stackup;
-- explicit `exported_stackup` evidence provenance;
-- `preliminary_only=True` for analytic candidates.
-
-Analytic geometry is deliberately not promoted to manufacturer-verified or external field-solver evidence.
-
-### Power integrity / PDN
-
-For each identified power rail Generation B records:
-
-- power-converter source candidates only when topology/intent supports them;
-- remaining connected load candidates;
-- capacitor members as conservative decoupling candidates;
-- explicit rail current when supplied;
-- inherited trace/local-copper/pour strategy intent;
-- whether meaningful power-via capacity validation is required.
-
-Current density and voltage drop remain `unknown` until both current and sufficient copper geometry/material/current-path evidence exist. Numeric via current capacity is not guessed.
-
-Switching-node nets connected to a power converter produce regulator hot-loop **candidates**. They do not become proven current loops until pad-level source/load/return direction is available.
-
-### Return-path strategy
-
-Generation B integrates the existing `analyze_return_path()` engine for nets that require a continuous reference or have precision/sense semantics. The existing analyzer remains authoritative for its bounded observations:
-
-- adjacent-reference resolution from physical stack order;
-- missing reference copper;
-- possible split crossings;
-- layer transitions without normalized return-via evidence;
-- disclosed skipped checks where the export is insufficient.
-
-Ground remains continuous by default; mixed analog/digital naming does not create an automatic split.
-
-### Noise compatibility
-
-Distance-only placement risk is no longer sufficient for physical triage. Generation B creates aggressor/victim pairs only when the aggressor has explicit edge-rate or frequency evidence. The bounded score combines:
-
-- known timing evidence;
-- Generation A emission/sensitivity/criticality;
-- actual component-centroid separation from normalized geometry.
-
-It does **not** assert trace parallelism, spectral overlap, field coupling or EMC compliance. Those require route observations or stronger solvers/evidence.
-
-### Via intelligence
-
-Normalized vias receive semantic roles only when evidence supports them:
-
-- signal via;
-- power via;
-- ground-stitching via;
-- reference-sensitive return-transition candidate;
-- differential transition member;
-- thermal via only from explicit normalized thermal metadata.
-
-A via fence is not inferred merely from proximity. The existing via geometry/span validator remains the low-level authority, and semantic roles never imply numeric current capacity.
+Analytic impedance candidates stay `preliminary_only`; current density, voltage drop and numeric via capacity remain unknown until sufficient physical evidence exists. No via fence, split ground, EMC compliance or field-solver result is invented.
 
 ## Generation C — PCB routes intentionally
 
-**Status: planned.**
+**Status: implemented internally on `pcb_routing_policy.py`; PR #84 is the merge gate.**
+
+Generation C translates A/B engineering evidence into deterministic routing policy while leaving actual trace/via/pour mutation in the existing routing compiler and guarded semantic transaction path.
 
 ### Routing policy compiler
 
-Translate net intent into concrete router policy: priority, width/clearance, preferred layers, via budget/penalty, target impedance, pair/skew rules, reference requirement and spacing/shielding constraints.
+`compile_pcb_routing_policy()` produces one typed policy per net with:
+
+- deterministic engineering priority and stable route order;
+- explicit minimum spacing and preferred/forbidden layers;
+- explicit via budget and Generation A via penalty;
+- target impedance/tolerance when known;
+- max length/skew when known;
+- reference requirement/reference net and preliminary stackup candidates;
+- stub sensitivity and shielding preference.
+
+Missing width, spacing, impedance, timing or other physical limits remain unknown. Generation C does not manufacture a trace width merely because a net is critical.
 
 ### Route ordering
 
-Route topology-critical nets first rather than XML order. Typical ordering is switching/RF/timing/high-speed/precision analog before ordinary controls and indicators, but the actual order derives from criticality/constraints rather than a fixed protocol list.
+Nets are sorted by criticality, electrical roles and explicit constraints rather than XML order or one hard-coded protocol list. Switching/RF/differential/clock/precision nets naturally receive higher priority when their intent/evidence supports it.
 
-### SI-aware routing and crosstalk
+### Observed-route SI checks
 
-Add post-candidate checks for impedance continuity, differential symmetry/skew, stubs, parallel-coupling exposure, plane/reference discontinuity and layer-transition return path.
+`evaluate_route_observation()` evaluates supplied route observations for:
 
-### Copper / plane / pour planner
+- maximum length;
+- via budget;
+- forbidden-layer use;
+- continuous reference requirement;
+- explicit impedance tolerance;
+- skew;
+- stubs on stub-sensitive nets;
+- measured parallel-route exposure.
 
-Choose trace versus local copper versus plane/pour from known current/return/thermal constraints. Add refill/island/cutout/thermal-relief validation only after authoritative DipTrace geometry/evidence exists.
+Absent observation or absent constraint stays `unknown`. Parallel exposure is reported without inventing one universal crosstalk pass/fail threshold.
+
+### Copper strategy
+
+Generation C preserves Generation A/B topology intent when deciding whether a net is fundamentally a trace, local-copper-minimized path, local plane/pour candidate, continuous plane, shield/chassis domain, Kelvin candidate or explicit star topology.
+
+Any strategy involving native poured/plane copper is marked as requiring authoritative DipTrace refill/geometry evidence before acceptance. Unknown rail current does not become a fabricated current-capacity conclusion.
 
 ### Placement feedback
 
-Routing may return bounded placement repairs instead of accepting pathological routes, for example a small move/rotation that removes several vias or restores a valid reference path. The router proposes; the joint optimizer decides.
+Failed route observations can return bounded endpoint-placement feedback. Reference-continuity and via-budget failures are treated as strong feedback signals; the optimizer may consider a bounded endpoint move, but routing policy itself does not move components.
 
 ## Generation D — whole-board optimization
 
-**Status: planned.**
+**Status: implementation in progress on a stacked branch.**
 
-Combine placement, routing, SI, PI, return-path, EMI-risk, thermal, DFM/DFA/DFT and manufacturing constraints into one bounded multi-objective loop.
+Generation D combines placement, routing, SI, PI, return-path, EMI-risk, thermal and manufacturing metrics into one bounded multi-objective selector. Hard violations are lexicographically dominant and can never be traded for a better soft score. The complete score stays decomposed; there is no opaque "AI board quality" value.
 
-Hard violations are lexicographically dominant and cannot be traded away for a prettier score. A candidate with new DRC/mechanical/safety violations loses regardless of wire length or visual compactness.
-
-The complete score remains decomposed. There is no opaque "AI board quality" value without component metrics.
-
-Generation D also adds benchmark families for MCU/decoupling, regulators, ADC/mixed signal, USB/high-speed differential, Ethernet/CAN, RF/antenna and higher-current power designs, followed by controlled DipTrace open/save/re-export acceptance.
+Generation D also defines engineering-trap benchmark families followed by controlled real-DipTrace open/refill/DRC/save/reopen/re-export acceptance where native geometry matters.
 
 ## Testing and acceptance
 
-Generation A automated coverage includes component/net role inference, functional grouping, explicit electrical overrides, unknown-value preservation, ground topology safety, differential-pair evidence, decomposed placement scoring, intent-aware placement and hard-geometry/budget refusal.
+Generation A automated coverage includes component/net role inference, functional grouping, explicit overrides, unknown-value preservation, ground-topology safety, differential-pair evidence, decomposed placement scoring and hard-geometry/budget refusal.
 
-Generation B automated coverage adds:
+Generation B adds stackup provenance, unknown-current/source preservation, explicit current/converter facts, reference-sensitive return paths, timing-gated noise analysis, bounded via-role classification and invalid-radius rejection.
 
-- exported stackup/reference candidates without solver-trust promotion;
-- unknown-current/source preservation in PDN analysis;
-- explicit operator current/converter facts;
-- reference-sensitive return-path targeting;
-- timing-gated noise analysis;
-- bounded via semantic-role classification;
-- rejection of invalid return-via search radius.
+Generation C adds deterministic route ordering, constraint propagation, preliminary reference policy, unknown-width preservation, observed SI failure/unknown behavior, bounded placement feedback, copper/refill evidence boundaries and wrong-net rejection.
 
-Each later generation must add small engineering trap fixtures rather than relying on one large demo board. A real-DipTrace acceptance fixture is required before claims about poured copper, plane behavior, via structures or native round-trip semantics are promoted beyond the existing evidence boundary.
+A real-DipTrace acceptance fixture remains required before claims about poured copper, plane behavior, via structures or native round-trip semantics are promoted beyond the existing evidence boundary.
 
 ## Non-claims
 
@@ -250,4 +143,4 @@ The PCB design engine does **not** currently claim:
 - fabrication or assembly sign-off;
 - globally optimal placement/routing.
 
-Generations A and B provide the deterministic intent, placement and physical-context foundation on which routing policy and whole-board optimization can be built.
+Generations A-C provide deterministic intent, placement, physical-context and routing-policy foundations for the bounded whole-board optimizer.

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -234,6 +234,7 @@ src/diptrace_mcp/pattern_recommendation.py
 src/diptrace_mcp/pcb_design_intent.py
 src/diptrace_mcp/pcb_physical.py
 src/diptrace_mcp/pcb_placement.py
+src/diptrace_mcp/pcb_routing_policy.py
 src/diptrace_mcp/placement.py
 src/diptrace_mcp/plans.py
 src/diptrace_mcp/policy.py
@@ -377,6 +378,7 @@ tests/test_pattern_recommendation.py
 tests/test_pattern_validation.py
 tests/test_pcb_design_engine.py
 tests/test_pcb_physical.py
+tests/test_pcb_routing_policy.py
 tests/test_phase4.py
 tests/test_placement.py
 tests/test_plugin_settings.py

--- a/src/diptrace_mcp/pcb_routing_policy.py
+++ b/src/diptrace_mcp/pcb_routing_policy.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from .adapters import DocumentSnapshot
+from .domain import StrictModel
+from .errors import CapabilityUnavailableError
+from .pcb_design_intent import (
+    PCBDesignIntent,
+    PCBIntentOverrides,
+    PCBNetIntent,
+    ReturnStrategy,
+    build_pcb_design_intent,
+)
+from .pcb_physical import PCBPhysicalAnalysis, analyze_pcb_physics
+
+
+class PCBLayerReferencePolicy(StrictModel):
+    signal_layer: str
+    reference_layers: list[str] = Field(default_factory=list)
+    structure: Literal["microstrip", "symmetric_stripline"]
+    confidence: Literal["low", "high"] = "low"
+    preliminary_only: bool = True
+
+
+class PCBNetRoutingPolicy(StrictModel):
+    net_id: str
+    name: str | None = None
+    roles: list[str] = Field(default_factory=list)
+    priority: int = Field(ge=0, le=1000)
+    criticality: int = Field(ge=0, le=100)
+    trace_width_mm: float | None = None
+    minimum_spacing_mm: float | None = None
+    preferred_layers: list[str] = Field(default_factory=list)
+    forbidden_layers: list[str] = Field(default_factory=list)
+    max_vias: int | None = None
+    via_penalty: int = Field(ge=0, le=100)
+    target_impedance_ohm: float | None = None
+    impedance_tolerance_percent: float | None = None
+    max_length_mm: float | None = None
+    max_skew_mm: float | None = None
+    reference_plane_required: bool = False
+    reference_net: str | None = None
+    reference_candidates: list[PCBLayerReferencePolicy] = Field(default_factory=list)
+    stub_sensitive: bool = False
+    shielding_preferred: bool = False
+    reasons: list[str] = Field(default_factory=list)
+
+
+CopperStrategy = Literal[
+    "trace",
+    "local_copper_minimized",
+    "local_plane_or_pour_candidate",
+    "continuous_plane_preferred",
+    "chassis_or_shield",
+    "kelvin_candidate",
+    "explicit_star",
+    "unknown",
+]
+
+
+class PCBCopperStrategy(StrictModel):
+    net_id: str
+    name: str | None = None
+    strategy: CopperStrategy
+    current_a: float | None = None
+    requires_refill_evidence: bool = False
+    reasons: list[str] = Field(default_factory=list)
+
+
+class PCBRoutingPolicySet(StrictModel):
+    intent: PCBDesignIntent
+    physical: PCBPhysicalAnalysis
+    policies: list[PCBNetRoutingPolicy] = Field(default_factory=list)
+    route_order: list[str] = Field(default_factory=list)
+    copper_strategies: list[PCBCopperStrategy] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+CheckStatus = Literal["pass", "fail", "unknown"]
+
+
+class PCBRouteObservation(StrictModel):
+    net_id: str
+    length_mm: float | None = Field(default=None, ge=0.0)
+    via_count: int | None = Field(default=None, ge=0)
+    used_layers: list[str] = Field(default_factory=list)
+    maintained_reference: bool | None = None
+    impedance_ohm: float | None = Field(default=None, gt=0.0)
+    skew_mm: float | None = Field(default=None, ge=0.0)
+    stub_length_mm: float | None = Field(default=None, ge=0.0)
+    parallel_exposure_mm: float | None = Field(default=None, ge=0.0)
+
+
+class PCBSICheck(StrictModel):
+    key: str
+    status: CheckStatus
+    actual: Any = None
+    limit: Any = None
+    reason: str
+
+
+class PCBPlacementFeedback(StrictModel):
+    net_id: str
+    component_ids: list[str] = Field(default_factory=list)
+    severity: Literal["none", "consider", "strong"] = "none"
+    reasons: list[str] = Field(default_factory=list)
+    action: Literal["none", "bounded_endpoint_move_candidate"] = "none"
+
+
+class PCBRouteEvaluation(StrictModel):
+    net_id: str
+    checks: list[PCBSICheck] = Field(default_factory=list)
+    hard_failures: int = Field(ge=0)
+    placement_feedback: PCBPlacementFeedback
+    observations_used: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+_ROLE_BONUS: dict[str, int] = {
+    "switching_node": 180,
+    "rf": 170,
+    "differential": 150,
+    "clock": 140,
+    "precision_analog": 130,
+    "reference": 130,
+    "current_sense": 125,
+    "feedback": 115,
+    "high_current_power": 110,
+    "analog": 70,
+    "power": 60,
+    "reset": 30,
+    "control": 20,
+    "digital": 15,
+    "ground": 10,
+    "shield": 10,
+    "unknown": 0,
+}
+
+
+def _require_board(snapshot: DocumentSnapshot) -> None:
+    if snapshot.board is None:
+        raise CapabilityUnavailableError("PCB routing policy requires a PCB document")
+
+
+def _priority(net: PCBNetIntent) -> int:
+    role_bonus = max((_ROLE_BONUS.get(role, 0) for role in net.roles), default=0)
+    constraint_bonus = 0
+    constraints = net.constraints
+    if constraints.target_impedance_ohm is not None:
+        constraint_bonus += 80
+    if constraints.max_skew_mm is not None:
+        constraint_bonus += 70
+    if constraints.max_length_mm is not None:
+        constraint_bonus += 50
+    if constraints.max_vias is not None:
+        constraint_bonus += 30
+    if constraints.edge_rate_ns is not None:
+        constraint_bonus += 60
+    if constraints.signal_frequency_hz is not None:
+        constraint_bonus += 40
+    return min(1000, net.criticality * 5 + role_bonus + constraint_bonus)
+
+
+def _reference_policies(
+    physical: PCBPhysicalAnalysis,
+) -> list[PCBLayerReferencePolicy]:
+    return [
+        PCBLayerReferencePolicy(
+            signal_layer=item.signal_layer,
+            reference_layers=list(item.reference_layers),
+            structure=item.structure,
+            confidence=item.reference_plane_confidence,
+            preliminary_only=item.preliminary_only,
+        )
+        for item in physical.reference_candidates
+    ]
+
+
+def _policy_for_net(
+    net: PCBNetIntent,
+    references: list[PCBLayerReferencePolicy],
+) -> PCBNetRoutingPolicy:
+    constraints = net.constraints
+    preferred = list(dict.fromkeys(constraints.preferred_layers))
+    forbidden = list(dict.fromkeys(constraints.forbidden_layers))
+    applicable_references = [
+        item
+        for item in references
+        if not preferred or item.signal_layer in preferred
+    ]
+    reasons = [
+        (
+            "Priority is deterministic from Generation A criticality, roles and "
+            "explicit constraints."
+        ),
+        (
+            "Physical routing limits are copied from explicit/exported facts; "
+            "missing width/clearance is not invented."
+        ),
+    ]
+    if net.reference_plane_required:
+        reasons.append(
+            "Reference candidates come from Generation B exported-stackup "
+            "analysis and remain preliminary."
+        )
+    return PCBNetRoutingPolicy(
+        net_id=net.net_id,
+        name=net.name,
+        roles=list(net.roles),
+        priority=_priority(net),
+        criticality=net.criticality,
+        trace_width_mm=None,
+        minimum_spacing_mm=constraints.minimum_spacing_mm,
+        preferred_layers=preferred,
+        forbidden_layers=forbidden,
+        max_vias=constraints.max_vias,
+        via_penalty=net.via_penalty,
+        target_impedance_ohm=constraints.target_impedance_ohm,
+        impedance_tolerance_percent=constraints.impedance_tolerance_percent,
+        max_length_mm=constraints.max_length_mm,
+        max_skew_mm=constraints.max_skew_mm,
+        reference_plane_required=net.reference_plane_required,
+        reference_net=constraints.reference_net,
+        reference_candidates=applicable_references,
+        stub_sensitive=constraints.stub_sensitive,
+        shielding_preferred=constraints.shielding_preferred,
+        reasons=reasons,
+    )
+
+
+def _topology_strategy(
+    intent: PCBDesignIntent,
+    net_id: str,
+) -> ReturnStrategy | None:
+    match = next(
+        (item for item in intent.power_ground if item.net_id == net_id),
+        None,
+    )
+    return match.strategy if match is not None else None
+
+
+def _rail_current(physical: PCBPhysicalAnalysis, net_id: str) -> float | None:
+    match = next(
+        (item for item in physical.pdn_rails if item.net_id == net_id),
+        None,
+    )
+    return match.current_a if match is not None else None
+
+
+def _copper_strategy(
+    net: PCBNetIntent,
+    intent: PCBDesignIntent,
+    physical: PCBPhysicalAnalysis,
+) -> PCBCopperStrategy:
+    topology = _topology_strategy(intent, net.net_id)
+    current = _rail_current(physical, net.net_id)
+    strategy: CopperStrategy
+    if topology is not None:
+        strategy = topology
+    elif {"power", "high_current_power"}.intersection(net.roles):
+        strategy = "local_plane_or_pour_candidate"
+    else:
+        strategy = "trace"
+    requires_refill = strategy in {
+        "local_plane_or_pour_candidate",
+        "continuous_plane_preferred",
+        "chassis_or_shield",
+        "explicit_star",
+    }
+    reasons = ["Strategy preserves Generation A return/power topology intent."]
+    if current is None and {"power", "high_current_power"}.intersection(net.roles):
+        reasons.append(
+            "Rail current is unknown; strategy is a topology candidate, not a "
+            "current-capacity conclusion."
+        )
+    if requires_refill:
+        reasons.append(
+            "Any poured/plane result requires authoritative DipTrace refill and "
+            "geometry evidence before acceptance."
+        )
+    return PCBCopperStrategy(
+        net_id=net.net_id,
+        name=net.name,
+        strategy=strategy,
+        current_a=current,
+        requires_refill_evidence=requires_refill,
+        reasons=reasons,
+    )
+
+
+def compile_pcb_routing_policy(
+    snapshot: DocumentSnapshot,
+    *,
+    overrides: PCBIntentOverrides | None = None,
+    intent: PCBDesignIntent | None = None,
+    physical: PCBPhysicalAnalysis | None = None,
+) -> PCBRoutingPolicySet:
+    """Compile Generation C router policy without creating or mutating routes."""
+
+    _require_board(snapshot)
+    intent = intent or build_pcb_design_intent(snapshot, overrides)
+    physical = physical or analyze_pcb_physics(snapshot, intent=intent)
+    references = _reference_policies(physical)
+    policies = [_policy_for_net(net, references) for net in intent.nets]
+    route_order = [
+        item.net_id
+        for item in sorted(
+            policies,
+            key=lambda item: (-item.priority, item.net_id),
+        )
+    ]
+    return PCBRoutingPolicySet(
+        intent=intent,
+        physical=physical,
+        policies=sorted(policies, key=lambda item: item.net_id),
+        route_order=route_order,
+        copper_strategies=sorted(
+            [_copper_strategy(net, intent, physical) for net in intent.nets],
+            key=lambda item: item.net_id,
+        ),
+        assumptions=[
+            (
+                "Generation C policy is compiled from A/B evidence and does not "
+                "itself mutate traces, vias or pours."
+            ),
+            (
+                "Unknown trace width, spacing, impedance or timing facts remain "
+                "unknown unless supplied/exported."
+            ),
+            (
+                "Existing routing compiler and semantic transaction path remain "
+                "authoritative for actual edits."
+            ),
+        ],
+        warnings=sorted(set([*intent.warnings, *physical.warnings])),
+        limitations=[
+            (
+                "Route ordering is engineering priority, not proof of global "
+                "routing optimality."
+            ),
+            (
+                "Reference candidates are preliminary until board-specific "
+                "copper/refill and solver evidence exists."
+            ),
+            (
+                "Copper strategy is intent; native pour refill/island/thermal "
+                "behavior is not synthesized here."
+            ),
+        ],
+    )
+
+
+def _check(
+    key: str,
+    *,
+    actual: Any,
+    limit: Any,
+    failed: bool | None,
+    pass_reason: str,
+    fail_reason: str,
+    unknown_reason: str,
+) -> PCBSICheck:
+    if failed is None:
+        return PCBSICheck(
+            key=key,
+            status="unknown",
+            actual=actual,
+            limit=limit,
+            reason=unknown_reason,
+        )
+    return PCBSICheck(
+        key=key,
+        status="fail" if failed else "pass",
+        actual=actual,
+        limit=limit,
+        reason=fail_reason if failed else pass_reason,
+    )
+
+
+def evaluate_route_observation(
+    policy: PCBNetRoutingPolicy,
+    observation: PCBRouteObservation,
+    *,
+    component_ids: list[str] | None = None,
+) -> PCBRouteEvaluation:
+    """Evaluate supplied route observations; absence of observations stays unknown."""
+
+    if observation.net_id != policy.net_id:
+        raise ValueError("route observation net_id does not match routing policy")
+    checks: list[PCBSICheck] = []
+    checks.append(
+        _check(
+            "max_length",
+            actual=observation.length_mm,
+            limit=policy.max_length_mm,
+            failed=(
+                observation.length_mm > policy.max_length_mm
+                if observation.length_mm is not None
+                and policy.max_length_mm is not None
+                else None
+            ),
+            pass_reason="Observed route length is within the explicit maximum.",
+            fail_reason="Observed route length exceeds the explicit maximum.",
+            unknown_reason="Length or explicit maximum is unavailable.",
+        )
+    )
+    checks.append(
+        _check(
+            "via_budget",
+            actual=observation.via_count,
+            limit=policy.max_vias,
+            failed=(
+                observation.via_count > policy.max_vias
+                if observation.via_count is not None and policy.max_vias is not None
+                else None
+            ),
+            pass_reason="Observed via count is within the explicit budget.",
+            fail_reason="Observed via count exceeds the explicit budget.",
+            unknown_reason="Via count or explicit via budget is unavailable.",
+        )
+    )
+    forbidden_used = sorted(
+        set(observation.used_layers).intersection(policy.forbidden_layers)
+    )
+    checks.append(
+        PCBSICheck(
+            key="forbidden_layers",
+            status="fail" if forbidden_used else "pass",
+            actual=forbidden_used,
+            limit=policy.forbidden_layers,
+            reason=(
+                "Observed route uses a forbidden layer."
+                if forbidden_used
+                else "No observed used layer is explicitly forbidden."
+            ),
+        )
+    )
+    reference_failed: bool | None
+    if not policy.reference_plane_required:
+        reference_failed = False
+    elif observation.maintained_reference is None:
+        reference_failed = None
+    else:
+        reference_failed = not observation.maintained_reference
+    checks.append(
+        _check(
+            "reference_continuity",
+            actual=observation.maintained_reference,
+            limit=policy.reference_plane_required,
+            failed=reference_failed,
+            pass_reason=(
+                "Observed reference continuity satisfies the policy requirement."
+            ),
+            fail_reason="Observed route breaks the required continuous reference.",
+            unknown_reason=(
+                "Reference continuity was not observed for a reference-sensitive net."
+            ),
+        )
+    )
+    impedance_failed: bool | None = None
+    tolerance = policy.impedance_tolerance_percent
+    target = policy.target_impedance_ohm
+    if (
+        observation.impedance_ohm is not None
+        and target is not None
+        and tolerance is not None
+    ):
+        impedance_failed = (
+            abs(observation.impedance_ohm - target)
+            > target * tolerance / 100.0
+        )
+    checks.append(
+        _check(
+            "impedance",
+            actual=observation.impedance_ohm,
+            limit={"target_ohm": target, "tolerance_percent": tolerance},
+            failed=impedance_failed,
+            pass_reason="Observed impedance is inside the explicit tolerance.",
+            fail_reason="Observed impedance is outside the explicit tolerance.",
+            unknown_reason="Observed impedance, target or tolerance is unavailable.",
+        )
+    )
+    checks.append(
+        _check(
+            "skew",
+            actual=observation.skew_mm,
+            limit=policy.max_skew_mm,
+            failed=(
+                observation.skew_mm > policy.max_skew_mm
+                if observation.skew_mm is not None
+                and policy.max_skew_mm is not None
+                else None
+            ),
+            pass_reason="Observed skew is within the explicit maximum.",
+            fail_reason="Observed skew exceeds the explicit maximum.",
+            unknown_reason="Observed skew or explicit maximum is unavailable.",
+        )
+    )
+    stub_failed: bool | None
+    if not policy.stub_sensitive:
+        stub_failed = False
+    elif observation.stub_length_mm is None:
+        stub_failed = None
+    else:
+        stub_failed = observation.stub_length_mm > 0.0
+    checks.append(
+        _check(
+            "stub",
+            actual=observation.stub_length_mm,
+            limit=0.0 if policy.stub_sensitive else None,
+            failed=stub_failed,
+            pass_reason="No disallowed stub was observed.",
+            fail_reason="A stub was observed on a stub-sensitive net.",
+            unknown_reason=(
+                "Stub exposure was not observed for a stub-sensitive net."
+            ),
+        )
+    )
+    parallel_status: CheckStatus = (
+        "unknown" if observation.parallel_exposure_mm is None else "pass"
+    )
+    checks.append(
+        PCBSICheck(
+            key="parallel_exposure",
+            status=parallel_status,
+            actual=observation.parallel_exposure_mm,
+            limit=None,
+            reason=(
+                "Parallel exposure was measured; no universal numeric crosstalk "
+                "limit is invented."
+                if observation.parallel_exposure_mm is not None
+                else "Parallel route exposure was not observed."
+            ),
+        )
+    )
+    hard_failures = sum(item.status == "fail" for item in checks)
+    strong = any(
+        item.key in {"reference_continuity", "via_budget"}
+        and item.status == "fail"
+        for item in checks
+    )
+    consider = hard_failures > 0
+    feedback = PCBPlacementFeedback(
+        net_id=policy.net_id,
+        component_ids=sorted(set(component_ids or [])),
+        severity="strong" if strong else ("consider" if consider else "none"),
+        reasons=[item.reason for item in checks if item.status == "fail"],
+        action=(
+            "bounded_endpoint_move_candidate"
+            if consider and component_ids
+            else "none"
+        ),
+    )
+    observations_used = [
+        key
+        for key, value in {
+            "length_mm": observation.length_mm,
+            "via_count": observation.via_count,
+            "used_layers": observation.used_layers,
+            "maintained_reference": observation.maintained_reference,
+            "impedance_ohm": observation.impedance_ohm,
+            "skew_mm": observation.skew_mm,
+            "stub_length_mm": observation.stub_length_mm,
+            "parallel_exposure_mm": observation.parallel_exposure_mm,
+        }.items()
+        if value not in (None, [])
+    ]
+    return PCBRouteEvaluation(
+        net_id=policy.net_id,
+        checks=checks,
+        hard_failures=hard_failures,
+        placement_feedback=feedback,
+        observations_used=observations_used,
+        limitations=[
+            (
+                "The evaluator checks supplied observations; it does not infer "
+                "hidden trace geometry."
+            ),
+            (
+                "Crosstalk/parallel exposure has no invented universal pass/fail "
+                "threshold."
+            ),
+        ],
+    )

--- a/tests/test_pcb_routing_policy.py
+++ b/tests/test_pcb_routing_policy.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.pcb_design_intent import (
+    PCBElectricalConstraints,
+    PCBIntentOverrides,
+    PCBNetOverride,
+)
+from diptrace_mcp.pcb_routing_policy import (
+    PCBRouteObservation,
+    compile_pcb_routing_policy,
+    evaluate_route_observation,
+)
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _snapshot(name: str = "pcb.xml"):
+    return build_snapshot(DipTraceDocument.load(FIXTURES / name, 10_000_000))
+
+
+def _policy_by_name(result, name: str):
+    return next(item for item in result.policies if item.name == name)
+
+
+def test_generation_c_compiles_differential_constraints_and_reference_policy() -> None:
+    result = compile_pcb_routing_policy(_snapshot("diff_pair_pcb.xml"))
+
+    plus = _policy_by_name(result, "USB_D+")
+    minus = _policy_by_name(result, "USB_D-")
+    for policy in (plus, minus):
+        assert "differential" in policy.roles
+        assert policy.max_length_mm == pytest.approx(10.0)
+        assert policy.max_skew_mm == pytest.approx(0.25)
+        assert policy.reference_plane_required is True
+        assert policy.reference_candidates
+        assert all(item.preliminary_only for item in policy.reference_candidates)
+    assert result.route_order.index(plus.net_id) < len(result.route_order)
+    assert result.route_order.index(minus.net_id) < len(result.route_order)
+
+
+def test_generation_c_preserves_explicit_router_constraints_without_inventing_width() -> None:
+    overrides = PCBIntentOverrides(
+        nets=[
+            PCBNetOverride(
+                selector="SIGNAL",
+                roles=["clock"],
+                constraints=PCBElectricalConstraints(
+                    edge_rate_ns=1.0,
+                    target_impedance_ohm=50.0,
+                    impedance_tolerance_percent=10.0,
+                    max_length_mm=20.0,
+                    max_skew_mm=0.5,
+                    max_vias=2,
+                    preferred_layers=["Top"],
+                    forbidden_layers=["Bottom"],
+                    minimum_spacing_mm=0.25,
+                    stub_sensitive=True,
+                    shielding_preferred=True,
+                ),
+            )
+        ]
+    )
+
+    result = compile_pcb_routing_policy(_snapshot(), overrides=overrides)
+    policy = _policy_by_name(result, "SIGNAL")
+
+    assert policy.trace_width_mm is None
+    assert policy.minimum_spacing_mm == pytest.approx(0.25)
+    assert policy.preferred_layers == ["Top"]
+    assert policy.forbidden_layers == ["Bottom"]
+    assert policy.max_vias == 2
+    assert policy.target_impedance_ohm == pytest.approx(50.0)
+    assert policy.impedance_tolerance_percent == pytest.approx(10.0)
+    assert policy.max_length_mm == pytest.approx(20.0)
+    assert policy.stub_sensitive is True
+    assert policy.shielding_preferred is True
+
+
+def test_generation_c_route_order_is_deterministic_and_engineering_weighted() -> None:
+    overrides = PCBIntentOverrides(
+        nets=[
+            PCBNetOverride(
+                selector="SIGNAL",
+                roles=["clock"],
+                constraints=PCBElectricalConstraints(edge_rate_ns=1.0),
+            )
+        ]
+    )
+    first = compile_pcb_routing_policy(_snapshot(), overrides=overrides)
+    second = compile_pcb_routing_policy(_snapshot(), overrides=overrides)
+    signal = _policy_by_name(first, "SIGNAL")
+    vcc = _policy_by_name(first, "VCC")
+
+    assert first.route_order == second.route_order
+    assert signal.priority > vcc.priority
+    assert first.route_order.index(signal.net_id) < first.route_order.index(vcc.net_id)
+
+
+def test_generation_c_evaluates_observed_si_constraints_and_requests_feedback() -> None:
+    overrides = PCBIntentOverrides(
+        nets=[
+            PCBNetOverride(
+                selector="SIGNAL",
+                roles=["clock"],
+                constraints=PCBElectricalConstraints(
+                    edge_rate_ns=1.0,
+                    target_impedance_ohm=50.0,
+                    impedance_tolerance_percent=5.0,
+                    max_length_mm=10.0,
+                    max_skew_mm=0.1,
+                    max_vias=1,
+                    forbidden_layers=["Bottom"],
+                    stub_sensitive=True,
+                ),
+            )
+        ]
+    )
+    compiled = compile_pcb_routing_policy(_snapshot(), overrides=overrides)
+    policy = _policy_by_name(compiled, "SIGNAL")
+    component_ids = next(
+        net.component_ids for net in compiled.intent.nets if net.net_id == policy.net_id
+    )
+
+    evaluation = evaluate_route_observation(
+        policy,
+        PCBRouteObservation(
+            net_id=policy.net_id,
+            length_mm=12.0,
+            via_count=3,
+            used_layers=["Top", "Bottom"],
+            maintained_reference=False,
+            impedance_ohm=60.0,
+            skew_mm=0.2,
+            stub_length_mm=1.0,
+            parallel_exposure_mm=4.0,
+        ),
+        component_ids=component_ids,
+    )
+    checks = {item.key: item for item in evaluation.checks}
+
+    for key in (
+        "max_length",
+        "via_budget",
+        "forbidden_layers",
+        "reference_continuity",
+        "impedance",
+        "skew",
+        "stub",
+    ):
+        assert checks[key].status == "fail"
+    assert checks["parallel_exposure"].status == "pass"
+    assert evaluation.hard_failures == 7
+    assert evaluation.placement_feedback.severity == "strong"
+    assert evaluation.placement_feedback.action == "bounded_endpoint_move_candidate"
+    assert evaluation.placement_feedback.component_ids == sorted(component_ids)
+
+
+def test_generation_c_keeps_unobserved_or_unconstrained_checks_unknown() -> None:
+    compiled = compile_pcb_routing_policy(_snapshot())
+    policy = _policy_by_name(compiled, "SIGNAL")
+    evaluation = evaluate_route_observation(
+        policy,
+        PCBRouteObservation(net_id=policy.net_id),
+    )
+    checks = {item.key: item for item in evaluation.checks}
+
+    assert policy.trace_width_mm is None
+    assert checks["max_length"].status == "unknown"
+    assert checks["via_budget"].status == "unknown"
+    assert checks["impedance"].status == "unknown"
+    assert checks["parallel_exposure"].status == "unknown"
+    assert evaluation.placement_feedback.action == "none"
+
+
+def test_generation_c_copper_strategy_preserves_unknown_current_and_refill_boundary() -> None:
+    result = compile_pcb_routing_policy(_snapshot())
+    vcc = next(item for item in result.copper_strategies if item.name == "VCC")
+    signal = next(item for item in result.copper_strategies if item.name == "SIGNAL")
+
+    assert vcc.strategy == "local_plane_or_pour_candidate"
+    assert vcc.current_a is None
+    assert vcc.requires_refill_evidence is True
+    assert any("current is unknown" in item for item in vcc.reasons)
+    assert signal.strategy == "trace"
+    assert signal.requires_refill_evidence is False
+
+
+def test_generation_c_rejects_observation_for_wrong_net() -> None:
+    result = compile_pcb_routing_policy(_snapshot())
+    policy = _policy_by_name(result, "SIGNAL")
+
+    with pytest.raises(ValueError, match="net_id does not match"):
+        evaluate_route_observation(
+            policy,
+            PCBRouteObservation(net_id="wrong-net"),
+        )


### PR DESCRIPTION
Stacked on Generation B while PR #83 completes validation. Implements internal Generation C routing-policy compilation and observed-route SI checks: deterministic engineering route ordering, explicit constraint propagation, preliminary reference policy from Generation B, conservative copper strategy, route-observation validation, and bounded placement feedback. No public MCP tools are added; actual trace/via/pour mutation remains in the existing guarded routing/semantic path.