### PR TITLE
Close schematic quality campaign in documentation

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -13,7 +13,9 @@ This development record tracks changes merged after the immutable `v0.2.1` relea
 - pin-aware joint placement/routing scoring for hypothetical candidates;
 - bounded non-mutating placement repair driven by route feedback and re-scored by the joint optimizer;
 - **atomic selective schematic reroute planner** that identifies only explicit sheet-local nets touched by moved parts, fails closed on unresolved endpoints/routes, and emits one dependency-safe `delete_wire -> move_components -> add_wire` semantic batch for the existing guarded transaction path;
-- deterministic schematic ensemble ranking that combines builtin-but-explicitly-labelled readability motifs, pin-aware route quality and bounded placement-grid congestion pressure.
+- deterministic schematic ensemble ranking that combines builtin-but-explicitly-labelled readability motifs, pin-aware route quality and bounded placement-grid congestion pressure;
+- fail-closed validation for stale/geometrically inconsistent Wire segment references while preserving valid middle-of-segment joins;
+- real-DipTrace schematic authoring/readability campaign coverage for cases 01–18, including incremental editing, failed-operation safety, single- and multi-net atomic reroute, obstacle/readability repair and a repaired 22-part stress schematic.
 
 ### PCB Generations A-D
 
@@ -69,6 +71,7 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 
 - The public MCP contract remains frozen at 159 tools despite the new internal EDA layers and prepared package-level library mutation request API.
 - Existing-wired schematics no longer represent a fundamental placement dead-end: affected explicit wire geometry can now be selectively replanned as one atomic semantic transaction batch. The older conservative placement planners may still refuse existing wires when used directly.
+- The initial real-DipTrace schematic quality campaign is complete: cases 01–18 closed with retained failed/invalid attempts, targeted fixes, operator visual review and native Save/Close/Reopen/re-export evidence. PR #90 merged the bounded fixes into `main`.
 - PCB Generation D can now compare multiple internally generated bounded placement candidates rather than only caller-supplied synthetic examples.
 - DSN/SES results can be structurally and semantically screened before import without mutating the PCB.
 - Real-DipTrace capture candidates can be converted into reproducible machine-readable and Markdown evidence reports without rewriting historical evidence or manufacturing trust.
@@ -82,10 +85,11 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 
 - atomic selective schematic reroute currently rebuilds affected sheet-local explicit nets from resolved pin endpoints; it does not preserve arbitrary pre-existing manual junction topology as a visual constraint;
 - stronger sheet-level/global schematic congestion scheduling and external/reference motif ingestion remain future work;
-- real-DipTrace product-quality acceptance for the new higher-level schematic ensemble and PCB candidate ensemble remains claim-specific manual evidence, not inferred from unit tests;
+- the completed 18-case schematic campaign supports its tested scope only; new schematic claims such as hierarchy, topology-preserving reroute or automatic rotation/pin-facing behavior still require claim-specific evidence;
+- PCB candidate/whole-board quality remains subject to current-candidate real-DipTrace/native refill/plane/via acceptance where stronger claims are desired;
 - cinematic UI macros and calibration still require real-client verification for the exact DipTrace version/editor configuration;
 - staged cinematic playback of vias/layer transitions remains unsupported;
-- Windows lifecycle gates remain pending after the current manual-acceptance pause;
+- Windows lifecycle gates remain pending; the next project-required formal gate is `windows_clean_install_repair_uninstall`;
 - the library mutation request/preview contract remains package-level and unregistered in the public MCP tool snapshot;
 - native manufacturing generation, field-solver/PI/EMC/thermal sign-off, universal compatibility, signed-binary trust, independent review and production readiness are not claimed.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ development prerelease and `diptrace-mcp==0.2.1` on PyPI were published on
 Development has continued on `main` after that immutable release. Current
 post-release work includes the schematic layout/placement-routing foundation,
 PCB Generations A-D, the 90% combined supported-environment coverage gate, and
