### PR TITLE
Finalize PCB Generation D joint optimization

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -20,7 +20,11 @@ This temporary development record avoids rewriting the immutable `0.2.1` release
 - internal PCB Generation C routing-policy compiler with deterministic engineering route order, explicit layer/via/length/skew/impedance/reference/stub/shield constraints and unknown-width preservation;
 - observed-route SI checks for length, via budget, forbidden layers, reference continuity, impedance, skew and stubs, with no invented universal crosstalk threshold;
 - conservative trace/local-copper/plane/pour strategy and bounded endpoint-placement feedback while native routing/pour edits remain on the existing guarded semantic path;
-- PCB Generation C regression coverage for constraint propagation, route ordering, SI failure/unknown behavior, copper evidence boundaries and wrong-net rejection.
+- PCB Generation C regression coverage for constraint propagation, route ordering, SI failure/unknown behavior, copper evidence boundaries and wrong-net rejection;
+- internal PCB Generation D whole-board candidate selector with lexicographically dominant safety/mechanical/connectivity/DRC/reference/manufacturing hard violations;
+- decomposed placement/routing/via/SI/PI/return-path/EMI-risk/thermal-risk/manufacturing soft scoring with deterministic tie-breaking and bounded candidate count;
+- Generation D engineering-trap benchmark catalog covering MCU/decoupling/crystal, regulators, mixed-signal ADC, current sense, high-speed differential, Ethernet/CAN, RF, high-current power and multilayer controlled-impedance cases;
+- PCB Generation D regression coverage for hard-rule dominance, deterministic ranking, plan-reference preservation, candidate bounds, non-finite score rejection and synthetic-vs-native acceptance boundaries.
 
 ## Documentation
 
@@ -29,8 +33,9 @@ This temporary development record avoids rewriting the immutable `0.2.1` release
 - documented the internal EDA architecture, PCB design-intent domain models and the split between low-level placement legalization and intent-aware placement v2;
 - documented Generation B stackup/reference, PDN, return-path, timing-gated noise and via-intelligence evidence boundaries;
 - documented Generation C routing-policy, observed-route SI, copper/refill and placement-feedback boundaries;
+- documented Generation D hard/soft optimization contract and benchmark acceptance boundary;
 - clarified that the private/manual Q1 Component Angle campaign is PASS while package-owned public evidence/trust promotion remains a separate reviewed contract.
 
-The Generation A-C work intentionally leaves the 159-tool public MCP surface unchanged. It is internal EDA capability until a separate, deliberate public API decision is made.
+The Generation A-D work intentionally leaves the 159-tool public MCP surface unchanged. It is internal EDA capability until a separate, deliberate public API decision is made.
 
 This file should be folded into the normal `CHANGELOG.md` when the next version is selected.

--- a/docs/PCB_DESIGN_ENGINE.md
+++ b/docs/PCB_DESIGN_ENGINE.md
@@ -32,7 +32,7 @@ physical context / stackup / PDN / return Generation B
 routing policy / SI / copper decisions    Generation C
         |
         v
-joint score and bounded repair             Generation D
+joint score and bounded repair            Generation D
         |
         v
 guarded semantic plan -> preview -> SHA-bound apply -> review
@@ -50,7 +50,7 @@ Generation A deliberately preserves unknown physics. Ordinary ground defaults to
 
 ## Generation B — PCB understands fields and current paths
 
-**Status: implemented internally on `pcb_physical.py`; PR #83 is the merge gate.**
+**Status: implemented, regression-tested and merged to `main` in PR #83.**
 
 `analyze_pcb_physics()` consumes Generation A intent plus existing normalized stackup, geometry, via and return-path evidence. It is non-mutating and provides:
 
@@ -65,7 +65,7 @@ Analytic impedance candidates stay `preliminary_only`; current density, voltage 
 
 ## Generation C — PCB routes intentionally
 
-**Status: implemented internally on `pcb_routing_policy.py`; PR #84 is the merge gate.**
+**Status: implemented, regression-tested and merged to `main` in PR #84.**
 
 Generation C translates A/B engineering evidence into deterministic routing policy while leaving actual trace/via/pour mutation in the existing routing compiler and guarded semantic transaction path.
 
@@ -114,11 +114,35 @@ Failed route observations can return bounded endpoint-placement feedback. Refere
 
 ## Generation D — whole-board optimization
 
-**Status: implementation in progress on a stacked branch.**
+**Status: implemented internally on `pcb_joint_optimizer.py`; PR #86 is the final merge gate.**
 
-Generation D combines placement, routing, SI, PI, return-path, EMI-risk, thermal and manufacturing metrics into one bounded multi-objective selector. Hard violations are lexicographically dominant and can never be traded for a better soft score. The complete score stays decomposed; there is no opaque "AI board quality" value.
+Generation D selects among bounded whole-board candidates without bypassing the existing guarded write path.
 
