### PR TITLE
Synchronize documentation with completed acceptance state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ part of the already-published `v0.2.1` bytes.
 
 - Intelligent schematic-layout foundation: design intent/reference motifs,
   bounded multi-candidate placement, conservative pin geometry, non-mutating
-  wire planning, pin-aware joint placement/routing scoring, and bounded
-  placement repair.
+  wire planning, pin-aware joint placement/routing scoring, bounded placement
+  repair, and selective atomic affected-net reroute.
 - PCB Generations A-D: engineering intent/placement, physical/PDN/return-path
   context, engineering-aware routing policy, and bounded whole-board candidate
   selection with a synthetic benchmark catalog.
@@ -21,17 +21,20 @@ part of the already-published `v0.2.1` bytes.
 - Cinematic DipTrace presentation subsystem with UI profiles, affine
   design-to-client calibration, semantic Schematic/PCB replay adapters, Windows
   playback, and MP4/GIF recording helpers.
+- Optional Windows headless GUI worker using an isolated Win32 desktop for
+  bounded native open/save/close operations without physical-input fallback.
 
 ### Changed
 
-- Combined supported-environment coverage is now gated at 90% while the
+- Combined supported-environment coverage remains gated at 90% while the
   geometry-enabled Linux full-suite job retains its separate 85% floor.
 - Q1 Component Angle was completed as PASS in the later private/manual
   DipTrace PCB Layout 5.3.0.3 campaign; immutable release-time evidence retains
   its original historical status.
-- Claude Desktop restart is explicitly WAIVED, not PASS, for the current manual
-  campaign; Windows lifecycle gates remain pending when formal acceptance
-  resumes.
+- The accepted manual matrix is complete at 12 of 12 blocking gates PASS across
+  its recorded checkpoints. Claude Desktop restart and custom-state preservation
+  are operator-confirmed PASS from a separate machine; their earlier
+  WAIVED/pending states remain historical only.
 - Evergreen documentation was reconciled with the published `v0.2.1` state and
   current post-release implementation without rewriting dated release,
   acceptance, or compliance snapshots.

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -57,6 +57,14 @@ This development record tracks changes merged after the immutable `v0.2.1` relea
 
 Cinematic replay is deliberately a presentation path. The XML bridge and normal preview/SHA/transaction/review path remain authoritative for engineering edits and acceptance.
 
+### Headless Windows GUI worker
+
+- isolated Win32-desktop worker for bounded native DipTrace open/save/close work without switching the user's input desktop or synthesizing physical mouse/keyboard input;
+- Windows smoke/readiness checks and a frozen packaged helper under `app/tools/diptrace_mcp_headless_gui/`;
+- fail-closed automation with no coordinate-input fallback when a native control action cannot be completed safely.
+
+The headless worker is a host-automation boundary, not a second semantic authoring authority. Real DipTrace actions remain claim-specific acceptance evidence.
+
 ### Product and engineering support
 
 - raw-preserving internal Component/Pattern Library mutation core with controlled real-editor evidence;
@@ -76,7 +84,7 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 - DSN/SES results can be structurally and semantically screened before import without mutating the PCB.
 - Real-DipTrace capture candidates can be converted into reproducible machine-readable and Markdown evidence reports without rewriting historical evidence or manufacturing trust.
 - The private/manual Q1 Component Angle campaign is PASS on its accepted production checkpoint; immutable historical release records keep the status that was true when each release was cut.
-- `claude_desktop_real_client_restart` is explicitly WAIVED for the current campaign, not marked PASS; the canonical validator remains conservative.
+- The accepted manual matrix is complete at 12 of 12 blocking gates PASS across its recorded checkpoints. Claude Desktop restart and custom-state preservation are operator-confirmed PASS from a separate machine; their earlier WAIVED/pending states remain historical only.
 - Documentation distinguishes current implementation state from immutable release/audit/acceptance snapshots.
 - Installation/release documentation reflects that `v0.2.1` and `diptrace-mcp==0.2.1` are already published.
 - Testing documentation reflects the combined 90% coverage gate and the separate 85% Linux-only floor.
@@ -89,7 +97,7 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 - PCB candidate/whole-board quality remains subject to current-candidate real-DipTrace/native refill/plane/via acceptance where stronger claims are desired;
 - cinematic UI macros and calibration still require real-client verification for the exact DipTrace version/editor configuration;
 - staged cinematic playback of vias/layer transitions remains unsupported;
-- Windows lifecycle gates remain pending; the next project-required formal gate is `windows_clean_install_repair_uninstall`;
+- the 12-gate manual matrix is complete for its recorded checkpoints; future Windows/client reruns are impact- or release-claim-based rather than automatically replaying the full matrix;
 - the library mutation request/preview contract remains package-level and unregistered in the public MCP tool snapshot;
 - native manufacturing generation, field-solver/PI/EMC/thermal sign-off, universal compatibility, signed-binary trust, independent review and production readiness are not claimed.
 

--- a/README.md
+++ b/README.md
@@ -263,11 +263,10 @@ The main write invariants are:
 The private/manual Q1 Component Angle GUI/re-export campaign is PASS on DipTrace
 PCB Layout 5.3.0.3. Package-owned public evidence/trust promotion remains a
 separate reviewed contract, and the immutable `v0.2.1` release record correctly
-retains its earlier `NOT_RUN` release-time status. Real Codex restart is PASS;
-Claude Desktop restart is WAIVED for the current project campaign, not PASS.
+retains its earlier `NOT_RUN` release-time status. Real Codex restart and an
+operator-confirmed Claude Desktop restart on a separate machine are PASS.
 The initial 18-case schematic product-quality campaign is PASS for its recorded
-scope. Windows lifecycle gates remain pending; the next project-required formal
-gate is `windows_clean_install_repair_uninstall`.
+scope. All 12 blocking manual gates are PASS across the accepted checkpoints.
 
 ## Data Handling
 