-cinematic UI calibration/replay. Those later `main` features are not
-retroactively part of the published `v0.2.1` bytes.
+cinematic UI calibration/replay. The initial 18-case real-DipTrace schematic
+authoring/readability campaign is complete and its bounded fixes were merged by
+PR #90. Those later `main` features are not retroactively part of the published
+`v0.2.1` bytes.
 
 The previous [`v0.2.0`](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.2.0)
 and current `v0.2.1` release identities remain immutable. Existing tags and
@@ -88,8 +90,19 @@ Internal EDA development deliberately does not expand that public tool surface
 one heuristic at a time. The current schematic stack includes design intent and
 reference motifs, hierarchical and bounded multi-candidate placement,
 conservative pin-geometry resolution, non-mutating wire planning, pin-aware
-joint placement/routing scoring, and bounded placement repair. Selective atomic
-replacement of affected existing wires remains future work.
+joint placement/routing scoring, bounded placement repair, and selective atomic
+replacement of affected existing wire geometry. `schematic_atomic_reroute.py`
+rebuilds only affected explicit sheet-local nets as one dependency-safe
+`delete_wire -> move_components -> add_wire` semantic batch while preserving
+unaffected explicit geometry and the existing guarded transaction boundary.
+
+The initial 18-case real-DipTrace schematic authoring/readability campaign is
+complete. The final repaired stress schematic contained 22 parts, 48 pins,
+16 nets, and 32 wires; it was operator-accepted and survived real DipTrace
+Save/Close/Reopen/re-export with all 12 required schematic semantic categories
+preserved. This is exact-scope product evidence, not a claim of globally optimal
+layout, arbitrary hierarchy/topology support, or universal DipTrace compatibility.
+Future schematic host retests are impact-based or tied to genuinely new claims.
 
 The PCB design engine is implemented through four internal bounded generations:
 
@@ -252,7 +265,9 @@ PCB Layout 5.3.0.3. Package-owned public evidence/trust promotion remains a
 separate reviewed contract, and the immutable `v0.2.1` release record correctly
 retains its earlier `NOT_RUN` release-time status. Real Codex restart is PASS;
 Claude Desktop restart is WAIVED for the current project campaign, not PASS.
-Windows lifecycle gates remain pending when formal acceptance resumes.
+The initial 18-case schematic product-quality campaign is PASS for its recorded
+scope. Windows lifecycle gates remain pending; the next project-required formal
+gate is `windows_clean_install_repair_uninstall`.
 
 ## Data Handling
 
@@ -285,7 +300,10 @@ See [Testing](docs/TESTING.md) and [Development](docs/DEVELOPMENT.md).
 - [Usage](docs/USAGE.md)
 - [MCP tools and resources](docs/MCP_TOOLS.md)
 - [Architecture](docs/ARCHITECTURE.md)
+- [EDA intelligence map](docs/EDA_INTELLIGENCE.md)
 - [Schematic layout engine](docs/SCHEMATIC_LAYOUT_ENGINE.md)
+- [Schematic authoring validation campaign](docs/SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md)
+- [Manual acceptance checkpoint](docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md)
 - [PCB design engine and A-D roadmap](docs/PCB_DESIGN_ENGINE.md)
 - [Cinematic demo mode](docs/CINEMATIC_DEMO_MODE.md)
 - [Placement engine](docs/PLACEMENT_ENGINE.md)

--- a/docs/AUTOMATABLE_ROADMAP_CLOSURE.md
+++ b/docs/AUTOMATABLE_ROADMAP_CLOSURE.md
@@ -18,7 +18,8 @@ Subsequent work on `main` went further:
 
 - the internal library mutation core gained controlled real Component Editor / Pattern Editor round-trip evidence;
 - aggregate supported-environment coverage reached an enforced 90% gate;
-- the schematic layout track gained bounded placement/wire/joint-scoring/repair foundations;
+- the schematic layout track gained bounded placement, routing, joint scoring/repair and selective atomic reroute foundations;
+- the initial 18-case real-DipTrace schematic authoring/readability campaign completed, including incremental edits, transaction-failure safety, single- and multi-net atomic reroute, obstacle/readability repair, native round-trip reuse and a repaired 22-part stress schematic;
 - PCB Generations A-D were implemented as internal engineering-intelligence layers;
 - cinematic DipTrace UI calibration/replay/recording was merged as a separate presentation subsystem.
 