-Generation D also defines engineering-trap benchmark families followed by controlled real-DipTrace open/refill/DRC/save/reopen/re-export acceptance where native geometry matters.
+### Hard-rule dominance
+
+`PCBHardViolations` keeps safety, mechanical, connectivity, DRC, reference-path and manufacturing violations as separate integer dimensions. Candidate ranking is lexicographic across those dimensions before any soft metric is considered. A candidate that introduces a hard violation cannot win because it has shorter routing, fewer vias or a prettier placement score.
+
+### Decomposed soft score
+
+`PCBSoftScore` keeps placement, routing, via count, signal integrity, power integrity, return path, EMI risk, thermal risk and manufacturing cost separate. Their finite sum is only a deterministic tie-break between candidates with identical hard-violation vectors.
+
+The optimizer rejects non-finite soft metrics, duplicate candidate IDs, empty candidate sets and candidate counts above the configured bound. External routers, external solvers and operator candidates can participate only as candidate/evidence sources; they do not gain authority to apply edits.
+
+### Benchmark catalog
+
+`pcb_benchmark_catalog()` defines engineering-trap families for:
+
+- MCU + decoupling + crystal;
+- regulator/power;
+- ADC mixed signal;
+- precision current sense;
+- high-speed differential;
+- Ethernet/CAN/interface;
+- RF/antenna;
+- higher-current power distribution;
+- multilayer controlled-impedance routing.
+
+These catalog entries are explicitly `synthetic_regression_only`. Each retains `requires_real_diptrace_acceptance=True`; a synthetic PASS cannot be promoted into a claim about native copper refill, planes, via structures or DipTrace round-trip behavior.
 
 ## Testing and acceptance
 
@@ -127,6 +151,8 @@ Generation A automated coverage includes component/net role inference, functiona
 Generation B adds stackup provenance, unknown-current/source preservation, explicit current/converter facts, reference-sensitive return paths, timing-gated noise analysis, bounded via-role classification and invalid-radius rejection.
 
 Generation C adds deterministic route ordering, constraint propagation, preliminary reference policy, unknown-width preservation, observed SI failure/unknown behavior, bounded placement feedback, copper/refill evidence boundaries and wrong-net rejection.
+
+Generation D adds hard-rule dominance, deterministic ranking/tie-breaking, plan-reference preservation, bounded candidate counts, non-finite score rejection and benchmark acceptance-boundary tests.
 
 A real-DipTrace acceptance fixture remains required before claims about poured copper, plane behavior, via structures or native round-trip semantics are promoted beyond the existing evidence boundary.
 
@@ -143,4 +169,4 @@ The PCB design engine does **not** currently claim:
 - fabrication or assembly sign-off;
 - globally optimal placement/routing.
 
-Generations A-C provide deterministic intent, placement, physical-context and routing-policy foundations for the bounded whole-board optimizer.
+Generations A-D provide deterministic intent, placement, physical-context, routing-policy and bounded whole-board candidate-selection foundations. Applying any resulting semantic plan remains subject to the normal preview, SHA, policy, transaction and review boundaries.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ That commit includes the post-PR #65/#66 Ponytail pass (PR #68). Later developme
 
 The durable recovery record is [MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md](MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md), updated on 2026-08-10. Resume from that checkpoint instead of repeating already accepted gates.
 
-A new product-development track also starts at this checkpoint: **intelligent schematic and PCB design quality**. Formal lifecycle acceptance is paused while the project proves that it can make defensible EDA decisions rather than only safe XML edits. The schematic and PCB engines share the same internal generate -> score -> improve architecture. Schematic readability remains its own acceptance track; PCB Generation A now establishes the electrical-intent and placement foundation in parallel without expanding the public MCP surface.
+A new product-development track also starts at this checkpoint: **intelligent schematic and PCB design quality**. Formal lifecycle acceptance is paused while the project proves that it can make defensible EDA decisions rather than only safe XML edits. The schematic and PCB engines share the same internal generate -> score -> improve architecture. Schematic readability remains its own acceptance track. PCB Generations A-C are merged, while Generation D is implemented on PR #86 pending its final green merge gate; none of these generations expand the public MCP surface.
 
 ## Completed real-host / real-client acceptance
 
@@ -241,7 +241,7 @@ The detailed design document is [`PCB_DESIGN_ENGINE.md`](PCB_DESIGN_ENGINE.md). 
 
 #### Phase 32 — PCB design intent, net intelligence and electrical criticality
 
-**Status: implemented internally; acceptance requires green repository CI.**
+**Status: implemented, regression-tested and merged in PR #81.**
 
 Build a typed engineering graph above raw connectivity:
 
@@ -267,7 +267,7 @@ This prevents the unsafe shortcut "analog + digital => split ground" from becomi
 
 #### Phase 33 — intent-aware PCB placement v2
 
-**Status: implemented internally; acceptance requires green repository CI.**
+**Status: implemented, regression-tested and merged in PR #81.**
 
 Keep the existing `placement.py` as the low-level geometry/legalization authority and add a higher board-level placer that:
 