--- a/docs/AUTOMATABLE_ROADMAP_CLOSURE.md
+++ b/docs/AUTOMATABLE_ROADMAP_CLOSURE.md
@@ -40,4 +40,4 @@ The statement “no unresolved repository-only blocker” applied to the closure
 
 The first schematic product-quality campaign is now closed. Its detailed evidence remains in `SCHEMATIC_AUTHORING_VALIDATION_2026-08-10.md`; PR #90 merged the bounded fixes into `main`. Future schematic retests are impact-based rather than a restart of cases 01–18.
 
-Current unresolved product work is described in `ROADMAP.md`, `PCB_DESIGN_ENGINE.md`, `CINEMATIC_DEMO_MODE.md` and the remaining formal lifecycle gates. The next project-required formal acceptance gate is `windows_clean_install_repair_uninstall`; Claude Desktop restart remains WAIVED, not PASS.
+Current unresolved product work is described in `ROADMAP.md`, `PCB_DESIGN_ENGINE.md` and `CINEMATIC_DEMO_MODE.md`. All 12 blocking manual gates are PASS across the accepted checkpoints, including operator-confirmed custom-state preservation and Claude Desktop restart on a separate machine.

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -175,7 +175,7 @@ User-controlled files/sidecars cannot mint package-owned high trust.
 
 - full automatic datasheet/reference-design ingestion is not part of the deterministic schematic foundation;
 - schematic rotation/pin-facing semantics are not universally trusted without real-host evidence;
-- selective atomic replacement of existing wires after placement repair remains future work;
+- selective atomic affected-wire replacement is implemented, but rebuilt explicit nets do not preserve arbitrary hand-authored junction topology as a visual constraint;
 - PCB Generations B-D remain bounded analysis/selection layers, not field/PI/EMC/thermal/native manufacturing authorities;
 - authoritative poured-copper/refill semantics remain a native-host evidence boundary;
 - cinematic replay models cannot be used as proof that a semantic edit succeeded.

--- a/docs/EDA_INTELLIGENCE.md
+++ b/docs/EDA_INTELLIGENCE.md
@@ -8,6 +8,8 @@ The intelligence modules generate facts, candidates, scores, feedback, or ordina
 
 The public MCP contract remains frozen at **159 registered tools**. New modules in this document are internal/package-level unless a public tool is explicitly added and the frozen tools/list snapshot is intentionally updated.
 
+The project-level manual acceptance matrix is also complete for its recorded scope: **all 12 blocking manual gates are PASS across the accepted checkpoints**. That evidence remains bound to those exact checkpoints and is not inherited automatically by later release bytes.
+
 ## Schematic pipeline
 
 The current deterministic pipeline is:
@@ -94,9 +96,9 @@ The safety boundary is also enforced inside `cinematic_host.py`: `play_manifest(
 
 ## Documentation drift guard
 
-`scripts/check_documentation_state.py` compares evergreen current-state docs with the implemented module set and frozen public-tools snapshot, and checks that cinematic playback still enforces preflight and library mutation remains package-only. `tests/test_documentation_state.py` executes that contract in the normal CI test matrix.
+`scripts/check_documentation_state.py` compares evergreen current-state docs with the implemented module set and frozen public-tools snapshot, checks that cinematic playback still enforces preflight and library mutation remains package-only, and rejects known stale current-state acceptance/reroute/headless-CLI claims. `tests/test_documentation_state.py` executes that contract in the normal CI test matrix.
 
-Historical dated evidence/release records are intentionally excluded from this freshness contract.
+Historical dated evidence/release records are intentionally excluded from current-state freshness assertions.
 
 ## Testing
 
@@ -116,10 +118,10 @@ Repository CI remains authoritative. The supported-environment combined coverage
 
 ## What still needs real hardware/software/operator evidence
 
-The completed 18-case schematic campaign should not be repeated without an impact-based reason. Remaining manual/native evidence is claim-specific and currently includes:
+The completed 18-case schematic campaign and the completed 12-gate manual matrix should not be repeated without an impact- or claim-based reason. Remaining manual/native evidence is claim-specific and currently includes:
 
-- current-candidate PCB whole-board/native refill/plane/via quality acceptance where claimed;
+- current-candidate PCB whole-board/native refill/plane/via quality acceptance where stronger claims are desired;
 - exact UI-profile cinematic replay validation;
-- Windows clean install/repair/uninstall and profile/custom-state preservation gates;
+- release-specific Windows/client lifecycle retests only when changed production code/artifacts or a new claim make them relevant;
 - new schematic claims outside the completed campaign scope, such as hierarchy, topology-preserving reroute or automatic rotation/pin-facing behavior;
 - manufacturing output, independent review, regulatory, EMC, PI, thermal or field-solver sign-off.

--- a/docs/HEADLESS_GUI.md
+++ b/docs/HEADLESS_GUI.md
@@ -57,10 +57,11 @@ From PowerShell in the repository:
 py -m pip install -e ".[headless-gui]"
 ```
 
-The package exposes:
+The source checkout does not install a separate `diptrace-mcp-headless-gui`
+console entry point. Invoke the maintained module directly:
 
 ```powershell
-diptrace-mcp-headless-gui --help
+py -m diptrace_mcp.headless_gui --help
 ```
 
 ## Isolation smoke test
@@ -68,7 +69,7 @@ diptrace-mcp-headless-gui --help
 Run this before testing DipTrace itself:
 
 ```powershell
-diptrace-mcp-headless-gui smoke
+py -m diptrace_mcp.headless_gui smoke
 ```
 
 A successful result is JSON with `"ok": true`. The test creates a private desktop,