@@ -30,13 +31,13 @@ The original architectural constraints still apply:
 - synthetic fixture packs never become DipTrace export/open-save/round-trip evidence merely because they parse or inverse-round-trip;
 - internal Component/Pattern mutation remains below the public native-library write-tool boundary until a deliberate API decision;
 - manufacturing, assembly, thermal, EMC/PI, legal and other external conclusions remain explicitly scoped;
-- real-host/client PASS results stay bound to the exact candidate on which they were collected;
+- real-host/client PASS results stay bound to the exact candidate and tested path on which they were collected;
 - cinematic UI replay is presentation automation and not an alternate semantic write authority.
 
 ## Current interpretation
 
 The statement “no unresolved repository-only blocker” applied to the closure campaign that produced the manual acceptance matrix. It should not be read as “there is no more repository product work.”
 
-Current active development includes schematic product-quality work and later PCB/cinematic acceptance described in `ROADMAP.md`, `SCHEMATIC_LAYOUT_ENGINE.md`, `PCB_DESIGN_ENGINE.md` and `CINEMATIC_DEMO_MODE.md`.
+The first schematic product-quality campaign is now closed. Its detailed evidence remains in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`; PR #90 merged the bounded fixes into `main`. Future schematic retests are impact-based rather than a restart of cases 01–18.
 
-Formal manual lifecycle acceptance remains paused at the current project checkpoint. Claude Desktop restart is WAIVED, not PASS; Windows clean install/repair/uninstall is the next project-required formal gate when acceptance resumes.
+Current unresolved product work is described in `ROADMAP.md`, `PCB_DESIGN_ENGINE.md`, `CINEMATIC_DEMO_MODE.md` and the remaining formal lifecycle gates. The next project-required formal acceptance gate is `windows_clean_install_repair_uninstall`; Claude Desktop restart remains WAIVED, not PASS.

--- a/docs/EDA_INTELLIGENCE.md
+++ b/docs/EDA_INTELLIGENCE.md
@@ -41,6 +41,14 @@ The schematic ensemble adds a bounded congestion estimate using placement-grid o
 
 External/project/datasheet motifs can still be supplied explicitly with provenance. Automatic external motif ingestion remains separate work.
 
+### Real-DipTrace schematic quality checkpoint
+
+The initial product-quality campaign in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md` is complete. Cases 01–18 exercised real DipTrace authoring/readability, incremental edits, transaction safety, single- and multi-net atomic reroute, obstacle/readability repair, native Save/Close/Reopen/re-export and a repaired 22-part stress schematic.
+
+The final repaired stress case was operator-accepted and all 12 required schematic semantic categories survived native round-trip. PR #90 merged the bounded production fixes while preserving the frozen 159-tool public contract. This is evidence for the tested campaign scope, not a universal DipTrace-layout or global-optimality claim.
+
+Future schematic real-host work is impact-based: rerun only cases plausibly affected by later production changes, or add new cases for genuinely new claims such as hierarchy, external motif ingestion, topology preservation or automatic symbol rotation.
+
 ## PCB Generations A-D
 
 The current layers are:
@@ -108,10 +116,10 @@ Repository CI remains authoritative. The supported-environment combined coverage
 
 ## What still needs real hardware/software/operator evidence
 
-Unit/property tests do not replace:
+The completed 18-case schematic campaign should not be repeated without an impact-based reason. Remaining manual/native evidence is claim-specific and currently includes:
 
-- current-candidate real DipTrace schematic readability/product-quality acceptance;
 - current-candidate PCB whole-board/native refill/plane/via quality acceptance where claimed;
 - exact UI-profile cinematic replay validation;
 - Windows clean install/repair/uninstall and profile/custom-state preservation gates;
+- new schematic claims outside the completed campaign scope, such as hierarchy, topology-preserving reroute or automatic rotation/pin-facing behavior;
 - manufacturing output, independent review, regulatory, EMC, PI, thermal or field-solver sign-off.

--- a/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
+++ b/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
@@ -1,16 +1,35 @@
-# Manual Acceptance Checkpoint — 2026-08-09, updated 2026-08-10
+# Manual Acceptance Checkpoint — 2026-08-09, updated 2026-08-13
 
