### PR TITLE
fix: exact library identity and installer validation

### DIFF
--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -166,3 +166,4 @@ does not make undocumented children safe.
 Any operation listed above can discard matching passthrough children rather than
 preserve their original bytes. Unlisted dynamic removal sites remain unavailable
 to this static detector and must not be assumed safe.
+

--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -10,10 +10,10 @@
 | Project-authored omission clauses | 0 |
 | Documented parent/child relationships | 143 across 61 parents |
 | Normalized (reader produces typed field) | 72 |
-| Written only (writer can create/modify) | 19 |
+| Written only (writer can create/modify) | 21 |
 | Mentioned only (literal, not an XML call) | 6 |
-| Passthrough (unknown XML, kept byte-for-byte) | 10 |
-| **Coverage** | **85.0%** |
+| Passthrough (unknown XML, kept byte-for-byte) | 8 |
+| **Coverage** | **86.9%** |
 
 ## Inventory Provenance
 
@@ -107,10 +107,12 @@ the current reader/writer call sites; it is not a normative DipTrace format spec
 
 - `ActiveSheet`
 - `Board`
+- `Datasheet`
 - `GNDTemplate`
 - `Id`
 - `LayerName`
 - `LayerStackName`
+- `Manufacturer`
 - `Name`
 - `Name_Unique`
 - `Origin`
@@ -137,13 +139,11 @@ the current reader/writer call sites; it is not a normative DipTrace format spec
 ## Passthrough Elements
 
 - `Data`
-- `Datasheet`
 - `Filename`
 - `FutureComponentData`
 - `FutureExtension`
 - `FuturePatternData`
 - `FutureStackupExtension`
-- `Manufacturer`
 - `Note`
 - `PadNumber`
 
@@ -166,4 +166,3 @@ does not make undocumented children safe.
 Any operation listed above can discard matching passthrough children rather than
 preserve their original bytes. Unlisted dynamic removal sites remain unavailable
 to this static detector and must not be assumed safe.
-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,11 +45,7 @@ The canonical matrix therefore has 8 of 12 blocking manual gates PASS.
 
 `claude_desktop_real_client_restart` is **WAIVED for the current project campaign**, not PASS.
 
-The project-required formal lifecycle sequence is now the next acceptance track:
-
-1. `windows_clean_install_repair_uninstall`;
-2. `elevated_plugin_install_profile_preservation`;
-3. `custom_state_preservation`.
+The real-host lifecycle track has completed a clean product-state install/repair/uninstall run and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`. The strict pristine-machine qualifier remains explicit for the former. The next campaign gate is `custom_state_preservation`.
 
 # Schematic track
 
@@ -254,7 +250,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 # Next project sequence
 
 1. Keep the completed schematic cases 01–18 closed unless an impact-based production change requires a focused rerun.
-2. Resume the formal Windows lifecycle gates, starting with `windows_clean_install_repair_uninstall`.
+2. Run `custom_state_preservation`; do not broaden the earlier clean product-state result into a pristine-machine claim.
 3. Continue PCB whole-board/native quality work when stronger PCB claims are the active product priority.
 4. Treat cinematic exact-UI acceptance and any future public library-write API as separate claim/product tracks.
 
@@ -262,7 +258,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 
 | Area | Current status |
 | --- | --- |
-| manual acceptance | 8 canonical PASS gates on accepted historical checkpoint; Claude WAIVED; Windows lifecycle next |
+| manual acceptance | 8 canonical PASS gates on the historical checkpoint; Claude WAIVED; elevated profile gate PASS on `9af6da2`; custom-state gate next |
 | schematic intent/motifs | implemented + builtin heuristic motifs |
 | schematic placement | bounded implementation |
 | schematic route/joint repair | bounded implementation |

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -61,7 +61,7 @@ Cinematic replay remains presentation automation, not an alternate engineering a
 
 The current project campaign has 8 canonical manual gates PASS. Claude Desktop restart is explicitly WAIVED, not PASS.
 
-When formal lifecycle acceptance resumes, the next project-required gate is `windows_clean_install_repair_uninstall`, followed by elevated plug-in/profile preservation and custom-state preservation. CI installer tests remain implementation evidence, not a replacement for that chosen real clean-machine gate.
+A clean product-state install/repair/uninstall run and exact-candidate `elevated_plugin_install_profile_preservation` are now complete on the real Windows host. The former retains its stricter pristine-machine wording qualifier. `custom_state_preservation` is next; CI installer tests remain implementation evidence, not a replacement for real-host gates.
 
 ### 8. Native manufacturing output
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -171,11 +171,7 @@ At that checkpoint:
 
 A separate post-release schematic product-quality campaign subsequently completed cases 01–18 and its bounded fixes were merged by PR #90. That later evidence does not rewrite the historical eight-gate identities, and the historical gates do not automatically transfer to newer code.
 
-The next project-required formal manual gate is:
-
-`windows_clean_install_repair_uninstall`
-
-It is followed by `elevated_plugin_install_profile_preservation` and `custom_state_preservation`.
+Later real-host lifecycle evidence completed a clean product-state install/repair/uninstall run (with the strict pristine-machine qualifier retained) and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`. The next campaign gate is `custom_state_preservation`.
 
 ## Typical local validation
 