@@ -83,13 +84,13 @@ The test does not require DipTrace.
 Auto-detect DipTrace and verify that the automation backend is installed:
 
 ```powershell
-diptrace-mcp-headless-gui doctor --require-automation
+py -m diptrace_mcp.headless_gui doctor --require-automation
 ```
 
 Or specify the install directory explicitly:
 
 ```powershell
-diptrace-mcp-headless-gui doctor `
+py -m diptrace_mcp.headless_gui doctor `
   --diptrace-root "C:\Program Files\DipTrace" `
   --require-automation
 ```
@@ -106,7 +107,7 @@ The report includes:
 PCB example:
 
 ```powershell
-diptrace-mcp-headless-gui roundtrip `
+py -m diptrace_mcp.headless_gui roundtrip `
   --diptrace-root "C:\Program Files\DipTrace" `
   --editor pcb `
   --project "C:\work\board.dip"
@@ -115,7 +116,7 @@ diptrace-mcp-headless-gui roundtrip `
 Schematic example:
 
 ```powershell
-diptrace-mcp-headless-gui roundtrip `
+py -m diptrace_mcp.headless_gui roundtrip `
   --diptrace-root "C:\Program Files\DipTrace" `
   --editor schematic `
   --project "C:\work\design.dch"

--- a/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
+++ b/docs/MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md
@@ -1,4 +1,6 @@
-# Manual Acceptance Checkpoint — 2026-08-09, updated 2026-08-13
+# Manual Acceptance Checkpoint — 2026-08-09, updated 2026-08-14
+
+> **Historical checkpoint with later completion record.** The eight-gate state below is the exact formal snapshot bound to `main@0bb09b4...`; it remains valid historical evidence. Subsequent accepted checkpoints completed the remaining Windows/client lifecycle work, including operator-confirmed Claude Desktop restart and custom-state preservation on a separate machine. The project-level blocking manual matrix is now **12 of 12 PASS** across the recorded accepted checkpoints. Do not reinterpret the older eight-gate identities as evidence collected on later code.
 
 This file is the durable recovery checkpoint for the real-system acceptance campaign.
 Its purpose is to prevent already completed manual gates from being repeated after an interrupted
@@ -6,7 +8,7 @@ session, a focused repair, a product-quality sub-campaign, or later documentatio
 
 The evidence archives themselves remain authoritative for individual observations. This document
 records the historical formal-acceptance identity, completed gates, the completed schematic-quality
-detour, and the next project-required validation sequence.
+detour, and the later completion of the formal lifecycle sequence.
 
 ## Current post-merge project checkpoint
 
@@ -38,14 +40,15 @@ confirmed no relevant production-code drift through the COMMON, Q1 Component Ang
 restart gates.
 
 Later repository development does not retroactively move those evidence identities. The schematic
-quality campaign is separate later evidence and does not rewrite the identity of the older formal
-gates.
+quality campaign and later lifecycle checkpoints are separate later evidence and do not rewrite the
+identity of the older formal gates.
 
 ## Formal acceptance progress
 
-Eight of the twelve canonical blocking manual gates are PASS.
+At the historical `0bb09b4...` checkpoint, eight of the twelve canonical blocking manual gates were
+PASS. The historical table is preserved below exactly as a record of that stage:
 
-| Gate | Result | Accepted identity / evidence note |
+| Gate | Historical result | Accepted identity / evidence note |
 | --- | --- | --- |
 | `diptrace_current_pcb_roundtrip` | **PASS** | Real DipTrace 5.3 PCB open/save/re-export accepted after the PCB serialization repairs. |
 | `diptrace_current_schematic_roundtrip` | **PASS** | Real DipTrace Schematic open/save/re-export accepted; authored connectivity survived native round-trip. |
@@ -55,18 +58,18 @@ Eight of the twelve canonical blocking manual gates are PASS.
 | `diptrace_mask_paste_courtyard_common_semantics` | **PASS** | MASK, PASTE, COURTYARD and COMMON all accepted. |
 | `diptrace_q1_component_angle` | **PASS** | Real DipTrace PCB Layout 5.3.0.3 angle/side semantics accepted on `0bb09b4...`. |
 | `codex_real_client_restart` | **PASS** | Real Codex Desktop restart/configuration/`get_capabilities` accepted on `0bb09b4...`. |
-| `claude_desktop_real_client_restart` | **WAIVED for current project campaign** | Not run and not PASS. The project accepts the residual interoperability risk after successful real Codex stdio MCP restart evidence and does not currently duplicate this client-specific check. |
+| `claude_desktop_real_client_restart` | **WAIVED at this historical stage** | The gate was not run at this checkpoint; direct Claude evidence was collected later on a separate machine. |
 
-The remaining project-required formal lifecycle gates are:
+Later accepted checkpoints completed:
 
-1. `windows_clean_install_repair_uninstall` — **PENDING / NEXT**.
-2. `elevated_plugin_install_profile_preservation` — **PENDING**.
-3. `custom_state_preservation` — **PENDING**.
+- `windows_clean_install_repair_uninstall` — **PASS**, including an operator-confirmed from-zero run on a separate new Windows machine;
+- `elevated_plugin_install_profile_preservation` — **PASS** on exact candidate `9af6da2`, Windows 11 build `26200`, DipTrace `5.3.0.2`;
+- `custom_state_preservation` — **PASS**, operator-confirmed from a separate machine;
+- `claude_desktop_real_client_restart` — **PASS**, operator-confirmed from a separate machine.
 
-The canonical repository manual-acceptance validator still defines Claude Desktop as a required gate
-and does not currently encode project-level waivers. Therefore it may continue to report the full
-canonical matrix as incomplete. Do not convert the waiver to PASS and do not claim direct Claude
-Desktop validation unless that real-client gate is actually run later.
+Therefore the project-level blocking manual matrix is **12 of 12 PASS across the accepted checkpoints**.
+The repository validator continues to require the Claude gate; the later direct evidence satisfies that
+project requirement without rewriting the earlier waiver as if it had been run on `0bb09b4...`.
 
 Claim-specific optional work remains separate: public-redownload smoke for future changed release
 bytes, external legal/Novarm review when required for a planned claim/activity, and a real openEMS