-This file is the durable recovery checkpoint for the current real-system acceptance campaign.
+This file is the durable recovery checkpoint for the real-system acceptance campaign.
 Its purpose is to prevent already completed manual gates from being repeated after an interrupted
-Work session, a focused repair, or later documentation-only commits.
+session, a focused repair, a product-quality sub-campaign, or later documentation-only commits.
 
 The evidence archives themselves remain authoritative for individual observations. This document
-records the accepted production candidate, completed gates, the intentional pause point, and the
-next validation priority.
+records the historical formal-acceptance identity, completed gates, the completed schematic-quality
+detour, and the next project-required validation sequence.
 
-## Accepted production candidate
+## Current post-merge project checkpoint
 
-The production-code candidate accepted through the latest completed gates is:
+PR #90 (`Complete schematic authoring quality validation`) is merged. Its production merge identity is:
+
+`main@6bfb656008e27f07e665a9b63540d6dc4a5174b6`
+
+That merge closes the initial 18-case real-DipTrace schematic authoring/readability campaign described
+in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`. The final repaired stress design contains 22 parts,
+48 pins, 16 nets and 32 wires; it was operator-accepted and survived real DipTrace Save/Close/Reopen/
+re-export with all 12 required schematic semantic categories preserved.
+
+PR #90 was green before merge, including DCO, Ruff/Mypy/static generated checks, Linux/macOS/Windows
+tests, geometry/fallback coverage, bridge build/smoke and the frozen 159-tool public MCP contract.
+The bounded fixes found during the campaign were merged without adding a public MCP tool.
+
+Documentation-only commits after `6bfb656...` do not change that production-code identity. Future
+schematic reruns are impact-based or tied to new claims; cases 01–18 are not a standing regression
+ritual that must be repeated in full.
+
+## Historical formal accepted production candidate
+
+The production-code candidate accepted through the eight historical canonical manual PASS gates is:
 
 `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba`
 
@@ -18,9 +37,9 @@ This is the merge of PR #68 (`Ponytail: aggressive repository cleanup`). The acc
 confirmed no relevant production-code drift through the COMMON, Q1 Component Angle, and Codex
 restart gates.
 
-Later repository development does not retroactively move those evidence identities. When resuming
-acceptance or starting a new product-quality validation, explicitly record the actual production
-candidate being tested rather than transferring PASS results to newer code by inference.
+Later repository development does not retroactively move those evidence identities. The schematic
+quality campaign is separate later evidence and does not rewrite the identity of the older formal
+gates.
 
 ## Formal acceptance progress
 
@@ -36,11 +55,11 @@ Eight of the twelve canonical blocking manual gates are PASS.
 | `diptrace_mask_paste_courtyard_common_semantics` | **PASS** | MASK, PASTE, COURTYARD and COMMON all accepted. |
 | `diptrace_q1_component_angle` | **PASS** | Real DipTrace PCB Layout 5.3.0.3 angle/side semantics accepted on `0bb09b4...`. |
 | `codex_real_client_restart` | **PASS** | Real Codex Desktop restart/configuration/`get_capabilities` accepted on `0bb09b4...`. |
-| `claude_desktop_real_client_restart` | **WAIVED for current project campaign** | Not run and not PASS. The project accepts the residual interoperability risk after successful real Codex stdio MCP restart evidence and will not spend current validation time duplicating this client-specific check. |
+| `claude_desktop_real_client_restart` | **WAIVED for current project campaign** | Not run and not PASS. The project accepts the residual interoperability risk after successful real Codex stdio MCP restart evidence and does not currently duplicate this client-specific check. |
 
 The remaining project-required formal lifecycle gates are:
 
-1. `windows_clean_install_repair_uninstall` — **PENDING**.
+1. `windows_clean_install_repair_uninstall` — **PENDING / NEXT**.
 2. `elevated_plugin_install_profile_preservation` — **PENDING**.
 3. `custom_state_preservation` — **PENDING**.
 
@@ -135,8 +154,7 @@ Codex evidence ZIP SHA256:
 
 Rationale: the real Codex client demonstrated the current server's stdio MCP startup, tool exposure,
 restart lifecycle and stable `get_capabilities` behavior. The project chooses not to spend current
-manual-validation time duplicating that lifecycle check in Claude Desktop before core schematic
-quality is proven.
+manual-validation time duplicating that lifecycle check in Claude Desktop.
 
 This is a risk acceptance, not evidence. Specifically:
 
@@ -145,66 +163,62 @@ This is a risk acceptance, not evidence. Specifically:
 - the gate must not be recorded as PASS;
 - claims of direct Claude Desktop validation remain unsupported unless the gate is run later.
 
-## Intentional pause before the remaining formal lifecycle gates
+## Schematic authoring/readability campaign — COMPLETE
 
-The formal lifecycle campaign is intentionally **PAUSED** while the project validates core schematic
-authoring/readability. When lifecycle acceptance resumes, the next project-required gate is:
+The schematic-quality detour that previously paused the remaining lifecycle gates is complete.
+Detailed per-case evidence, retained failures and hashes remain in
+`SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`.
+
+Campaign coverage included:
+
+- small authored circuits and label/marking readability;
+- RC/reference-style placement and routing;
+- single-net and multi-net atomic reroute;
+- near-obstacle and pre-existing ugly-geometry repair;
+- incremental edits across multiple commits;
+- failed-operation/transaction safety and actionable diagnostics;
+- representative native Save/Close/Reopen/re-export;
+- a larger 22-part / 48-pin / 16-net / 32-wire stress schematic.
+
+The campaign intentionally retained QUALITY FAIL, SEMANTIC FAIL and INVALID ATTEMPT evidence where
+appropriate. Fixes were focused, affected tests and adjacent smoke checks were added, and historical
+PASS cases were not reset without impact-based cause.
+
+The final repaired stress candidate was visually accepted, electrically correct, and native-round-trip
+stable across all 12 required schematic semantic categories. PR #90 merged the production fixes.
+
+This closes the initial schematic quality gate for the tested scope. It does not claim globally optimal
+layout, arbitrary hand-authored junction-topology preservation, hierarchy support, automatic symbol
+rotation/pin-facing correctness, or universal DipTrace compatibility.
+
+## Next formal validation sequence
+
+The project no longer needs to keep the lifecycle campaign paused for schematic-quality work.
+The next project-required gate is:
 
 `windows_clean_install_repair_uninstall`
 
-The Claude Desktop gate is skipped by explicit project waiver, not by inference.
+Then run, in order:
 
-Before resuming the Windows/profile gates, the project will prioritize real-world schematic
-authoring/readability validation. The reason is product confidence: the next question is not merely
-whether the server installs and restarts, but whether it can produce a normal, readable, useful
-schematic in real DipTrace.
+1. `elevated_plugin_install_profile_preservation`;
+2. `custom_state_preservation`.
 
-## Immediate validation priority — real schematic authoring/readability
-
-PR #66 added deterministic bounded readability routing for newly authored schematic wires, and the
-subsequent Ponytail pass may have changed adjacent code. The historical
-`diptrace_ratline_and_wire_roundtrip` PASS proves its exact historical scope, but it does not prove
-that current higher-level schematic authoring produces good human-readable designs.
-
-The next project validation should exercise the explicitly selected current code candidate on small
-real circuits, for example:
-
-- resistor divider;
-- LED + resistor;
-- divider + capacitor / simple RC network;
-- a deliberately collision-prone placement;
-- cases with RefDes, Value and net labels near wires;
-- at least one small multi-net schematic built from a clean starting point.
-
-Inspect both electrical correctness and presentation quality:
-
-- correct parts, pins and net connectivity;
-- sensible component placement and orientation;
-- orthogonal/Manhattan wire geometry where appropriate;
-- no wire through unrelated symbols;
-- no unnecessary wire crossings or collinear overlaps;
-- no wire covering RefDes, Value or net labels;
-- clear intentional junctions and no accidental junction implication;
-- no absurd detours or needless bends;
-- native DipTrace open/save/reopen/re-export preserves the result;
-- the resulting schematic is understandable to a human without manual cleanup being the default.
-
-Any reproducible visual/authoring problem should become a focused regression case and, if needed, a
-separate code repair. Do not erase or rerun historical PASS evidence merely because this stronger
-product-quality validation finds a new issue.
+Claude Desktop remains skipped by explicit project waiver, not by inference.
 
 ## Resume rules
 
 When resuming work from this checkpoint:
 
-- do not restart completed gates;
-- treat `0bb09b4...` as the accepted production-code identity for the completed PASS gates;
+- do not restart completed historical gates;
+- do not replay schematic cases 01–18 without an impact-based production change or a genuinely new claim;
+- treat `0bb09b4...` as the accepted production-code identity for the eight historical formal PASS gates;
+- treat `6bfb656...` as the production merge identity for the closed schematic-quality fixes;
 - treat Claude Desktop as WAIVED, not PASS;
 - if a later project decision requires direct Claude evidence, run it as a fresh gate rather than rewriting the waiver;
 - if relevant production code changes, record the new candidate explicitly and rerun only the evidence plausibly affected by that code change;
-- keep historical FAIL attempts immutable;
+- keep historical FAIL/QUALITY FAIL/SEMANTIC FAIL/INVALID ATTEMPT records immutable;
 - distinguish operator/path/seed mistakes from product defects;
-- Work may prepare files, hashes, XML comparisons and evidence automatically; ask the operator only for meaningful real-GUI checkpoints;
+- prepare files, hashes, XML comparisons and evidence automatically where possible; ask the operator only for meaningful real-GUI checkpoints;
 - stop on a genuine blocking product FAIL and repair it separately;
 - do not silently expand the public MCP contract while performing acceptance or validation repairs.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,19 +8,27 @@ This roadmap separates three states:
 
 Implementation never implies universal DipTrace compatibility. Historical evidence stays bound to the production identity that was actually tested.
 
-## Current checkpoint — 2026-08-11
+## Current checkpoint — 2026-08-13
 
 The current source/package version is `0.2.1`. The immutable `v0.2.1` release and PyPI package are published; post-release development is tracked separately.
 
-The latest accepted manual-production checkpoint remains:
+The schematic-quality production fixes were merged by PR #90. The production merge identity is:
+
+`main@6bfb656008e27f07e665a9b63540d6dc4a5174b6`
+
+Documentation-only commits after that merge do not change the production-code identity of the closed schematic-quality campaign.
+
+The historical formal manual-acceptance checkpoint remains:
 
 `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba`
 
 The durable recovery record is [MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md](MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md). Completed real-host/client PASS evidence is not silently transferred to later code.
 
+The detailed schematic product-quality campaign is in [SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md](SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md). Cases 01–18 are complete; future reruns are impact-based or tied to new claims rather than a replay of the whole campaign.
+
 Current cross-domain implementation detail is in [EDA_INTELLIGENCE.md](EDA_INTELLIGENCE.md).
 
-## Completed manual gates on the accepted checkpoint
+## Completed manual gates on the accepted historical checkpoint
 
 PASS:
 
@@ -37,7 +45,7 @@ The canonical matrix therefore has 8 of 12 blocking manual gates PASS.
 
 `claude_desktop_real_client_restart` is **WAIVED for the current project campaign**, not PASS.
 
-When lifecycle acceptance resumes, the project-required sequence remains:
+The project-required formal lifecycle sequence is now the next acceptance track:
 
 1. `windows_clean_install_repair_uninstall`;
 2. `elevated_plugin_install_profile_preservation`;
@@ -49,11 +57,9 @@ Detailed implementation: [SCHEMATIC_LAYOUT_ENGINE.md](SCHEMATIC_LAYOUT_ENGINE.md
 
 ## Phase 26 — real-world readability baseline
 
-**Status: active product checkpoint.**
+**Status: complete for the initial real-DipTrace product-quality campaign.**
 
-Repository functionality is substantially stronger than the historical wire-only acceptance. The remaining question is product quality in real DipTrace: whether complete generated/repaired schematics become materially easier to read without routine manual cleanup.
-
-The real-host validation document remains `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`.
+The historical wire-only acceptance was strengthened by an 18-case real-host campaign covering authored schematics, visual readability, incremental editing, transaction-failure safety, native round-trip and representative stress composition. Failed/invalid intermediate attempts remain retained as evidence rather than being erased by later repairs.
 
 ## Phase 27 — design intent and reference motifs
 
@@ -109,6 +115,7 @@ Implemented:
 - **selective reroute of explicit affected `(net, sheet)` groups when moved parts touch existing wires**;
 - **one dependency-safe semantic batch combining wire deletion, component movement and replacement wire authoring**;
 - fail-closed refusal if any affected endpoint/route cannot be rebuilt;
+- fail-closed rejection of stale/geometrically inconsistent Wire segment references;
 - no rewriting of unaffected explicit wire geometry;
 - no automatic page-spanning explicit wiring of previously unwired nets by default.
 
@@ -118,9 +125,13 @@ Next refinement: optional intentional-junction preservation and bounded iterativ
 
 ## Phase 31 — schematic quality gate
 
-**Status: pending product-level real-DipTrace acceptance.**
+**Status: PASS / closed for the initial 18-case campaign.**
 
-Close only when representative ugly-but-electrically-correct schematics are reliably improved without connectivity/ERC regression and without routine manual cleanup, with controlled real-host open/save/re-export evidence for the affected primitives.
+Cases 01–18 in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md` are complete. The campaign found and repaired real quality/semantic issues, retained failed and invalid attempts, validated single- and multi-net atomic reroute, checked incremental edits and transaction failure behavior, reused representative native evidence where impact analysis allowed it, and closed on a repaired 22-part stress schematic.
+
+The final representative schematic was operator-accepted and survived real DipTrace Save/Close/Reopen/re-export with all 12 required schematic semantic categories preserved. PR #90 merged the bounded fixes without expanding the public MCP contract.
+
+This gate is not a universal claim. New capabilities outside the tested scope — hierarchy, automatic symbol rotation/pin-facing, topology-preserving reroute, broader datasheet/reference ingestion, or materially changed production code — require focused new evidence.
 
 # PCB track — Generations A-D
 
