### PR TITLE
fix(schematic): prevent wire cleanup through endpoint symbols

### DIFF
--- a/src/diptrace_mcp/services/schematic_wire_quality.py
+++ b/src/diptrace_mcp/services/schematic_wire_quality.py
@@ -214,6 +214,39 @@ def _part_obstacles(snapshot: DocumentSnapshot, operation: AddWireOperation) -> 
     return result
 
 
+def _endpoint_pin_envelopes(
+    snapshot: DocumentSnapshot,
+    operation: AddWireOperation,
+    pin_anchors: dict[tuple[str, int], Point],
+) -> list[BBox]:
+    """Keep cleanup routes from re-entering their own endpoint symbols."""
+    if snapshot.schematic is None:
+        return []
+    result: list[BBox] = []
+    for part in snapshot.schematic.parts:
+        if not (
+            _endpoint_matches_part(operation.start, part)
+            or _endpoint_matches_part(operation.end, part)
+        ):
+            continue
+        points = [
+            point
+            for (part_id, _), point in pin_anchors.items()
+            if part_id == part.stable_id
+        ]
+        if len(points) < 2:
+            continue
+        box = BBox(
+            min(point.x for point in points),
+            min(point.y for point in points),
+            max(point.x for point in points),
+            max(point.y for point in points),
+        )
+        if box.width > _EPS and box.height > _EPS:
+            result.append(box)
+    return result
+
+
 def _xml_mm(document: DipTraceDocument, value: str | None) -> float | None:
     if value is None:
         return None
@@ -573,7 +606,11 @@ def clean_schematic_wire_operation(
     supplied[-1] = _wire_anchor(snapshot, operation.end, supplied[-1], pin_anchors)
     supplied = _simplify_points(supplied)
     start, end = supplied[0], supplied[-1]
-    obstacles = [*_part_obstacles(snapshot, operation), *_text_obstacles(document, operation.sheet)]
+    obstacles = [
+        *_part_obstacles(snapshot, operation),
+        *_endpoint_pin_envelopes(snapshot, operation, pin_anchors),
+        *_text_obstacles(document, operation.sheet),
+    ]
     existing = _existing_wire_segments(snapshot, operation.sheet)
     touches = _intentional_wire_touches(operation, start, end)
     original = _quality(supplied, obstacles, existing, touches)

--- a/tests/test_schematic_wire_planner.py
+++ b/tests/test_schematic_wire_planner.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from diptrace_mcp.adapters import build_snapshot, stable_id
 from diptrace_mcp.domain import ObjectRecord
+from diptrace_mcp.geometry import Point
 from diptrace_mcp.operations import AddWireOperation
 from diptrace_mcp.schematic_wire_planner import plan_schematic_wire_candidate
+from diptrace_mcp.services import schematic_wire_quality
 from diptrace_mcp.services.schematic_wire_quality import clean_schematic_wire_operation
 from diptrace_mcp.xml_document import DipTraceDocument
 
@@ -17,6 +20,58 @@ MAX_BYTES = 10_000_000
 
 def _load() -> DipTraceDocument:
     return DipTraceDocument.load(FIXTURES / "schematic.xml", MAX_BYTES)
+
+
+def test_cleanup_rejects_reroute_that_reenters_endpoint_symbol(monkeypatch) -> None:
+    snapshot = build_snapshot(_load())
+    assert snapshot.schematic is not None
+    part = next(item for item in snapshot.schematic.parts if item.refdes == "R1")
+    obstacle = ObjectRecord(
+        stable_id=stable_id("part", "test", "obstacle"),
+        kind="part",
+        refdes="U2",
+        bbox={"min_x": -1.0, "min_y": 19.0, "max_x": 1.0, "max_y": 21.0},
+        attributes={"sheet": 0},
+    )
+    snapshot.schematic.parts = [part, obstacle]
+    snapshot.objects[obstacle.stable_id] = obstacle
+    monkeypatch.setattr(
+        schematic_wire_quality,
+        "resolve_document_schematic_pin_geometry",
+        lambda _: SimpleNamespace(
+            pins=[
+                SimpleNamespace(
+                    part_id=part.stable_id,
+                    pin_index=index,
+                    absolute_position={"x": x, "y": y},
+                )
+                for index, (x, y) in enumerate(
+                    ((8.0, 20.0), (12.0, 18.0), (8.0, 22.0), (12.0, 22.0))
+                )
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        schematic_wire_quality,
+        "_route",
+        lambda *_: [
+            Point(8.0, 20.0),
+            Point(12.0, 20.0),
+            Point(12.0, 30.0),
+            Point(-10.0, 30.0),
+            Point(-10.0, 20.0),
+        ],
+    )
+    operation = AddWireOperation(
+        net="VCC",
+        points=[{"x": 8.0, "y": 20.0}, {"x": -10.0, "y": 20.0}],
+        start={"type": "Pin", "refdes": "R1", "pin": 0},
+        end={"type": "Free"},
+    )
+
+    cleaned = clean_schematic_wire_operation(_load(), snapshot, operation)
+
+    assert cleaned.points == operation.points
 
 
 def test_planner_is_non_mutating_and_routes_around_component_obstacles() -> None:


### PR DESCRIPTION
Reapply the isolated wire-cleanup regression fix on top of the current main without carrying the stale unsigned branch history.

## Scope

Explain the bounded change and the user-visible outcome. Link the issue or
decision record that authorized the work when one exists.

## DCO and provenance

- [ ] Every commit has a `Signed-off-by:` line under [`DCO`](../DCO).
- [ ] I disclosed the origin, license, and redistribution basis for code,
      fixtures, schemas, examples, documentation, and generated files.
- [ ] I disclosed meaningful AI assistance, if any, and described the human
      review performed.
- [ ] I remain responsible for correctness, security, provenance, and the
      right to redistribute the submitted work.

## Safety, security, and privacy

- [ ] Safety gates remain fail-closed.
- [ ] New DipTrace claims cite an official specification or controlled
      real-export evidence.
- [ ] Synthetic evidence is labelled as synthetic.
- [ ] Unknown XML and bytes outside the intended edit are preserved.
- [ ] No proprietary, customer, personal, secret, private, restricted, or
      submission/application material is included.
- [ ] Security-sensitive details are handled through `SECURITY.md`, not this
      pull request.

## Generated artifacts

- [ ] MCP tool snapshot changes were regenerated and reviewed, or no public
      tool descriptor changed.
- [ ] Specification inventory and format-coverage outputs were regenerated
      when their inputs changed.
- [ ] Compliance inventory, SBOM, provenance, and release allowlists were
      regenerated or checked when their inputs changed.
- [ ] Documentation and code claims remain equivalent.

## Verification

List the exact commands and environments used. State any platform, licensed
DipTrace, signing, or external-tool checks that were not run.

- [ ] All required CI checks for the current head commit are green. A red or
      pending required check means this pull request is not merge-ready.

## Review notes

Explain error-contract, transaction, evidence-level, performance, signing,
packaging, and rollback effects. A passing round trip through this repository's
own reader and writer is not proof of a DipTrace convention.