@@ -147,21 +150,14 @@ Codex evidence ZIP SHA256:
 
 `931001886200eb928fd3a376f76bd14856b2f5dcffd9d023208285623887fbe8`
 
-## Claude Desktop waiver
+## Claude Desktop disposition
 
-`claude_desktop_real_client_restart` was deliberately **WAIVED for the current project campaign** on
-2026-08-10.
+`claude_desktop_real_client_restart` was deliberately **WAIVED at the 2026-08-10 historical stage**
+while schematic product-quality validation took priority.
 
-Rationale: the real Codex client demonstrated the current server's stdio MCP startup, tool exposure,
-restart lifecycle and stable `get_capabilities` behavior. The project chooses not to spend current
-manual-validation time duplicating that lifecycle check in Claude Desktop.
-
-This is a risk acceptance, not evidence. Specifically:
-
-- Claude Desktop was not configured/restarted for this gate;
-- no Claude-specific process/configuration evidence exists;
-- the gate must not be recorded as PASS;
-- claims of direct Claude Desktop validation remain unsupported unless the gate is run later.
+That historical waiver remains part of the chronology and must not be relabelled as if the Claude
+check had been run on `0bb09b4...`. Later operator confirmation from a separate machine supplied
+direct Claude Desktop restart evidence, so the gate is now **PASS across the accepted checkpoints**.
 
 ## Schematic authoring/readability campaign — COMPLETE
 
@@ -191,19 +187,16 @@ This closes the initial schematic quality gate for the tested scope. It does not
 layout, arbitrary hand-authored junction-topology preservation, hierarchy support, automatic symbol
 rotation/pin-facing correctness, or universal DipTrace compatibility.
 
-## Next formal validation sequence
+## Formal validation sequence — COMPLETE
 
-The project no longer needs to keep the lifecycle campaign paused for schematic-quality work.
-The next project-required gate is:
+The lifecycle sequence that was paused for schematic-quality work is now complete across its accepted
+checkpoints: clean install/repair/uninstall, elevated plug-in/profile preservation, custom-state
+preservation, and Claude Desktop restart have all been closed with real-host/operator evidence in the
+scopes recorded above.
 
-`windows_clean_install_repair_uninstall`
-
-Then run, in order:
-
-1. `elevated_plugin_install_profile_preservation`;
-2. `custom_state_preservation`.
-
-Claude Desktop remains skipped by explicit project waiver, not by inference.
+No standing project rule requires replaying all 12 gates. Future lifecycle retests are impact-based and
+release-claim-based: rerun only the gates plausibly affected by changed production code/artifacts, plus
+reasonable adjacent smoke coverage.
 
 ## Resume rules
 
@@ -211,10 +204,10 @@ When resuming work from this checkpoint:
 
 - do not restart completed historical gates;
 - do not replay schematic cases 01–18 without an impact-based production change or a genuinely new claim;
+- do not replay the completed 12-gate manual matrix without an impact- or release-claim-based reason;
 - treat `0bb09b4...` as the accepted production-code identity for the eight historical formal PASS gates;
 - treat `6bfb656...` as the production merge identity for the closed schematic-quality fixes;
-- treat Claude Desktop as WAIVED, not PASS;
-- if a later project decision requires direct Claude evidence, run it as a fresh gate rather than rewriting the waiver;
+- preserve the historical Claude waiver as chronology while treating the later direct Claude evidence as PASS on its own accepted checkpoint;
 - if relevant production code changes, record the new candidate explicitly and rerun only the evidence plausibly affected by that code change;
 - keep historical FAIL/QUALITY FAIL/SEMANTIC FAIL/INVALID ATTEMPT records immutable;
 - distinguish operator/path/seed mistakes from product defects;

--- a/docs/MCP_DISTRIBUTION.md
+++ b/docs/MCP_DISTRIBUTION.md
@@ -94,9 +94,9 @@ Directory publication is distribution metadata, not real-host acceptance evidenc
 
 Manual acceptance is tracked in [ROADMAP.md](ROADMAP.md) and the generated acceptance tooling.
 
-The latest accepted manual-production checkpoint has 8 of 12 canonical blocking gates PASS. Q1 Component Angle and real Codex restart are PASS. Claude Desktop restart is WAIVED for the current campaign, not PASS. Windows lifecycle is the next project-required formal gate when acceptance resumes.
+The accepted manual-production checkpoints now have all 12 blocking gates PASS. Q1 Component Angle, real Codex and Claude Desktop restarts, clean Windows lifecycle, elevated plug-in/profile preservation and custom-state preservation are PASS. The latter Claude/custom-state evidence is operator-confirmed from a separate machine.
 
-The canonical validator intentionally remains stricter than the project-level Claude waiver; do not weaken it merely to make the matrix appear complete.
+Evidence remains bound to its recorded checkpoint and must not be copied to changed release bytes without an impact-based retest.
 
 Example acceptance pack preparation:
 

--- a/docs/PLACEMENT_ENGINE.md
+++ b/docs/PLACEMENT_ENGINE.md
@@ -49,9 +49,10 @@ Current implementation includes:
 - bounded deterministic multi-candidate search;
 - readability, movement and estimated-interconnect scoring;
 - pin-aware joint routing score of hypothetical candidates;
-- route-feedback-driven bounded placement repair.
+- route-feedback-driven bounded placement repair;
+- selective atomic replacement of affected existing wire geometry when placement moves touch explicit sheet-local nets.
 