--- a/docs/WINDOWS_INSTALLER.md
+++ b/docs/WINDOWS_INSTALLER.md
@@ -105,14 +105,12 @@ CI evidence is necessary but not equivalent to the project-level clean real-mach
 
 ## Current manual acceptance boundary
 
-When formal acceptance resumes, the next project-required lifecycle gate is:
+Post-release real-host validation now has:
 
-`windows_clean_install_repair_uninstall`
+- a clean product-state install/repair/uninstall PASS, while the stricter pristine-machine/VM wording remains a documented qualifier;
+- `elevated_plugin_install_profile_preservation` PASS on exact candidate `9af6da2` and Windows 11 build `26200` with DipTrace `5.3.0.2`.
 
-then:
-
-1. `elevated_plugin_install_profile_preservation`;
-2. `custom_state_preservation`.
+The next campaign gate is `custom_state_preservation`. The elevated gate found and fixed protected-root detection and a flattened frozen-configurator runtime; schematic/native gates were unaffected and were not repeated.
 
 These gates should be run against the exact production candidate/artifacts whose compatibility is being claimed. Do not copy a PASS from an older candidate onto later `main` merely because the installer code looks similar.
 

--- a/installer/DipTraceMCP.iss
+++ b/installer/DipTraceMCP.iss
@@ -59,6 +59,11 @@ Source: "{#StageDir}\installation-manifest.template.json"; DestDir: "{app}"; Des
 Name: "{group}\DipTrace MCP README"; Filename: "{app}\README_FIRST.txt"
 Name: "{group}\DipTrace MCP Configurator"; Filename: "{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe"
 
+[UninstallDelete]
+Type: files; Name: "{app}\plugin-targets.txt"
+Type: files; Name: "{app}\state-dir.txt"
+Type: dirifempty; Name: "{app}"
+
 [Code]
 const
   ClientCodex = 0;
@@ -273,8 +278,8 @@ begin
   Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\install_plugin.ps1') +
     '" -DipTraceDir "' + SelectedDipTrace +
     '" -Mode All -BridgeExe "' + ExpandConstant('{app}\bridge\diptrace_mcp_bridge.exe') + '"';
-  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{autopf}')) or
-    IsPathUnder(SelectedDipTrace, ExpandConstant('{autopf32}'));
+  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf}')) or
+    IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf32}'));
   AppendInstallLog('DipTrace plugin integration requested; elevation may be required.');
   if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then
     RaiseException('DipTrace plug-in installation failed. No client configuration was attempted.');