@@ -286,82 +286,47 @@ Generation A intentionally preserves side/rotation and uses proximity/noise prox
 
 #### Phase 34 — stackup, PDN, return-path and via intelligence
 
-**Status: planned.**
+**Status: implemented, regression-tested and merged in PR #83.**
 
-Add physical decision layers before serious routing:
-
-- stackup/reference-layer relationships and manufacturable controlled-impedance geometry;
-- distinct trust levels for analytic impedance estimates, manufacturer geometry and external field-solver evidence;
-- PDN graph per rail: source, loads, steady/transient current when known, bulk/local decoupling, distribution and voltage-drop/current bottlenecks;
-- decoupling and switching-regulator hot-loop geometry using pad/current paths rather than only component distance;
-- return-path analysis across continuous reference copper, plane gaps/splits and layer transitions;
-- power/ground stitching, signal-return vias and current-carrying via requirements;
-- via roles: signal, power, ground stitching, return transition, differential transition, thermal and justified via fence.
+The implemented `pcb_physical.py` layer provides exported-stackup/reference candidates, conservative PDN source/load/decoupling analysis, regulator hot-loop candidates, bounded return-path integration and semantic via-role classification. It preserves unknown current, current density, voltage drop and numeric via capacity instead of manufacturing values.
 
 The existing via span/geometry validator, impedance estimator and return-path analyzer remain lower-level inputs. Unknown authoritative pour/refill geometry stays explicit until verified.
 
 #### Phase 35 — noise compatibility, impedance and electrical placement refinement
 
-**Status: planned.**
+**Status: bounded implementation merged in PR #83.**
 
-Replace distance-only noise proxies with bounded aggressor/victim analysis using known edge/frequency, parallel exposure, layer/reference structure and separation. Refine placement scoring with:
-
-- decoupling loop area;
-- switching hot-loop/switch-node area;
-- analog/RF/clock separation;
-- impedance-compatible routing corridors;
-- reference-plane availability;
-- expected via transitions;
-- connector/interface flow;
-- thermal clustering/spreading heuristics;
-- high-current path geometry.
-
-The engine still reports risk indicators, not EMC/PI sign-off.
+Generation B adds timing-gated aggressor/victim analysis using explicit edge-rate/frequency evidence plus normalized geometry/reference context. It remains a risk triage layer rather than EMC/PI sign-off. Broader pad-level current-loop, field-solver and manufacturer-geometry refinement remains future evidence work.
 
 ### Generation C — PCB routes intentionally
 
 #### Phase 36 — routing policy compiler and route ordering
 
-**Status: planned.**
+**Status: implemented, regression-tested and merged in PR #84.**
 
-Compile net intent into concrete router policy rather than making the router guess: priority, width/clearance, preferred/forbidden layers, via budget/penalty, target impedance, pair/skew constraints, continuous-reference requirement, spacing, shielding and stub policy.
-
-Route topology-critical nets before ordinary control/indicator nets. Ordering derives from criticality and explicit constraints rather than XML order or a hard-coded protocol list.
+`pcb_routing_policy.py` compiles net intent into deterministic priority/order plus explicit spacing, preferred/forbidden layers, via budgets/penalties, impedance/tolerance, max length/skew, continuous-reference requirements, stub sensitivity and shielding preference. Missing width/timing/impedance facts remain unknown.
 
 #### Phase 37 — SI-aware routing, copper strategy and placement feedback
 
-**Status: planned.**
+**Status: bounded implementation merged in PR #84.**
 
-Extend candidate routing/review to include:
-
-- impedance continuity and differential symmetry/skew;
-- stub and excessive-via penalties;
-- parallel coupling/crosstalk exposure;
-- reference-plane continuity and return-via proximity across layer changes;
-- current-aware power routing;
-- trace vs local copper vs plane/pour planning;
-- ground stitching and local shielding where justified;
-- authoritative refill/island/cutout/thermal-relief handling only after DipTrace geometry/evidence is sufficient.
-
-Routing may produce bounded placement repairs: move/rotate a part, open a corridor, remove several vias or restore a valid reference path. The joint optimizer decides whether the repair wins globally.
+Generation C evaluates supplied route observations for length, via budget, forbidden layers, reference continuity, impedance, skew and stubs; reports parallel exposure without inventing a universal crosstalk threshold; preserves trace/local-copper/plane/pour topology intent; and emits bounded endpoint-placement feedback for pathological candidates. Native routing and poured-copper edits remain in the existing guarded semantic path.
 
 ### Generation D — optimize the whole board
 
 #### Phase 38 — joint multi-objective PCB optimizer
 
-**Status: planned.**
+**Status: implemented internally on PR #86; final green CI/merge is the acceptance gate.**
 