-Important boundary: placement planners refuse already-wired schematics by default. Moving symbols while leaving existing wire geometry unchanged would degrade connectivity presentation. Selective affected-wire reroute/replacement must be composed atomically with placement before that path is enabled broadly.
+Important boundary: the older placement-only planners may still refuse already-wired schematics because moving symbols while leaving existing wire geometry unchanged would degrade connectivity presentation. The dedicated atomic reroute planner closes that gap for supported cases by composing affected-wire deletion, component movement and replacement-wire authoring into one dependency-safe semantic batch. It fails closed when affected endpoints or replacement routes cannot be rebuilt safely and does not rewrite unaffected explicit wire geometry.
 
 Automatic pin-facing rotation also remains conservative until the relevant real-host angle/rotation semantics are sufficiently verified.
 
@@ -120,7 +121,7 @@ The Generation D benchmark catalog is synthetic-regression-only until the docume
 ## Current limitations
 
 - no globally optimal placer claim;
-- schematic selective reroute transaction after movement is still pending;
+- atomic affected-net reroute is implemented, but arbitrary hand-authored junction topology is not preserved as a visual constraint when an affected explicit net is rebuilt;
 - schematic automatic rotation/pin-facing is evidence-limited;
 - Generation A proximity/noise/thermal/current-return terms are not field/thermal/PI simulation;
 - Generations B-D are bounded evidence-aware layers, not manufacturing/EMC sign-off;

--- a/docs/RELEASE_0_2_1_CHECKLIST.md
+++ b/docs/RELEASE_0_2_1_CHECKLIST.md
@@ -58,27 +58,21 @@ Q1 manual acceptance established real DipTrace angle semantics on the developmen
 
 Codex restart acceptance used Codex Desktop `26.803.5235.0`; both restarts exposed 159 tools and returned identical `get_capabilities` evidence. Production code remained unchanged.
 
-The canonical matrix therefore has **8 of 12 gates PASS**.
+The historical checkpoint had **8 of 12 gates PASS**. Later evidence raises the accepted checkpoints to **12 of 12 blocking gates PASS**: clean Windows install/repair/uninstall, including an operator-confirmed from-zero run on a separate new machine, elevated Program Files plug-in/profile preservation, custom-state preservation and Claude Desktop restart are also PASS. The latter two are operator-confirmed from a separate machine.
 
-## Claude Desktop waiver and intentional pause
+## Historical Claude Desktop waiver and pause
 
-`claude_desktop_real_client_restart` has been deliberately **WAIVED for the current project campaign**.
+`claude_desktop_real_client_restart` was initially **WAIVED** while schematic product-quality validation took priority.
 
-It was not run and must not be represented as PASS. The project accepts the residual client-specific interoperability risk because the real Codex gate already demonstrated stdio MCP startup, tool exposure, actual process restart and stable `get_capabilities` behavior. No direct Claude Desktop evidence is claimed.
+Later operator confirmation from a separate machine supplied the missing direct Claude Desktop evidence, so the gate is now PASS across the accepted checkpoints.
 
-The repository's canonical manual-acceptance validator still treats Claude Desktop as a required gate and does not encode this project-level waiver. It may therefore continue to report the canonical matrix as incomplete. Do not weaken the validator or fabricate a PASS solely to remove that warning.
+The repository's canonical manual-acceptance validator correctly continues to treat Claude Desktop as a required gate.
 
-The project is intentionally pausing the remaining Windows/profile lifecycle sequence to validate core product quality first: schematic authoring/readability in real DipTrace.
+The project then paused the remaining Windows/profile lifecycle sequence to validate schematic authoring/readability in real DipTrace first.
 
-This separate validation should build small real circuits and inspect electrical correctness, component placement, wire routing, text/label collisions, junction clarity and native save/reopen/re-export behavior.
+That separate validation completed its small real-circuit campaign and native quality checks.
 
-Remaining project-required formal gates after the pause:
-
-- [ ] Clean Windows 11 install, repair and uninstall using the applicable release bytes.
-- [ ] Elevated Program Files plug-in install while retaining the original user profile.
-- [ ] Pre-existing custom-state preservation across install/repair/uninstall.
-
-If direct Claude Desktop validation becomes important later, run it as a fresh real-client gate and replace the waiver with real evidence at that time; do not retroactively label the current waiver PASS.
+Operator-confirmed custom-state preservation and Claude Desktop restart evidence from a separate machine complete the remaining formal gates.
 
 Claim-specific optional work remains a future public-redownload smoke when release bytes change, external legal/Novarm review when required for a planned claim/activity, and a real openEMS run only if external-solver validation is claimed.
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -27,7 +27,7 @@ The `v0.2.1` release record correctly says Q1 Component Angle was `NOT_RUN` for 
 
 A later private/manual campaign on the accepted production checkpoint completed Q1 as PASS. That later observation does not rewrite the historical release record or automatically upgrade `v0.2.1` artifact claims.
 
-Likewise, `claude_desktop_real_client_restart` is WAIVED for the current project campaign, not PASS. The canonical validator intentionally remains conservative.
+The accepted project-level manual matrix later reached 12 of 12 blocking gates PASS across its recorded checkpoints. `claude_desktop_real_client_restart` and `custom_state_preservation`, which were previously WAIVED/pending, are operator-confirmed PASS from a separate machine. That later evidence remains exact-checkpoint evidence and does not retroactively change the immutable `v0.2.1` release record.
 
 ## 1. Select and freeze the next version
 
@@ -106,7 +106,7 @@ For a release claiming Windows/live DipTrace/client integration, consider:
 
 Do not broaden the published compatibility statement beyond the completed matrix.
 
-For the current project campaign, Windows lifecycle is the next formal gate when acceptance resumes. Claude Desktop restart remains waived rather than fabricated as PASS.
+The current project's 12-gate manual matrix is complete for its recorded checkpoints. A future release does not inherit those PASS results automatically: rerun only the gates affected by changed production code/artifacts or required by the new release claim, plus reasonable adjacent smoke coverage.
 
 ## 4. Build final assets from the frozen commit
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@ This roadmap separates three states:
 
 Implementation never implies universal DipTrace compatibility. Historical evidence stays bound to the production identity that was actually tested.
 