@@ -240,6 +251,13 @@ Historical dated release/acceptance/audit records remain excluded from this fres
 
 Higher-level EDA modules should continue to prefer typed package internals and a small deliberate public surface.
 
+# Next project sequence
+
+1. Keep the completed schematic cases 01–18 closed unless an impact-based production change requires a focused rerun.
+2. Resume the formal Windows lifecycle gates, starting with `windows_clean_install_repair_uninstall`.
+3. Continue PCB whole-board/native quality work when stronger PCB claims are the active product priority.
+4. Treat cinematic exact-UI acceptance and any future public library-write API as separate claim/product tracks.
+
 # Phase summary
 
 | Area | Current status |
@@ -249,7 +267,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 | schematic placement | bounded implementation |
 | schematic route/joint repair | bounded implementation |
 | schematic selective atomic reroute | implemented for affected explicit sheet-local nets |
-| schematic product quality | real-DipTrace acceptance pending |
+| schematic product quality | **PASS for initial 18-case real-DipTrace campaign; future work impact/claim-based** |
 | PCB Generation A | implemented |
 | PCB Generation B | implemented/bounded |
 | PCB Generation C | implemented/bounded |
@@ -272,4 +290,5 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 - Native manufacturing generation is unavailable.
 - Cinematic replay is presentation automation, not engineering acceptance evidence.
 - Evidence reports do not grant trust/PASS.