-Combine placement, routing, SI, PI, return-path, EMI-risk, thermal and manufacturing/assembly/test constraints into one bounded generate -> score -> improve loop.
+`pcb_joint_optimizer.py` provides bounded candidate selection with separate safety, mechanical, connectivity, DRC, reference-path and manufacturing hard dimensions. Those hard dimensions are lexicographically dominant over decomposed placement, routing, vias, SI, PI, return-path, EMI-risk, thermal-risk and manufacturing soft metrics.
 
-The complete score remains decomposed. Hard DRC/mechanical/safety violations are lexicographically dominant and cannot be traded away for lower wire length, prettier geometry or fewer vias.
-
-External routers/solvers remain candidate/evidence generators; they do not bypass MCP trust, transaction or review boundaries.
+External routers/solvers remain candidate/evidence generators; they do not bypass MCP trust, transaction or review boundaries. The optimizer selects candidates and preserves plan/evidence references but does not apply edits itself.
 
 #### Phase 39 — PCB benchmark and real-DipTrace product acceptance
 
-**Status: planned.**
+**Status: benchmark catalog implemented on PR #86; real-DipTrace product acceptance remains pending.**
 
-Create small engineering-trap benchmark families rather than one giant demo board:
+The Generation D catalog includes small engineering-trap families rather than one giant demo board:
 
 - MCU + decoupling + crystal;
 - LDO and buck/boost regulator;
@@ -373,9 +338,7 @@ Create small engineering-trap benchmark families rather than one giant demo boar
 - higher-current power distribution;
 - multilayer controlled-impedance examples.
 
-For each retain deliberately poor, acceptable/reference and generated candidates where provenance permits. Measure hard-rule non-regression plus electrical/routeability/SI/PI/EMI-risk/thermal/manufacturing score components.
-
-Real-DipTrace acceptance for affected primitives must use generate -> open -> refill where required -> DRC/review -> save -> reopen -> re-export -> compare. Claims about poured copper, plane behavior, via structures or native semantics may not be promoted from synthetic parser round-trips alone.
+Catalog entries are explicitly synthetic-regression-only and retain a real-DipTrace acceptance requirement. Real-DipTrace acceptance for affected primitives must use generate -> open -> refill where required -> DRC/review -> save -> reopen -> re-export -> compare. Claims about poured copper, plane behavior, via structures or native semantics may not be promoted from synthetic parser round-trips alone.
 
 ## Remaining formal lifecycle acceptance
 
@@ -414,7 +377,7 @@ These are not core blockers unless the corresponding claim is planned:
 
 ## Repository implementation status
 
-The previous repository-only roadmap is implementation-complete, but the schematic/PCB intelligence track intentionally creates new product-development work. Current implementation already provides the foundation:
+The previous repository-only roadmap is implementation-complete, but the schematic/PCB intelligence track intentionally creates new product-development work. Current implementation now includes:
 
 - PCB, schematic and library parsing/querying;
 - guarded semantic transactions, rollback, SHA/policy/backup/atomic-write boundaries;
@@ -427,10 +390,12 @@ The previous repository-only roadmap is implementation-complete, but the schemat
 - deterministic pattern-recommendation baseline;
 - bounded DFM/DFA/DFT release-readiness checks;
 - manual-acceptance evidence tooling;
-- internal PCB Generation A design-intent/net-intelligence model;
-- internal intent-aware PCB placement v2 layered over the existing legalizer.
+- PCB Generation A design-intent/net-intelligence and intent-aware placement v2;
+- PCB Generation B physical-context, PDN, return-path, timing-gated noise and via intelligence;
+- PCB Generation C routing-policy, observed-route SI, copper strategy and placement feedback;
+- PCB Generation D bounded whole-board candidate selector and engineering-trap benchmark catalog.
 
-The new work should reuse these layers rather than duplicating them. High-level optimizers produce typed plans/operations that still pass through the existing guarded transaction and review paths.
+The new work reuses the existing guarded transaction/review layers rather than duplicating them. High-level optimizers produce typed plans, candidate references or bounded feedback that still pass through the existing guarded application path.
 
 ## Native library mutation status
 
@@ -479,14 +444,14 @@ The optimizer roadmap does not implicitly add or remove public tools. New optimi
 | 29 | planned — schematic | human-readable interconnect routing with placement feedback |
 | 30 | planned — schematic | joint placement/interconnect optimizer |
 | 31 | planned — schematic | quality benchmark and real-DipTrace readability acceptance |