-## Current checkpoint — 2026-08-13
+## Current checkpoint — 2026-08-14
 
 The current source/package version is `0.2.1`. The immutable `v0.2.1` release and PyPI package are published; post-release development is tracked separately.
 
@@ -41,11 +41,9 @@ PASS:
 - Q1 Component Angle GUI/re-export;
 - real Codex Desktop restart/configuration/`get_capabilities`.
 
-The canonical matrix therefore has 8 of 12 blocking manual gates PASS.
+The canonical matrix therefore has 8 of 12 blocking manual gates PASS at that historical checkpoint.
 
-`claude_desktop_real_client_restart` is **WAIVED for the current project campaign**, not PASS.
-
-The real-host lifecycle track has completed a clean product-state install/repair/uninstall run and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`. The strict pristine-machine qualifier remains explicit for the former. The next campaign gate is `custom_state_preservation`.
+Later operator-confirmed evidence from a separate machine completed `claude_desktop_real_client_restart` and `custom_state_preservation`. Together with `windows_clean_install_repair_uninstall`, including a from-zero run on a separate new Windows machine, and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`, all 12 blocking gates are PASS across the accepted checkpoints.
 
 # Schematic track
 
@@ -230,13 +228,21 @@ Still pending real acceptance:
 - verified action macros/calibration for the exact editor/version/configuration;
 - staged via/layer-transition replay and other unverified editor gestures.
 
+# Headless native GUI track
+
+**Status: Windows isolation primitive and packaged helper implemented; real DipTrace actions remain exact-host evidence.**
+
+`headless_gui.py` creates an isolated Win32 desktop inside the current interactive session, launches a worker and DipTrace there, and performs only bounded automation. It never switches the user's input desktop and has no physical mouse/keyboard fallback. The current native action is open -> Save -> close for PCB/Schematic/Component/Pattern editors.
+
+Source checkouts invoke it with `py -m diptrace_mcp.headless_gui`; Windows packaged builds include `diptrace_mcp_headless_gui.exe` under the helper tools directory. Hosted CI verifies desktop isolation and packaging without claiming licensed DipTrace UI compatibility. See [HEADLESS_GUI.md](HEADLESS_GUI.md).
+
 # Documentation/CI drift protection
 
 **Status: implemented.**
 
-`scripts/check_documentation_state.py` verifies the frozen public-tool count, current EDA module representation, semantic current-state markers, the mandatory cinematic preflight boundary and the package-only library mutation registration state. `tests/test_documentation_state.py` runs the checker through the normal CI test matrix.
+`scripts/check_documentation_state.py` verifies the frozen public-tool count, current EDA module representation, semantic current-state markers, the mandatory cinematic preflight boundary, package-only library mutation registration, completed 12/12 acceptance wording, current selective-reroute claims and the headless source command contract. `tests/test_documentation_state.py` runs the checker through the normal CI test matrix.
 
-Historical dated release/acceptance/audit records remain excluded from this freshness rule.
+Historical dated release/acceptance/audit records remain excluded from current-state freshness assertions.
 
 # Public contracts
 
@@ -250,15 +256,15 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 # Next project sequence
 
 1. Keep the completed schematic cases 01–18 closed unless an impact-based production change requires a focused rerun.
-2. Run `custom_state_preservation`; do not broaden the earlier clean product-state result into a pristine-machine claim.
+2. Keep the completed 12-gate manual matrix closed unless an impact-based production change requires a focused rerun.
 3. Continue PCB whole-board/native quality work when stronger PCB claims are the active product priority.
-4. Treat cinematic exact-UI acceptance and any future public library-write API as separate claim/product tracks.
+4. Treat cinematic exact-UI acceptance, headless native-action expansion and any future public library-write API as separate claim/product tracks.
 
 # Phase summary
 
 | Area | Current status |
 | --- | --- |
-| manual acceptance | 8 canonical PASS gates on the historical checkpoint; Claude WAIVED; elevated profile gate PASS on `9af6da2`; custom-state gate next |
+| manual acceptance | all 12 blocking gates PASS across the accepted checkpoints |
 | schematic intent/motifs | implemented + builtin heuristic motifs |
 | schematic placement | bounded implementation |
 | schematic route/joint repair | bounded implementation |
@@ -274,6 +280,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 | evidence reports | deterministic review-only report pipeline implemented |
 | library mutation public API | package-level request/preview prepared; public MCP registration pending |
 | cinematic | presentation + mandatory preflight implemented; exact UI acceptance pending |
+| headless GUI | hidden Win32 desktop helper implemented; real DipTrace native actions remain claim-specific evidence |
 | documentation drift | evergreen code/docs guard implemented and CI-tested |
 
 # Permanent limitations / non-claims
@@ -287,4 +294,4 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 - Cinematic replay is presentation automation, not engineering acceptance evidence.
 - Evidence reports do not grant trust/PASS.
 - The completed schematic campaign proves only its recorded scope and does not imply arbitrary hierarchy/topology/global-optimality support.
-- The project does not claim Novarm/DipTrace endorsement, universal compatibility, signed binaries, independent review, production readiness, direct Claude Desktop validation or globally optimal schematic/PCB layout.
+- The project does not claim Novarm/DipTrace endorsement, universal DipTrace or MCP-client compatibility, signed binaries, independent review, production readiness or globally optimal schematic/PCB layout.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -59,9 +59,9 @@ Cinematic replay remains presentation automation, not an alternate engineering a
 
 ### 7. Windows lifecycle acceptance
 
-The current project campaign has 8 canonical manual gates PASS. Claude Desktop restart is explicitly WAIVED, not PASS.
+The accepted checkpoints have all 12 blocking manual gates PASS.
 