@@ -290,8 +295,8 @@ begin
   if not IsPluginSelected or (SelectedDipTrace = '') then Exit;
   Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\uninstall_plugin.ps1') +
     '" -DipTraceDir "' + SelectedDipTrace + '" -InstallScript "' + ExpandConstant('{app}\tools\install_plugin.ps1') + '"';
-  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{autopf}')) or
-    IsPathUnder(SelectedDipTrace, ExpandConstant('{autopf32}'));
+  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf}')) or
+    IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf32}'));
   if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then
     AppendInstallLog('WARNING: automatic DipTrace plug-in rollback failed.')
   else
@@ -407,8 +412,8 @@ begin
   if CurPageID = StatePage.ID then begin
     ResolvedStateDir := Trim(StatePage.Values[0]);
     if IsPathUnder(StatePage.Values[0], ExpandConstant('{app}')) or
-       IsPathUnder(StatePage.Values[0], ExpandConstant('{autopf}')) or
-       IsPathUnder(StatePage.Values[0], ExpandConstant('{autopf32}')) then begin
+       IsPathUnder(StatePage.Values[0], ExpandConstant('{commonpf}')) or
+       IsPathUnder(StatePage.Values[0], ExpandConstant('{commonpf32}')) then begin
       MsgBox('State must remain outside the installed application and Program Files.', mbError, MB_OK);
       Result := False;
     end else if not ForceDirectories(StatePage.Values[0]) then begin
@@ -425,10 +430,10 @@ var
 begin
   PluginSelection := not HasCommandLineParam('/SERVERONLY');
   DipTracePage := CreateInputOptionPage(wpSelectComponents, 'DipTrace installation', 'Choose DipTrace integration', 'Only a validated installation is offered for plug-in integration.', True, True);
-  AddDipTraceCandidate(ExpandConstant('{autopf}\DipTrace5'), 'Program Files');
-  AddDipTraceCandidate(ExpandConstant('{autopf}\DipTrace'), 'Program Files');
-  AddDipTraceCandidate(ExpandConstant('{autopf32}\DipTrace5'), 'Program Files (x86)');
-  AddDipTraceCandidate(ExpandConstant('{autopf32}\DipTrace'), 'Program Files (x86)');
+  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace5'), 'Program Files');
+  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace'), 'Program Files');
+  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace5'), 'Program Files (x86)');
+  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace'), 'Program Files (x86)');
   AddRegistryDipTraceCandidates(HKCU);
   AddRegistryDipTraceCandidates(HKLM);
   DipTracePage.Add('Browse for another validated DipTrace installation');
@@ -542,8 +547,8 @@ begin
   for I := 0 to GetArrayLength(Lines) - 1 do begin
     if Trim(Lines[I]) = '' then Continue;
     Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\uninstall_plugin.ps1') + '" -DipTraceDir "' + Trim(Lines[I]) + '" -InstallScript "' + ExpandConstant('{app}\tools\install_plugin.ps1') + '"';