-| 32 | **implemented — PCB Generation A** | PCB design intent, net intelligence, criticality and conservative power/ground policy; CI gate required before acceptance |
-| 33 | **implemented — PCB Generation A** | intent-aware PCB placement v2 over existing legality/scoring; CI gate required before acceptance |
-| 34 | planned — PCB Generation B | stackup, PDN, return-path and via intelligence |
-| 35 | planned — PCB Generation B | noise compatibility, impedance/reference and placement refinement |
-| 36 | planned — PCB Generation C | routing-policy compiler and engineering-aware route ordering |
-| 37 | planned — PCB Generation C | SI-aware routing, copper/plane/pour strategy and placement feedback |
-| 38 | planned — PCB Generation D | joint multi-objective whole-board optimizer |
-| 39 | planned — PCB Generation D | engineering benchmark suite and real-DipTrace product acceptance |
+| 32 | complete — PCB Generation A | PCB design intent, net intelligence, criticality and conservative power/ground policy |
+| 33 | complete — PCB Generation A | intent-aware PCB placement v2 over existing legality/scoring |
+| 34 | complete — PCB Generation B | stackup/reference, PDN, return-path and via intelligence |
+| 35 | bounded complete — PCB Generation B | timing-gated noise compatibility and physical-context refinement |
+| 36 | complete — PCB Generation C | routing-policy compiler and engineering-aware route ordering |
+| 37 | bounded complete — PCB Generation C | observed SI checks, copper strategy and placement feedback |
+| 38 | implemented — PCB Generation D | bounded joint multi-objective candidate selection; PR #86 merge gate pending |
+| 39 | partial — PCB Generation D | engineering benchmark catalog implemented; real-DipTrace product acceptance pending |
 
 ## Permanent limitations and non-claims
 
@@ -495,6 +460,7 @@ The optimizer roadmap does not implicitly add or remove public tools. New optimi
 - Reference datasheet/reference-board motifs are guidance and provenance-bearing constraints, not proof that the generated design is manufacturer-approved.
 - The local router is bounded and is not a full push-and-shove/free-angle/global EDA router.
 - PCB Generation A intent/noise/thermal/current-return values are deterministic policy/proxies, not field, PI, thermal or EMC simulation results.
+- PCB Generations B-D preserve explicit evidence boundaries and do not turn analytic or synthetic results into field-solver, PI, thermal, EMC or native-DipTrace proof.
 - Copper-pour, return-path, impedance, thermal, DFM/DFA/DFT and manufacturing reviews retain approximation/skip boundaries.
 - Generic fabrication/assembly manifests are not native Gerber, NC Drill, ODB++, IPC-2581 or assembler sign-off packages.
 - The ngspice adapter runs user-provided netlists; it does not generate a complete simulation netlist from a DipTrace design.

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -232,6 +232,7 @@ src/diptrace_mcp/numeric_inputs.py
 src/diptrace_mcp/operations.py
 src/diptrace_mcp/pattern_recommendation.py
 src/diptrace_mcp/pcb_design_intent.py
+src/diptrace_mcp/pcb_joint_optimizer.py
 src/diptrace_mcp/pcb_physical.py
 src/diptrace_mcp/pcb_placement.py
 src/diptrace_mcp/pcb_routing_policy.py
@@ -377,6 +378,7 @@ tests/test_operation_schema.py
 tests/test_pattern_recommendation.py
 tests/test_pattern_validation.py
 tests/test_pcb_design_engine.py
+tests/test_pcb_joint_optimizer.py
 tests/test_pcb_physical.py
 tests/test_pcb_routing_policy.py
 tests/test_phase4.py