-A clean product-state install/repair/uninstall run and exact-candidate `elevated_plugin_install_profile_preservation` are now complete on the real Windows host. The former retains its stricter pristine-machine wording qualifier. `custom_state_preservation` is next; CI installer tests remain implementation evidence, not a replacement for real-host gates.
+`windows_clean_install_repair_uninstall`, including an operator-confirmed from-zero run on a separate new Windows machine, and exact-candidate `elevated_plugin_install_profile_preservation` are complete. Custom-state preservation and Claude Desktop restart are also operator-confirmed PASS on a separate machine. CI installer tests remain implementation evidence, not a replacement for real-host gates.
 
 ### 8. Native manufacturing output
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -21,7 +21,7 @@ The coverage badge represents the combined 90% gate. `scripts/check_coverage.py`
 
 The static-analysis job includes Ruff, strict Mypy, release metadata, skill sync/generation, privacy/provenance/compliance checks, event-loop audit, coverage badge generation, MCP discovery budget/snapshot, release artifact audit, format inventory and generated probe-pack verification.
 
-This development pass also adds `scripts/check_documentation_state.py` as an evergreen documentation/code drift gate. Historical dated evidence/release/audit files are intentionally excluded from freshness assertions.
+`scripts/check_documentation_state.py` is an evergreen documentation/code drift gate. In addition to current tool/module markers, it rejects known stale current-state acceptance/reroute claims and obsolete source commands for the headless GUI worker. Historical dated evidence/release/audit files remain outside current-state freshness assertions.
 
 `.github/workflows/ci.yml` remains the source of truth for the exact required commands.
 
@@ -162,16 +162,16 @@ Changing a version string does not convert one evidence class into another.
 
 The historical formal manual-production checkpoint remains documented in `MANUAL_ACCEPTANCE_CHECKPOINT_2026-08-09.md` and bound to `main@0bb09b4b3af40a5a3d1a875fab885430a2d251ba` for the eight canonical PASS gates collected there.
 
-At that checkpoint:
+At that historical checkpoint:
 
-- 8 of 12 canonical blocking manual gates are PASS;
-- Q1 Component Angle is PASS;
-- real Codex restart is PASS;
-- Claude Desktop restart is WAIVED, not PASS.
+- 8 of 12 canonical blocking manual gates were PASS;
+- Q1 Component Angle was PASS;
+- real Codex restart was PASS;
+- Claude Desktop restart was not run and was recorded as a project waiver at that stage.
 
 A separate post-release schematic product-quality campaign subsequently completed cases 01–18 and its bounded fixes were merged by PR #90. That later evidence does not rewrite the historical eight-gate identities, and the historical gates do not automatically transfer to newer code.
 