+- The completed schematic campaign proves only its recorded scope and does not imply arbitrary hierarchy/topology/global-optimality support.
 - The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review, production readiness, direct Claude Desktop validation or globally optimal schematic/PCB layout.

--- a/docs/SCHEMATIC_LAYOUT_ENGINE.md
+++ b/docs/SCHEMATIC_LAYOUT_ENGINE.md
@@ -86,11 +86,13 @@ Current limitation: affected explicit nets are rebuilt from resolved pin endpoin
 
 The older placement-only planners may still refuse an already-wired schematic when used directly. That behavior remains correct: a placement-only operation cannot safely move symbols while leaving wire geometry behind. Existing-wire support belongs to the atomic selective-reroute planner above.
 
-## Testing and evidence
+## Testing and real-host evidence
 
 Repository tests cover deterministic candidate generation/ranking, pin resolution, route scoring, repair budgets, selective reroute scope, locked-part refusal, unresolved-endpoint refusal, explicit readability feedback, source immutability and semantic replay.
 
-Those tests prove repository behavior, not visual product quality in a particular DipTrace build. The real-host schematic readability campaign in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md` remains the appropriate acceptance path for claims about human-readable output.
+The initial real-host schematic authoring/readability campaign is complete in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`. Cases 01–18 covered small circuits, reference-style composition, incremental edits, failed-operation safety, single- and multi-net atomic reroute, obstacle/readability repairs and a repaired 22-part stress schematic. The final representative artifacts were operator-accepted and survived real DipTrace Save/Close/Reopen/re-export with all 12 required semantic categories preserved.
+
+PR #90 merged the bounded fixes found by that campaign without expanding the 159-tool MCP contract. This closes the initial schematic product-quality gate for its tested scope. It does not prove global optimality, arbitrary hierarchy/topology handling or universal DipTrace compatibility. Later real-host retests should be impact-based or tied to new claims.
 
 ## Remaining work
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -63,9 +63,12 @@ Focused tests cover:
 - atomic selective reroute scope;
 - preservation of unaffected wire geometry;
 - source-document immutability before applying the semantic batch;