--- a/src/diptrace_mcp/pcb_joint_optimizer.py
+++ b/src/diptrace_mcp/pcb_joint_optimizer.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field
+
+from .domain import StrictModel
+
+
+class PCBHardViolations(StrictModel):
+    safety: int = Field(default=0, ge=0)
+    mechanical: int = Field(default=0, ge=0)
+    connectivity: int = Field(default=0, ge=0)
+    drc: int = Field(default=0, ge=0)
+    reference_path: int = Field(default=0, ge=0)
+    manufacturing: int = Field(default=0, ge=0)
+
+    def vector(self) -> tuple[int, int, int, int, int, int]:
+        return (
+            self.safety,
+            self.mechanical,
+            self.connectivity,
+            self.drc,
+            self.reference_path,
+            self.manufacturing,
+        )
+
+    def total(self) -> int:
+        return sum(self.vector())
+
+
+class PCBSoftScore(StrictModel):
+    placement: float = Field(default=0.0, ge=0.0)
+    routing: float = Field(default=0.0, ge=0.0)
+    vias: float = Field(default=0.0, ge=0.0)
+    signal_integrity: float = Field(default=0.0, ge=0.0)
+    power_integrity: float = Field(default=0.0, ge=0.0)
+    return_path: float = Field(default=0.0, ge=0.0)
+    emi_risk: float = Field(default=0.0, ge=0.0)
+    thermal_risk: float = Field(default=0.0, ge=0.0)
+    manufacturing: float = Field(default=0.0, ge=0.0)
+
+    def total(self) -> float:
+        return math.fsum(
+            (
+                self.placement,
+                self.routing,
+                self.vias,
+                self.signal_integrity,
+                self.power_integrity,
+                self.return_path,
+                self.emi_risk,
+                self.thermal_risk,
+                self.manufacturing,
+            )
+        )
+
+
+CandidateSource = Literal[
+    "internal",
+    "existing_board",
+    "local_router",
+    "external_router",
+    "external_solver",
+    "operator",
+]
+
+
+class PCBOptimizationCandidate(StrictModel):
+    candidate_id: str = Field(min_length=1, max_length=256)
+    source: CandidateSource = "internal"
+    hard: PCBHardViolations = Field(default_factory=PCBHardViolations)
+    soft: PCBSoftScore = Field(default_factory=PCBSoftScore)
+    plan_refs: list[str] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class PCBOptimizationResult(StrictModel):
+    selected: PCBOptimizationCandidate
+    ranking: list[str] = Field(default_factory=list)
+    candidate_count: int = Field(ge=1)
+    selection_key: list[float | int | str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+class PCBBenchmarkFamily(StrictModel):
+    family_id: str
+    description: str
+    trap_goals: list[str] = Field(default_factory=list)
+    acceptance: Literal["synthetic_regression_only"] = "synthetic_regression_only"
+    requires_real_diptrace_acceptance: bool = True
+
+
+_BENCHMARKS: tuple[PCBBenchmarkFamily, ...] = (
+    PCBBenchmarkFamily(
+        family_id="mcu_decoupling_crystal",
+        description="MCU with local decoupling and crystal/timing support",
+        trap_goals=[
+            "decoupling proximity",
+            "crystal loop compactness",
+            "reference continuity",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="regulator_power",
+        description="LDO and switching-regulator placement/routing",
+        trap_goals=[
+            "switch-node confinement",
+            "hot-loop compactness",
+            "power distribution",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="adc_mixed_signal",
+        description="ADC/sensor mixed analog and digital design",
+        trap_goals=[
+            "precision-net protection",
+            "continuous reference",
+            "aggressor separation",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="current_sense",
+        description="Current-shunt and precision-sense topology",
+        trap_goals=[
+            "Kelvin candidate preservation",
+            "high-current versus sense separation",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="high_speed_differential",
+        description="USB and other controlled high-speed differential links",
+        trap_goals=[
+            "pair symmetry",
+            "skew and via budget",
+            "reference continuity",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="ethernet_can_interface",
+        description="Ethernet/CAN/interface blocks and connectors",
+        trap_goals=[
+            "connector flow",
+            "critical-net ordering",
+            "return transitions",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="rf_antenna",
+        description="RF module, matching network and antenna region",
+        trap_goals=[
+            "RF path priority",
+            "matching-network compactness",
+            "keepout/reference discipline",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="high_current_power",
+        description="Higher-current power distribution",
+        trap_goals=[
+            "current-aware copper strategy",
+            "power-via capacity evidence boundary",
+        ],
+    ),
+    PCBBenchmarkFamily(
+        family_id="multilayer_controlled_impedance",
+        description="Multilayer controlled-impedance routing",
+        trap_goals=[
+            "stackup/reference selection",
+            "impedance evidence provenance",
+            "layer-transition return path",
+        ],
+    ),
+)
+
+
+def _validate_candidate(candidate: PCBOptimizationCandidate) -> None:
+    values = (
+        candidate.soft.placement,
+        candidate.soft.routing,
+        candidate.soft.vias,
+        candidate.soft.signal_integrity,
+        candidate.soft.power_integrity,
+        candidate.soft.return_path,
+        candidate.soft.emi_risk,
+        candidate.soft.thermal_risk,
+        candidate.soft.manufacturing,
+    )
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("candidate soft scores must be finite")
+
+
+def candidate_selection_key(
+    candidate: PCBOptimizationCandidate,
+) -> tuple[int, int, int, int, int, int, float, str]:
+    """Return a deterministic lexicographic key with hard violations dominant."""
+
+    _validate_candidate(candidate)
+    return (*candidate.hard.vector(), candidate.soft.total(), candidate.candidate_id)
+
+
+def select_pcb_candidate(
+    candidates: list[PCBOptimizationCandidate],
+    *,
+    max_candidates: int = 128,
+) -> PCBOptimizationResult:
+    """Select the best bounded whole-board candidate without applying any edit."""
+
+    if max_candidates < 1 or max_candidates > 10_000:
+        raise ValueError("max_candidates must be between 1 and 10000")
+    if not candidates:
+        raise ValueError("at least one PCB optimization candidate is required")
+    if len(candidates) > max_candidates:
+        raise ValueError("PCB optimization candidate count exceeds the bounded limit")
+    ids = [item.candidate_id for item in candidates]
+    if len(set(ids)) != len(ids):
+        raise ValueError("PCB optimization candidate_id values must be unique")
+    ranked = sorted(candidates, key=candidate_selection_key)
+    selected = ranked[0]
+    key = candidate_selection_key(selected)
+    return PCBOptimizationResult(
+        selected=selected,
+        ranking=[item.candidate_id for item in ranked],
+        candidate_count=len(ranked),
+        selection_key=[*key[:-1], key[-1]],
+        assumptions=[
+            "Hard safety/mechanical/connectivity/DRC/reference/manufacturing violations are lexicographically dominant over every soft metric.",
+            "Soft score remains decomposed; the total is only a deterministic tie-break among candidates with identical hard-violation vectors.",
+            "External routers and solvers are candidate/evidence sources only and cannot bypass the normal preview, SHA, policy, transaction or review path.",
+        ],
+        limitations=[
+            "Selection compares supplied candidate metrics; it does not manufacture missing SI/PI/thermal/EMC evidence.",
+            "The optimizer returns a candidate and plan references only; applying semantic operations remains an application-layer responsibility.",
+            "A synthetic benchmark PASS is not real DipTrace copper-refill, plane, via-structure or native round-trip acceptance.",
+        ],
+    )
+
+
+def pcb_benchmark_catalog() -> list[PCBBenchmarkFamily]:
+    """Return the deterministic Generation D engineering-trap benchmark catalog."""
+
+    return [item.model_copy(deep=True) for item in _BENCHMARKS]

--- a/src/diptrace_mcp/pcb_joint_optimizer.py
+++ b/src/diptrace_mcp/pcb_joint_optimizer.py
@@ -228,14 +228,32 @@ def select_pcb_candidate(
         candidate_count=len(ranked),
         selection_key=[*key[:-1], key[-1]],
         assumptions=[
-            "Hard safety/mechanical/connectivity/DRC/reference/manufacturing violations are lexicographically dominant over every soft metric.",
-            "Soft score remains decomposed; the total is only a deterministic tie-break among candidates with identical hard-violation vectors.",
-            "External routers and solvers are candidate/evidence sources only and cannot bypass the normal preview, SHA, policy, transaction or review path.",
+            (
+                "Hard safety/mechanical/connectivity/DRC/reference/manufacturing "
+                "violations are lexicographically dominant over every soft metric."
+            ),
+            (
+                "Soft score remains decomposed; the total is only a deterministic "
+                "tie-break among candidates with identical hard-violation vectors."
+            ),
+            (
+                "External routers and solvers are candidate/evidence sources only and "
+                "cannot bypass the normal preview, SHA, policy, transaction or review path."
+            ),
         ],
         limitations=[
-            "Selection compares supplied candidate metrics; it does not manufacture missing SI/PI/thermal/EMC evidence.",
-            "The optimizer returns a candidate and plan references only; applying semantic operations remains an application-layer responsibility.",
-            "A synthetic benchmark PASS is not real DipTrace copper-refill, plane, via-structure or native round-trip acceptance.",
+            (
+                "Selection compares supplied candidate metrics; it does not manufacture "
+                "missing SI/PI/thermal/EMC evidence."
+            ),
+            (
+                "The optimizer returns a candidate and plan references only; applying "
+                "semantic operations remains an application-layer responsibility."
+            ),
+            (
+                "A synthetic benchmark PASS is not real DipTrace copper-refill, plane, "
+                "via-structure or native round-trip acceptance."
+            ),
         ],
     )
 

--- a/tests/test_pcb_joint_optimizer.py
+++ b/tests/test_pcb_joint_optimizer.py
@@ -134,7 +134,7 @@ def test_generation_d_rejects_nonfinite_soft_scores() -> None:
         select_pcb_candidate([candidate])
 
 
-def test_generation_d_benchmark_catalog_covers_engineering_traps_without_claiming_native_acceptance() -> None:
+def test_generation_d_benchmark_catalog_has_engineering_traps() -> None:
     catalog = pcb_benchmark_catalog()
     ids = {item.family_id for item in catalog}
 

--- a/tests/test_pcb_joint_optimizer.py
+++ b/tests/test_pcb_joint_optimizer.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from diptrace_mcp.pcb_joint_optimizer import (
+    PCBHardViolations,
+    PCBOptimizationCandidate,
+    PCBSoftScore,
+    candidate_selection_key,
+    pcb_benchmark_catalog,
+    select_pcb_candidate,
+)
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    hard: PCBHardViolations | None = None,
+    soft: PCBSoftScore | None = None,
+    plan_refs: list[str] | None = None,
+) -> PCBOptimizationCandidate:
+    return PCBOptimizationCandidate(
+        candidate_id=candidate_id,
+        hard=hard or PCBHardViolations(),
+        soft=soft or PCBSoftScore(),
+        plan_refs=plan_refs or [],
+    )
+
+
+def test_generation_d_zero_hard_violations_beat_any_soft_score() -> None:
+    clean_but_expensive = _candidate(
+        "clean",
+        soft=PCBSoftScore(
+            placement=1000.0,
+            routing=1000.0,
+            signal_integrity=1000.0,
+            power_integrity=1000.0,
+        ),
+    )
+    pretty_but_drc_broken = _candidate(
+        "broken",
+        hard=PCBHardViolations(drc=1),
+        soft=PCBSoftScore(placement=0.0, routing=0.0),
+    )
+
+    result = select_pcb_candidate([pretty_but_drc_broken, clean_but_expensive])
+
+    assert result.selected.candidate_id == "clean"
+    assert result.ranking[0] == "clean"
+    assert result.selected.hard.total() == 0
+
+
+def test_generation_d_hard_violation_categories_are_lexicographically_dominant() -> None:
+    mechanical = _candidate(
+        "mechanical",
+        hard=PCBHardViolations(mechanical=1),
+    )
+    safety = _candidate(
+        "safety",
+        hard=PCBHardViolations(safety=1),
+    )
+
+    result = select_pcb_candidate([safety, mechanical])
+
+    assert result.selected.candidate_id == "mechanical"
+    assert candidate_selection_key(mechanical) < candidate_selection_key(safety)
+
+
+def test_generation_d_soft_score_is_decomposed_and_breaks_equal_hard_ties() -> None:
+    better = _candidate(
+        "better",
+        soft=PCBSoftScore(
+            placement=1.0,
+            routing=2.0,
+            vias=3.0,
+            signal_integrity=4.0,
+            power_integrity=5.0,
+            return_path=6.0,
+            emi_risk=7.0,
+            thermal_risk=8.0,
+            manufacturing=9.0,
+        ),
+    )
+    worse = _candidate(
+        "worse",
+        soft=PCBSoftScore(routing=100.0),
+    )
+
+    assert better.soft.total() == pytest.approx(45.0)
+    result = select_pcb_candidate([worse, better])
+    assert result.selected.candidate_id == "better"
+
+
+def test_generation_d_tie_break_is_deterministic_by_candidate_id() -> None:
+    result = select_pcb_candidate([_candidate("zeta"), _candidate("alpha")])
+
+    assert result.ranking == ["alpha", "zeta"]
+    assert result.selected.candidate_id == "alpha"
+
+
+def test_generation_d_preserves_plan_references_without_applying_them() -> None:
+    candidate = _candidate(
+        "plan",
+        plan_refs=["placement-plan:abc", "routing-plan:def"],
+    )
+
+    result = select_pcb_candidate([candidate])
+
+    assert result.selected.plan_refs == ["placement-plan:abc", "routing-plan:def"]
+    assert any("application-layer responsibility" in item for item in result.limitations)
+
+
+def test_generation_d_bounds_candidate_count_and_requires_unique_ids() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        select_pcb_candidate([])
+    with pytest.raises(ValueError, match="bounded limit"):
+        select_pcb_candidate([_candidate("a"), _candidate("b")], max_candidates=1)
+    with pytest.raises(ValueError, match="must be unique"):
+        select_pcb_candidate([_candidate("same"), _candidate("same")])
+    for value in (0, 10_001):
+        with pytest.raises(ValueError, match="between 1 and 10000"):
+            select_pcb_candidate([_candidate("a")], max_candidates=value)
+
+
+def test_generation_d_rejects_nonfinite_soft_scores() -> None:
+    candidate = _candidate(
+        "nonfinite",
+        soft=PCBSoftScore(routing=math.inf),
+    )
+
+    with pytest.raises(ValueError, match="must be finite"):
+        select_pcb_candidate([candidate])
+
+
+def test_generation_d_benchmark_catalog_covers_engineering_traps_without_claiming_native_acceptance() -> None:
+    catalog = pcb_benchmark_catalog()
+    ids = {item.family_id for item in catalog}
+
+    assert {
+        "mcu_decoupling_crystal",
+        "regulator_power",
+        "adc_mixed_signal",
+        "current_sense",
+        "high_speed_differential",
+        "ethernet_can_interface",
+        "rf_antenna",
+        "high_current_power",
+        "multilayer_controlled_impedance",
+    }.issubset(ids)
+    assert all(item.acceptance == "synthetic_regression_only" for item in catalog)
+    assert all(item.requires_real_diptrace_acceptance for item in catalog)

--- a/tests/test_pcb_joint_optimizer.py
+++ b/tests/test_pcb_joint_optimizer.py
@@ -125,10 +125,8 @@ def test_generation_d_bounds_candidate_count_and_requires_unique_ids() -> None:
 
 
 def test_generation_d_rejects_nonfinite_soft_scores() -> None:
-    candidate = _candidate(
-        "nonfinite",
-        soft=PCBSoftScore(routing=math.inf),
-    )
+    soft = PCBSoftScore.model_construct(routing=math.inf)
+    candidate = _candidate("nonfinite", soft=soft)
 
     with pytest.raises(ValueError, match="must be finite"):
         select_pcb_candidate([candidate])


### PR DESCRIPTION
Clean Generation D branch based on merged Generation C. Adds bounded whole-board candidate selection with lexicographically dominant hard-rule dimensions, decomposed soft scoring, deterministic ranking, bounded candidate validation, and an engineering-trap benchmark catalog. Release allowlist, tests, PCB design-engine documentation and roadmap are updated. The public MCP tools/list contract remains unchanged at 159 tools. Final CI #763, PyPI validation #239 and Windows installer #398 are all green.