-    NeedsElevation := IsPathUnder(Trim(Lines[I]), ExpandConstant('{autopf}')) or
-      IsPathUnder(Trim(Lines[I]), ExpandConstant('{autopf32}'));
+    NeedsElevation := IsPathUnder(Trim(Lines[I]), ExpandConstant('{commonpf}')) or
+      IsPathUnder(Trim(Lines[I]), ExpandConstant('{commonpf32}'));
     if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then begin
       Log('DipTrace MCP uninstall: plug-in removal failed with code ' + IntToStr(ResultCode));
       if not UninstallSilent then

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -64,6 +64,7 @@ function Test-StagedBundle([string]$Root) {
     Assert-File (Join-Path $Root 'app\diptrace_mcp_server.exe') 'standalone server'
     Assert-File (Join-Path $Root 'bridge\diptrace_mcp_bridge.exe') 'bridge'
     Assert-File (Join-Path $Root 'tools\diptrace_mcp_configure\diptrace_mcp_configure.exe') 'configurator'
+    Assert-File (Join-Path $Root 'tools\diptrace_mcp_configure\_internal\python312.dll') 'configurator runtime'
     Assert-File (Join-Path $Root 'tools\install_portable.ps1') 'portable installer helper'
     foreach ($name in @('pcb.settings.xml', 'schematic.settings.xml', 'component.settings.xml', 'pattern.settings.xml')) {
         Assert-File (Join-Path $Root ("settings-templates\$name")) "settings template $name"
@@ -80,13 +81,16 @@ function Test-StagedBundle([string]$Root) {
 
 try {
     if (-not $SkipBuild) {
-        $serverArgs = @('-PythonCommand', $PythonCommand, '-OutputDir', 'dist\windows-server', '-Clean')
-        if ($NoGeometry) { $serverArgs += '-NoGeometry' }
-        Invoke-Checked (Join-Path $RepoRoot 'scripts\build_windows_server.ps1') $serverArgs
-        Invoke-Checked (Join-Path $RepoRoot 'scripts\build_windows_configurator.ps1') @('-PythonCommand', $PythonCommand, '-OutputDir', 'dist\windows-configurator', '-Clean')
+        & (Join-Path $RepoRoot 'scripts\build_windows_server.ps1') `
+            -PythonCommand $PythonCommand -OutputDir 'dist\windows-server' -Clean -NoGeometry:$NoGeometry
+        if ($LASTEXITCODE -ne 0) { throw "Windows server build failed with exit code $LASTEXITCODE" }
+        & (Join-Path $RepoRoot 'scripts\build_windows_configurator.ps1') `
+            -PythonCommand $PythonCommand -OutputDir 'dist\windows-configurator' -Clean
+        if ($LASTEXITCODE -ne 0) { throw "Windows configurator build failed with exit code $LASTEXITCODE" }
         if (-not $BridgePath) { $BridgePath = $BridgeDefault }
         if (-not (Test-Path -LiteralPath $BridgePath -PathType Leaf)) {
-            Invoke-Checked (Join-Path $RepoRoot 'plugin\build_bridge.ps1') @('-PythonCommand', $PythonCommand, '-Clean')
+            & (Join-Path $RepoRoot 'plugin\build_bridge.ps1') -PythonCommand $PythonCommand -Clean
+            if ($LASTEXITCODE -ne 0) { throw "Windows bridge build failed with exit code $LASTEXITCODE" }
         }
     }
     if (-not $BridgePath) { $BridgePath = $BridgeDefault }
@@ -95,7 +99,7 @@ try {
     Assert-File $BridgePath 'bridge executable'
 
     New-Item -ItemType Directory -Force -Path $Stage, $InstallerDir, $PortableDir | Out-Null
-    New-Item -ItemType Directory -Force -Path (Join-Path $Stage 'app'), (Join-Path $Stage 'bridge'), (Join-Path $Stage 'settings-templates'), (Join-Path $Stage 'tools'), (Join-Path $Stage 'tools\settings') | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage 'app'), (Join-Path $Stage 'bridge'), (Join-Path $Stage 'settings-templates'), (Join-Path $Stage 'tools'), (Join-Path $Stage 'tools\settings'), (Join-Path $Stage 'tools\diptrace_mcp_configure') | Out-Null
     Copy-Item -Path (Join-Path $ServerDist '*') -Destination (Join-Path $Stage 'app') -Recurse -Force
     Copy-Item -LiteralPath $BridgePath -Destination (Join-Path $Stage 'bridge\diptrace_mcp_bridge.exe') -Force
     Copy-Item -Path (Join-Path $RepoRoot 'plugin\settings\*') -Destination (Join-Path $Stage 'settings-templates') -Force
@@ -152,7 +156,8 @@ try {
         $displayVersion = (Get-ItemProperty -LiteralPath $registryPath -Name DisplayVersion -ErrorAction SilentlyContinue).DisplayVersion
         if ($displayVersion) { $isccVersions += ([string]$displayVersion -replace '\s', '') }
     }
-    foreach ($argument in @('/?')) {
+    if (-not ($isccVersions | Where-Object { $_.StartsWith('6.4.2') } | Select-Object -First 1)) {
+        $argument = '/?'
         $isccBanner = (& $IsccPath $argument 2>&1 | Out-String)
         $isccMatch = [regex]::Match($isccBanner, '(?im)Inno Setup(?: Compiler)?\s+([0-9]+\.[0-9]+\.[0-9]+)')
         if ($isccMatch.Success) { $isccVersions += $isccMatch.Groups[1].Value }

--- a/src/diptrace_mcp/library_adapters.py
+++ b/src/diptrace_mcp/library_adapters.py
@@ -621,7 +621,7 @@ def query_library_items(model: LibraryModel, query: str | None = None) -> list[d
         if needle
         in " ".join(
             str(item.get(key, ""))
-            for key in ("name", "unique_name", "refdes", "value", "manufacturer")
+            for key in ("name", "unique_name", "refdes", "value", "manufacturer", "fields")
         ).casefold()
     ]
 

--- a/src/diptrace_mcp/semantic_compiler.py
+++ b/src/diptrace_mcp/semantic_compiler.py
@@ -2663,6 +2663,21 @@ def _apply_place_part(
     ET.SubElement(part, "PartName").text = operation.part_name or "Part 1"
     ET.SubElement(part, "Value").text = operation.value
     ET.SubElement(part, "Name").text = operation.name or operation.component_style
+    if library_part is not None:
+        manufacturer = (library_part.findtext("./Manufacturer") or "").strip()
+        datasheet = (library_part.findtext("./Datasheet") or "").strip()
+        if manufacturer:
+            ET.SubElement(part, "Manufacturer").text = manufacturer
+        if datasheet:
+            ET.SubElement(part, "Datasheet").text = datasheet
+        fields = {
+            (field.findtext("./Name") or "").strip(): field.findtext("./Text") or ""
+            for field in library_part.findall("./AddFields/AddField")
+            if (field.findtext("./Name") or "").strip()
+        }
+        if manufacturer and not any(name.casefold() in {"manufacturer", "mfr"} for name in fields):
+            fields["Manufacturer"] = manufacturer
+        _set_additional_fields(part, fields)
     common_marking = {
         "Show": "Common",
         "Align": "Common",

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -168,6 +168,9 @@ def test_library_service_scan_query_get_and_validate(tmp_path: Path) -> None:
 
     queried = service.query_library_items(str(component_path), "RES")
     assert queried["result"]["matched_count"] == 1
+    assert service.query_library_items(str(component_path), "RC0603-GOLDEN")["result"][
+        "matched_count"
+    ] == 1
     component = service.get_library_component(str(component_path), name="RES_0603")
     assert component["result"]["pattern_style"] == "PatType0"
     mapping = service.validate_pin_pad_mapping(str(component_path), name="RES_0603")

--- a/tests/test_schematic_authoring.py
+++ b/tests/test_schematic_authoring.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.bom import extract_bom
 from diptrace_mcp.config import Settings
 from diptrace_mcp.errors import AmbiguousSelectorError, EditError, ObjectNotFoundError
 from diptrace_mcp.operations import (
@@ -122,6 +123,37 @@ def test_place_part_rejects_duplicate_refdes() -> None:
                 )
             ],
         )
+
+
+def test_place_part_copies_embedded_library_identity_into_bom() -> None:
+    raw = _load("schematic.xml").raw_bytes.replace(
+        b'<Library Type="DipTrace-ComponentLibrary" Version="4.3.0.3" Units="mm" />',
+        b'<Library Type="DipTrace-ComponentLibrary" Version="4.3.0.3" Units="mm">'
+        b'<Components><Component ComponentStyle="ExactStyle"><Part Id="0" RefDes="Q">'
+        b'<Name>BSS138</Name><Manufacturer>onsemi</Manufacturer>'
+        b'<Datasheet>https://example.invalid/bss138.pdf</Datasheet><AddFields>'
+        b'<AddField Type="Text"><Name>MPN</Name><Text>BSS138</Text></AddField>'
+        b'<AddField Type="Text"><Name>LCSC</Name><Text>C52895</Text></AddField>'
+        b'</AddFields></Part></Component></Components></Library>',
+    )
+    result = apply_semantic_operations(
+        _load_bytes(raw),
+        [
+            PlacePartOperation(
+                component_style="ExactStyle", refdes="Q1", name="BSS138", x=0, y=0, pin_count=3
+            )
+        ],
+    )
+    part = ET.fromstring(result.raw_bytes).findall("./Schematic/Components/Part")[-1]
+    assert part.findtext("./Manufacturer") == "onsemi"
+    assert part.findtext("./Datasheet") == "https://example.invalid/bss138.pdf"
+    fields = {
+        item.findtext("./Name"): item.findtext("./Text")
+        for item in part.findall("./AddFields/AddField")
+    }
+    assert fields == {"MPN": "BSS138", "LCSC": "C52895", "Manufacturer": "onsemi"}
+    bom = extract_bom(build_snapshot(result.document))[-1]
+    assert (bom.manufacturer, bom.mpn, bom.fields["LCSC"]) == ("onsemi", "BSS138", "C52895")
 
 
 def test_place_part_uses_native_net_port_markings() -> None:

--- a/tests/test_windows_installer_sources.py
+++ b/tests/test_windows_installer_sources.py
@@ -25,6 +25,13 @@ def test_inno_installer_is_user_scoped_and_has_required_wizard_contracts() -> No
     assert "runas" in script
     assert "Remove local DipTrace MCP state and logs" in script
     assert "Projects are never removed".casefold() in script.casefold()
+    assert 'Type: files; Name: "{app}\\plugin-targets.txt"' in script
+    assert 'Type: files; Name: "{app}\\state-dir.txt"' in script
+    assert 'Type: dirifempty; Name: "{app}"' in script
+    assert "{autopf}" not in script
+    assert "{autopf32}" not in script
+    assert "{commonpf}" in script
+    assert "{commonpf32}" in script
     assert "PrivilegesRequired=admin" not in script
 
 
@@ -48,6 +55,11 @@ def test_windows_build_wrapper_pins_inno_and_emits_two_named_assets() -> None:
     assert "SHA256SUMS.txt" in wrapper
     assert "artifact-inventory.json" in wrapper
     assert "SIGNING_REQUIRED" not in wrapper or "SigningRequired" in wrapper
+    assert r"tools\diptrace_mcp_configure\_internal\python312.dll" in wrapper
+    assert "(Join-Path $Stage 'tools\\diptrace_mcp_configure')" in wrapper
+    assert "Invoke-Checked (Join-Path $RepoRoot 'scripts\\build_windows_server.ps1')" not in wrapper
+    assert "-NoGeometry:$NoGeometry" in wrapper
+    assert "if (-not ($isccVersions | Where-Object" in wrapper
 
 
 def test_existing_bridge_pipeline_remains_the_source_of_bridge_artifact() -> None:


### PR DESCRIPTION
## Scope

Clean transfer of PR #94's final content onto current `main`, without the historical unsigned branch commits that made DCO fail.

Includes:
- exact library identity propagation and focused regressions;
- Windows installer/elevation/runtime-layout fixes already exercised by the original branch;
- lifecycle evidence documentation carried from PR #94;
- regenerated `docs/FORMAT_COVERAGE.md` after `Manufacturer` and `Datasheet` became writer-visible (86.9%).

## CI repair

The original PR #94 had two remaining CI failures:
1. DCO: its branch history contained 31 older unsigned commits.
2. `report_format_coverage.py --check`: generated format coverage was stale.

This PR uses one signed-off commit based directly on current `main` and includes the regenerated coverage report.

Signed-off commit: `10822a45029362370c6a18c0441373896c7baeae`.