-- fail-closed locked-part behavior.
+- fail-closed locked-part and unresolved-endpoint behavior;
+- fail-closed rejection of stale/geometrically inconsistent Wire segment references while valid middle-of-segment joins remain accepted.
 
 Existing-wire support is now available through the dedicated atomic selective-reroute planner. Placement-only planners may still refuse already-wired schematics because they cannot safely move symbols without replacing affected geometry.
+
+The initial 18-case real-DipTrace schematic quality campaign is complete. Repository tests remain the automated regression layer; the detailed manual/native evidence and retained QUALITY FAIL/SEMANTIC FAIL/INVALID ATTEMPT history are in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`. Future manual reruns are impact-based rather than a replay of the whole campaign.
 
 ## PCB Generations A-D tests
 
@@ -155,19 +158,24 @@ Keep these distinct:
 
 Changing a version string does not convert one evidence class into another.
 
-## Manual acceptance checkpoint
+## Manual acceptance checkpoints
 
-The latest accepted manual-production checkpoint remains documented in `MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md` and bound to `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba`.
+The historical formal manual-production checkpoint remains documented in `MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md` and bound to `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba` for the eight canonical PASS gates collected there.
 
 At that checkpoint:
 
 - 8 of 12 canonical blocking manual gates are PASS;
 - Q1 Component Angle is PASS;
 - real Codex restart is PASS;
-- Claude Desktop restart is WAIVED, not PASS;
-- Windows lifecycle acceptance remains next when the formal campaign resumes.
+- Claude Desktop restart is WAIVED, not PASS.
 
-New repository tests do not transfer those PASS results to newer code automatically.
+A separate post-release schematic product-quality campaign subsequently completed cases 01–18 and its bounded fixes were merged by PR #90. That later evidence does not rewrite the historical eight-gate identities, and the historical gates do not automatically transfer to newer code.
+
+The next project-required formal manual gate is:
+
+`windows_clean_install_repair_uninstall`
+
+It is followed by `elevated_plugin_install_profile_preservation` and `custom_state_preservation`.
 
 ## Typical local validation
 


### PR DESCRIPTION
Synchronizes evergreen documentation after merging PR #90.

- marks the initial 18-case real-DipTrace schematic quality campaign complete for its tested scope;
- preserves the historical `0bb09b4...` identities of the eight formal manual PASS gates;
- records `6bfb656...` as the production merge identity for the schematic-quality fixes;
- makes `windows_clean_install_repair_uninstall` the next project-required formal gate;
- updates README, ROADMAP, acceptance checkpoint, testing, EDA/schematic docs, automatable-roadmap closure and `CHANGELOG_NEXT.md`;
- keeps Claude Desktop WAIVED rather than PASS and keeps the public MCP contract at 159 tools.

Documentation-only change; no production/runtime code is modified.