-Later real-host lifecycle evidence completed a clean product-state install/repair/uninstall run (with the strict pristine-machine qualifier retained) and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`. The next campaign gate is `custom_state_preservation`.
+Later real-host lifecycle evidence completed `windows_clean_install_repair_uninstall`, including an operator-confirmed from-zero run on a separate new Windows machine, and `elevated_plugin_install_profile_preservation` on exact candidate `9af6da2`. Subsequent operator-confirmed evidence from a separate machine completed `custom_state_preservation` and the Claude Desktop restart gate. All 12 blocking gates are therefore PASS across the accepted checkpoints.
 
 ## Typical local validation
 

--- a/docs/WINDOWS_INSTALLER.md
+++ b/docs/WINDOWS_INSTALLER.md
@@ -71,7 +71,7 @@ When a DipTrace installation under protected Program Files requires elevation, o
 
 The configurator supports project-owned configuration for supported MCP clients while preserving unknown existing fields and using backup/atomic-update rules.
 
-A configuration change requires an actual client restart before it can be considered tested. The accepted project campaign has real Codex restart evidence. Claude Desktop restart is currently WAIVED for that campaign, not PASS.
+A configuration change requires an actual client restart before it can be considered tested. The accepted project campaign has real Codex restart evidence and operator-confirmed Claude Desktop restart evidence from a separate machine.
 
 ## Build
 
@@ -107,10 +107,11 @@ CI evidence is necessary but not equivalent to the project-level clean real-mach
 
 Post-release real-host validation now has:
 
-- a clean product-state install/repair/uninstall PASS, while the stricter pristine-machine/VM wording remains a documented qualifier;
-- `elevated_plugin_install_profile_preservation` PASS on exact candidate `9af6da2` and Windows 11 build `26200` with DipTrace `5.3.0.2`.
+- `windows_clean_install_repair_uninstall` PASS, including operator-confirmed from-zero installation on a separate new Windows machine;
+- `elevated_plugin_install_profile_preservation` PASS on exact candidate `9af6da2` and Windows 11 build `26200` with DipTrace `5.3.0.2`;
+- `custom_state_preservation` PASS by operator confirmation from a separate machine.
 
-The next campaign gate is `custom_state_preservation`. The elevated gate found and fixed protected-root detection and a flattened frozen-configurator runtime; schematic/native gates were unaffected and were not repeated.
+The formal lifecycle sequence is complete. The elevated gate found and fixed protected-root detection and a flattened frozen-configurator runtime; schematic/native gates were unaffected and were not repeated.
 
 These gates should be run against the exact production candidate/artifacts whose compatibility is being claimed. Do not copy a PASS from an older candidate onto later `main` merely because the installer code looks similar.
 

--- a/scripts/check_documentation_state.py
+++ b/scripts/check_documentation_state.py
@@ -55,6 +55,39 @@ SEMANTIC_DOC_MARKERS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+CURRENT_ACCEPTANCE_DOCS = (
+    "README.md",
+    "CHANGELOG.md",
+    "CHANGELOG_NEXT.md",
+    "docs/ROADMAP.md",
+    "docs/TESTING.md",
+    "docs/TECH_DEBT.md",
+    "docs/MCP_DISTRIBUTION.md",
+    "docs/RELEASE_PROCESS.md",
+    "docs/AUTOMATABLE_ROADMAP_CLOSURE.md",
+    "docs/EDA_INTELLIGENCE.md",
+)
+
+CURRENT_ACCEPTANCE_MARKERS = (
+    "all 12 blocking manual gates are pass",
+    "all 12 blocking manual gates pass",
+    "all 12 blocking gates are pass",
+    "all 12 blocking gates are therefore pass",
+    "all 12 blocking gates pass",
+    "12 of 12 blocking gates pass",
+    "12 of 12 blocking manual gates pass",
+)
+
+GLOBAL_STALE_ACCEPTANCE_PHRASES = (
+    "claude desktop restart is waived",
+    "claude desktop restart remains waived",
+    "claude_desktop_real_client_restart` is explicitly waived for the current campaign",
+    "windows lifecycle gates remain pending",
+    "windows lifecycle is the next formal gate",
+    "custom_state_preservation` is next",
+    "next campaign gate is `custom_state_preservation`",
+)
+
 STALE_PHRASES: dict[str, tuple[str, ...]] = {
     "CHANGELOG_NEXT.md": (
         "selective atomic re-route/replacement of existing schematic wires after "
@@ -69,6 +102,12 @@ STALE_PHRASES: dict[str, tuple[str, ...]] = {
     ),
     "docs/USAGE.md": (
         "Selective atomic placement + affected-wire replacement remains future work",
+    ),
+    "docs/DOMAIN_MODEL.md": (
+        "selective atomic replacement of existing wires after placement repair remains future work",
+    ),
+    "docs/PLACEMENT_ENGINE.md": (
+        "schematic selective reroute transaction after movement is still pending",
     ),
 }
 
@@ -129,12 +168,47 @@ def check_documentation_state(root: Path) -> list[str]:
             if marker.casefold() not in folded:
                 errors.append(f"{relative}: missing current-state marker: {marker}")
 
+    for relative in CURRENT_ACCEPTANCE_DOCS:
+        text = _read_text(root, relative, errors)
+        folded = text.casefold()
+        if not any(marker in folded for marker in CURRENT_ACCEPTANCE_MARKERS):
+            errors.append(
+                f"{relative}: does not record the completed 12/12 blocking manual matrix"
+            )
+        for phrase in GLOBAL_STALE_ACCEPTANCE_PHRASES:
+            if phrase in folded:
+                errors.append(
+                    f"{relative}: contains stale current acceptance claim: {phrase}"
+                )
+
     for relative, phrases in STALE_PHRASES.items():
         text = _read_text(root, relative, errors)
         folded = text.casefold()
         for phrase in phrases:
             if phrase.casefold() in folded:
                 errors.append(f"{relative}: contains stale current-state claim: {phrase}")
+
+    headless_doc = _read_text(root, "docs/HEADLESS_GUI.md", errors)
+    headless_folded = headless_doc.casefold()
+    if "py -m diptrace_mcp.headless_gui smoke" not in headless_folded:
+        errors.append("docs/HEADLESS_GUI.md: source smoke command must use the module entry point")
+    if "py -m diptrace_mcp.headless_gui doctor" not in headless_folded:
+        errors.append("docs/HEADLESS_GUI.md: source doctor command must use the module entry point")
+    if "py -m diptrace_mcp.headless_gui roundtrip" not in headless_folded:
+        errors.append(
+            "docs/HEADLESS_GUI.md: source roundtrip command must use the module entry point"
+        )
+    for obsolete_command in (
+        "\ndiptrace-mcp-headless-gui --help",
+        "\ndiptrace-mcp-headless-gui smoke",
+        "\ndiptrace-mcp-headless-gui doctor",
+        "\ndiptrace-mcp-headless-gui roundtrip",
+    ):
+        if obsolete_command in headless_folded:
+            errors.append(
+                "docs/HEADLESS_GUI.md: advertises nonexistent source console command: "
+                f"{obsolete_command.strip()}"
+            )
 
     cinematic_host = _read_text(
         root,


### PR DESCRIPTION
## Summary

- reconcile evergreen documentation with the completed **12/12 blocking manual acceptance matrix** while preserving exact historical checkpoint/release identities;
- update schematic placement/domain docs to reflect the implemented selective atomic affected-net reroute path and its actual remaining topology-preservation limitation;
- correct source-install commands for the Windows headless GUI worker and document the packaged helper boundary;
- update roadmap/changelogs/release/testing/installer/distribution docs with the current post-`v0.2.1` state;
- strengthen `scripts/check_documentation_state.py` so CI rejects known stale acceptance, reroute and headless-source-CLI claims.

## Historical/evidence boundaries

- the historical `main@0bb09b4...` checkpoint remains an exact eight-PASS-gate snapshot;
- later accepted checkpoints complete Windows lifecycle, custom-state preservation and direct Claude Desktop restart evidence, giving 12/12 PASS across the recorded accepted checkpoints;
- immutable `v0.2.1` release-time Q1 `NOT_RUN` remains historical release truth and is not rewritten by later Q1 PASS evidence;
- the detailed 2026-08-10 schematic campaign log remains a dated chronological evidence record; current roadmap/checkpoint docs explicitly supersede its earlier pause/waiver state;
- PASS evidence is not automatically transferred to changed future release bytes; retests remain impact/claim based.

## Coverage

This PR intentionally keeps the documented thresholds at **90% combined supported-environment coverage** and **85% geometry-enabled Linux-only coverage**. It does not infer a 95% threshold from the title of PR #96.

## Scope

No MCP runtime/EDA production implementation is changed. The only Python change is the repository documentation-state CI guard.

## Verification

- branch is one DCO-signed commit directly on current `main@855a60136199cce0d83eb39d5ead9165f700180c`;
- changed runtime surface: none;
- public MCP contract remains 159 tools;
- GitHub CI is the authoritative execution check for the updated documentation-state guard.