### PR TITLE
feat: add selectable hidden/native launch mode to headless GUI worker

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -66,7 +66,7 @@ jobs:
           if-no-files-found: error
 
   build-installer:
-    name: Build Inno Setup and portable assets
+    name: Build split Inno Setup and portable assets
     needs: [build-server, build-bridge]
     runs-on: windows-latest
     steps:
@@ -100,7 +100,7 @@ jobs:
           $iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
           if (-not (Test-Path -LiteralPath $iscc)) { throw "Pinned ISCC.exe was not installed" }
           "ISCC_PATH=$iscc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Build unsigned installer and portable fallback
+      - name: Build unsigned per-user installer, admin plug-in installer, and portable fallback
         shell: pwsh
         run: .\scripts\build_windows_installer.ps1 -Version 0.2.1 -PythonCommand python -BridgePath .\plugin\dist\diptrace_mcp_bridge.exe -IsccPath "$env:ISCC_PATH" -OutputDir dist\windows-artifacts -SkipBuild
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -110,7 +110,7 @@ jobs:
           if-no-files-found: error
 
   installer-smoke:
-    name: Silent install, upgrade, uninstall, and stdio smoke
+    name: Split install, upgrade, uninstall, and stdio smoke
     needs: build-installer
     runs-on: windows-latest
     steps:
@@ -134,10 +134,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "portable server smoke failed" }
           New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\portable-workspace" | Out-Null
           Copy-Item -LiteralPath .\tests\fixtures\pcb.xml -Destination "$env:RUNNER_TEMP\portable-workspace\pcb.xml"
-      - name: Silent server-only install with spaces and Unicode workspace
+          $checksums = Get-Content .\dist\windows-artifacts\SHA256SUMS.txt -Raw
+          if ($checksums -notmatch 'DipTrace-MCP-Setup-') { throw "per-user installer missing from release checksum manifest" }
+          if ($checksums -notmatch 'DipTrace-MCP-Plugin-Setup-') { throw "plug-in installer missing from release checksum manifest" }
+      - name: Silent per-user install with spaces and Unicode workspace
         shell: pwsh
         run: |
-          $setup = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe | Select-Object -First 1
+          $setup = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe |
+            Where-Object { $_.Name -notlike '*Plugin*' } | Select-Object -First 1
           $root = Join-Path $env:RUNNER_TEMP 'DipTrace MCP installer smoke'
           $install = Join-Path $root 'installed server'
           $workspace = Join-Path $root 'Проекты DipTrace'
@@ -145,57 +149,36 @@ jobs:
           $setupLog = Join-Path $root 'setup.log'
           New-Item -ItemType Directory -Force -Path $workspace | Out-Null
           Set-Content -LiteralPath (Join-Path $workspace 'fixture.txt') -Value 'preserve' -Encoding utf8
-          $setupArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=`"$setupLog`"", '/TYPE=server', '/SERVERONLY', '/CLIENT=none', "/DIR=`"$install`"", "/WORKSPACE=`"$workspace`"", "/STATEDIR=`"$state`"")
+          $setupArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=`"$setupLog`"", '/TYPE=server', '/CLIENT=none', "/DIR=`"$install`"", "/WORKSPACE=`"$workspace`"", "/STATEDIR=`"$state`"")
           $setupProcess = Start-Process -FilePath $setup.FullName -ArgumentList $setupArgs -Wait -PassThru
-          $setupExit = $setupProcess.ExitCode
-          if ($setupExit -ne 0) {
-            Write-Host "Silent server-only setup exit code: $setupExit"
+          if ($setupProcess.ExitCode -ne 0) {
             if (Test-Path -LiteralPath $setupLog) { Get-Content -LiteralPath $setupLog }
-            $stateLogs = Join-Path $state 'logs'
-            if (Test-Path -LiteralPath $stateLogs) {
-              Get-ChildItem -LiteralPath $stateLogs -File | ForEach-Object {
-                Write-Host "--- $($_.FullName) ---"
-                Get-Content -LiteralPath $_.FullName
-              }
-            }
-            throw "silent server-only install failed"
+            throw "silent per-user install failed"
           }
           $server = Join-Path $install 'app\diptrace_mcp_server.exe'
           & $server --help
           if ($LASTEXITCODE -ne 0) { throw "installed server --help failed" }
+          if (Test-Path -LiteralPath (Join-Path $install 'bridge')) { throw "per-user installer must not install bridge payload" }
+          if (Test-Path -LiteralPath (Join-Path $install 'settings-templates')) { throw "per-user installer must not install settings payload" }
+          if (Test-Path -LiteralPath (Join-Path $install 'tools\install_plugin.ps1')) { throw "per-user installer must not install an elevation script" }
           $manifestPath = Join-Path $install 'installation-manifest.json'
           if (-not (Test-Path -LiteralPath $manifestPath)) { throw "installation manifest missing" }
           $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-          if ($manifest.PSObject.Properties.Name -notcontains 'created_by') { throw "installer did not write the runtime installation manifest" }
+          if ($manifest.PSObject.Properties.Name -notcontains 'created_by') { throw "installer did not write runtime manifest" }
           $stateMarker = Join-Path $install 'state-dir.txt'
           if (-not (Test-Path -LiteralPath $stateMarker)) { throw "installer state marker missing" }
           $actualState = (Get-Content -LiteralPath $stateMarker -Raw).Trim()
-          Write-Host "Installer manifest state_dir: $($manifest.state_dir)"
-          Write-Host "Installer state marker: $actualState"
-          Write-Host "Expected state directory: $state"
           if ([IO.Path]::GetFullPath($actualState) -ne [IO.Path]::GetFullPath($state)) { throw "installer resolved a different state directory" }
           $stateLogs = Join-Path $state 'logs'
-          if (-not (Test-Path -LiteralPath $stateLogs)) {
-            throw "install log directory missing"
-          }
           if (-not (Get-ChildItem -LiteralPath $stateLogs -Filter 'install-*.log')) { throw "install log missing" }
           Set-Content -LiteralPath (Join-Path $state 'keep.txt') -Value 'keep' -Encoding utf8
           $uninstallProcess = Start-Process -FilePath (Join-Path $install 'unins000.exe') -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART') -Wait -PassThru
           if ($uninstallProcess.ExitCode -ne 0) { throw "silent default uninstall failed" }
           if (-not (Test-Path -LiteralPath (Join-Path $workspace 'fixture.txt'))) { throw "workspace was removed" }
           if (-not (Test-Path -LiteralPath (Join-Path $state 'keep.txt'))) { throw "state was removed by default" }
-      - name: Full install, repair/idempotency, and optional state removal
+      - name: Split user and administrator plug-in lifecycle
         shell: pwsh
         run: |
-          $setup = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe | Select-Object -First 1
-          $root = Join-Path $env:RUNNER_TEMP 'DipTrace MCP full smoke'
-          $diptrace = Join-Path $root 'DipTrace5'
-          $install = Join-Path $root 'installed full'
-          $workspace = Join-Path $root 'Рабочие проекты'
-          $state = Join-Path $root 'state'
-          New-Item -ItemType Directory -Force -Path $diptrace, $workspace | Out-Null
-          Set-Content -LiteralPath (Join-Path $diptrace 'Pcb.exe') -Value 'synthetic module' -Encoding utf8
-          Set-Content -LiteralPath (Join-Path $workspace 'fixture.txt') -Value 'preserve' -Encoding utf8
           function Invoke-BoundedInstallerProcess {
             param(
               [Parameter(Mandatory = $true)] [string]$FilePath,
@@ -205,7 +188,6 @@ jobs:
             Write-Host "Starting $Label"
             $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
             if (-not $process.WaitForExit(180000)) {
-              Write-Host "$Label exceeded the 180 second CI bound; terminating its process tree."
               & taskkill.exe /PID $process.Id /T /F | Out-Host
               throw "$Label timed out"
             }
@@ -213,32 +195,56 @@ jobs:
             Write-Host "$Label exited with code $($process.ExitCode)"
             return $process.ExitCode
           }
-          $fullSetupArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/TYPE=full', '/CLIENT=none', "/DIR=`"$install`"", "/DIPTRACE=`"$diptrace`"", "/WORKSPACE=`"$workspace`"", "/STATEDIR=`"$state`"")
-          if ((Invoke-BoundedInstallerProcess -FilePath $setup.FullName -ArgumentList $fullSetupArgs -Label 'silent full install') -ne 0) { throw "silent full install failed" }
+
+          $setup = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe |
+            Where-Object { $_.Name -notlike '*Plugin*' } | Select-Object -First 1
+          $pluginSetup = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Plugin-Setup-*.exe | Select-Object -First 1
+          $root = Join-Path $env:RUNNER_TEMP 'DipTrace MCP split smoke'
+          $diptrace = Join-Path $root 'DipTrace5'
+          $install = Join-Path $root 'user install'
+          $pluginMeta = Join-Path $root 'admin plugin metadata'
+          $workspace = Join-Path $root 'Рабочие проекты'
+          $state = Join-Path $root 'state'
+          New-Item -ItemType Directory -Force -Path $diptrace, $workspace | Out-Null
+          Set-Content -LiteralPath (Join-Path $diptrace 'Pcb.exe') -Value 'synthetic module' -Encoding utf8
+          Set-Content -LiteralPath (Join-Path $workspace 'fixture.txt') -Value 'preserve' -Encoding utf8
+
+          $userArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/TYPE=full', '/CLIENT=none', "/DIR=`"$install`"", "/WORKSPACE=`"$workspace`"", "/STATEDIR=`"$state`"")
+          if ((Invoke-BoundedInstallerProcess -FilePath $setup.FullName -ArgumentList $userArgs -Label 'per-user install') -ne 0) { throw "per-user install failed" }
           foreach ($module in @('Pcb','Schematic','CompEdit','PattEdit')) {
-            if (-not (Test-Path -LiteralPath (Join-Path $diptrace "Plugins\$module\DipTraceMCP\settings.xml"))) { throw "settings missing for $module" }
+            if (Test-Path -LiteralPath (Join-Path $diptrace "Plugins\$module\DipTraceMCP")) {
+              throw "per-user installer crossed the privilege boundary for $module"
+            }
           }
+
+          $pluginArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=`"$pluginMeta`"", "/DIPTRACE=`"$diptrace`"")
+          if ((Invoke-BoundedInstallerProcess -FilePath $pluginSetup.FullName -ArgumentList $pluginArgs -Label 'administrator plug-in install') -ne 0) { throw "plug-in install failed" }
+          foreach ($module in @('Pcb','Schematic','CompEdit','PattEdit')) {
+            $target = Join-Path $diptrace "Plugins\$module\DipTraceMCP"
+            if (-not (Test-Path -LiteralPath (Join-Path $target 'settings.xml'))) { throw "settings missing for $module" }
+            if (-not (Test-Path -LiteralPath (Join-Path $target 'diptrace_mcp_bridge.exe'))) { throw "bridge missing for $module" }
+          }
+          if (-not (Test-Path -LiteralPath (Join-Path $pluginMeta 'payload\diptrace_mcp_bridge.exe'))) { throw "admin-owned plug-in payload missing" }
+
+          if ((Invoke-BoundedInstallerProcess -FilePath $setup.FullName -ArgumentList $userArgs -Label 'per-user repair') -ne 0) { throw "per-user repair failed" }
+          if ((Invoke-BoundedInstallerProcess -FilePath $pluginSetup.FullName -ArgumentList $pluginArgs -Label 'plug-in repair') -ne 0) { throw "plug-in repair failed" }
+
           $ownedStateMarker = Join-Path $state 'records\owned.txt'
           $unknownStateMarker = Join-Path $state 'user-state.txt'
           New-Item -ItemType Directory -Force -Path (Split-Path -Parent $ownedStateMarker) | Out-Null
           Set-Content -LiteralPath $ownedStateMarker -Value 'remove' -Encoding utf8
           Set-Content -LiteralPath $unknownStateMarker -Value 'preserve' -Encoding utf8
-          if ((Invoke-BoundedInstallerProcess -FilePath $setup.FullName -ArgumentList $fullSetupArgs -Label 'repair/second install') -ne 0) { throw "repair/second install failed" }
-          $uninstallLog = Join-Path $root 'optional-state-uninstall.log'
-          $uninstallArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/REMOVE_STATE', "/LOG=`"$uninstallLog`"")
-          try {
-            if ((Invoke-BoundedInstallerProcess -FilePath (Join-Path $install 'unins000.exe') -ArgumentList $uninstallArgs -Label 'optional state uninstall') -ne 0) { throw "optional state uninstall failed" }
-          } catch {
-            if (Test-Path -LiteralPath $uninstallLog) {
-              Write-Host '--- optional-state-uninstall.log ---'
-              Get-Content -LiteralPath $uninstallLog -Tail 120
-            }
-            throw
-          }
+
+          $pluginUninstaller = Join-Path $pluginMeta 'unins000.exe'
+          if ((Invoke-BoundedInstallerProcess -FilePath $pluginUninstaller -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART') -Label 'plug-in uninstall') -ne 0) { throw "plug-in uninstall failed" }
           foreach ($module in @('Pcb','Schematic','CompEdit','PattEdit')) {
-            if (Test-Path -LiteralPath (Join-Path $diptrace "Plugins\$module\DipTraceMCP")) { throw "plugin directory survived uninstall for $module" }
+            if (Test-Path -LiteralPath (Join-Path $diptrace "Plugins\$module\DipTraceMCP")) { throw "plugin directory survived plug-in uninstall for $module" }
           }
-          if (-not (Test-Path -LiteralPath (Join-Path $workspace 'fixture.txt'))) { throw "workspace was removed on full uninstall" }
+
+          $userUninstaller = Join-Path $install 'unins000.exe'
+          $uninstallArgs = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/REMOVE_STATE')
+          if ((Invoke-BoundedInstallerProcess -FilePath $userUninstaller -ArgumentList $uninstallArgs -Label 'per-user optional-state uninstall') -ne 0) { throw "per-user uninstall failed" }
+          if (-not (Test-Path -LiteralPath (Join-Path $workspace 'fixture.txt'))) { throw "workspace was removed" }
           if (Test-Path -LiteralPath $ownedStateMarker) { throw "optional state removal did not remove owned state" }
           if (-not (Test-Path -LiteralPath $unknownStateMarker)) { throw "optional state removal removed unknown user state" }
       - name: Frozen server MCP stdio initialize tools/list capabilities and read-only XML tool
@@ -252,13 +258,16 @@ jobs:
             & $portable --help | Out-Null
             if ($LASTEXITCODE -ne 0) { throw "portable --help failed during timing" }
           }
-          $installer = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe | Select-Object -First 1
+          $installer = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe |
+            Where-Object { $_.Name -notlike '*Plugin*' } | Select-Object -First 1
+          $pluginInstaller = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Plugin-Setup-*.exe | Select-Object -First 1
           $portableZip = Get-ChildItem .\dist\windows-artifacts\portable\DipTrace-MCP-Portable-*.zip | Select-Object -First 1
           $serverBytes = (Get-ChildItem "$env:RUNNER_TEMP\portable\app" -File -Recurse | Measure-Object -Property Length -Sum).Sum
           "server_bundle_bytes=$serverBytes"
           "bridge_bytes=$((Get-Item "$env:RUNNER_TEMP\portable\bridge\diptrace_mcp_bridge.exe").Length)"
           "portable_zip_bytes=$($portableZip.Length)"
-          "installer_bytes=$($installer.Length)"
+          "user_installer_bytes=$($installer.Length)"
+          "plugin_installer_bytes=$($pluginInstaller.Length)"
           "server_help_seconds=$([math]::Round($help.TotalSeconds, 3))"
 
   artifact-audit:
@@ -282,19 +291,23 @@ jobs:
           $portable = Get-ChildItem .\dist\windows-artifacts\portable\DipTrace-MCP-Portable-*.zip | Select-Object -First 1
           Expand-Archive -LiteralPath $portable.FullName -DestinationPath "$env:RUNNER_TEMP\audit-portable" -Force
           python scripts/audit_windows_bundle.py --root "$env:RUNNER_TEMP\audit-portable" --sha256 "$env:RUNNER_TEMP\audit-portable\SHA256SUMS.txt" --json
-      - name: Verify unsigned development artifacts fail closed when signing is required
+      - name: Verify unsigned development installers fail closed when signing is required
         shell: pwsh
         run: |
-          $installer = Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe | Select-Object -First 1
-          $result = Get-AuthenticodeSignature -LiteralPath $installer.FullName
-          if ($result.Status -ne 'NotSigned') { Write-Host "Installer status is $($result.Status); retaining evidence." }
-          $requireSignExit = 0
-          try {
-            & .\plugin\verify_signature.ps1 -Path $installer.FullName -RequireSigned -ExpectedSignerSubject 'HUMAN_ACTION_REQUIRED'
-            $requireSignExit = $LASTEXITCODE
-          } catch {
-            Write-Host "Expected fail-closed signing result: $($_.Exception.Message)"
-            $requireSignExit = 1
+          $installers = @(
+            (Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Setup-*.exe | Where-Object { $_.Name -notlike '*Plugin*' } | Select-Object -First 1),
+            (Get-ChildItem .\dist\windows-artifacts\installer\DipTrace-MCP-Plugin-Setup-*.exe | Select-Object -First 1)
+          )
+          foreach ($installer in $installers) {
+            $result = Get-AuthenticodeSignature -LiteralPath $installer.FullName
+            if ($result.Status -ne 'NotSigned') { Write-Host "$($installer.Name) status is $($result.Status); retaining evidence." }
+            $requireSignExit = 0
+            try {
+              & .\plugin\verify_signature.ps1 -Path $installer.FullName -RequireSigned -ExpectedSignerSubject 'HUMAN_ACTION_REQUIRED'
+              $requireSignExit = $LASTEXITCODE
+            } catch {
+              Write-Host "Expected fail-closed signing result for $($installer.Name): $($_.Exception.Message)"
+              $requireSignExit = 1
+            }
+            if ($requireSignExit -eq 0) { throw "unsigned installer passed a required-signing check: $($installer.Name)" }
           }
-          if ($requireSignExit -eq 0) { throw "unsigned installer passed a required-signing check" }
-          Write-Host "Unsigned installer correctly failed the required-signing check."

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -62,11 +62,12 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 ### Headless Windows GUI worker
 
 - isolated Win32-desktop worker for bounded native DipTrace open/save/close work without switching the user's input desktop or synthesizing physical mouse/keyboard input;
-- selectable launch mode: `hidden` (private `WinSta0` desktop, invisible) is the default, and `native` launches the editor on the operator's current interactive desktop so the round trip stays visible; the worker verifies it landed on the expected input desktop and fails closed with `native launch declined` when that desktop cannot be resolved;
-- Windows smoke/readiness checks and a frozen packaged helper under `app/tools/diptrace_mcp_headless_gui/`;
-- fail-closed automation with no coordinate-input fallback when a native control action cannot be completed safely.
+- selectable launch mode: `hidden` (separate randomly named `WinSta0` desktop, invisible) is the default, and `native` explicitly targets the verified current `WinSta0` input desktop so the round trip stays visible; native mode rejects elevated callers and validates desktop/window-station/session identity before DipTrace work;
+- Windows hidden/native smoke/readiness checks and a frozen packaged helper under `app/tools/diptrace_mcp_headless_gui/`;
+- fail-closed automation with no coordinate-input fallback when a native control action cannot be completed safely;
+- split Windows packaging boundary: the per-user MCP installer is permanently non-elevated, while a separate self-contained administrator plug-in installer owns only the bridge/settings payload and bounded DipTrace `Plugins\\<module>\\DipTraceMCP` writes.
 
-The headless worker is a host-automation boundary, not a second semantic authoring authority. Real DipTrace actions remain claim-specific acceptance evidence.
+The headless worker is a host-automation boundary, not a second semantic authoring authority or a process/filesystem/network/token/privilege sandbox. Real DipTrace actions remain claim-specific acceptance evidence.
 
 ### Product and engineering support
 
@@ -90,7 +91,7 @@ The headless worker is a host-automation boundary, not a second semantic authori
 - The private/manual Q1 Component Angle campaign is PASS on its accepted production checkpoint; immutable historical release records keep the status that was true when each release was cut.
 - The accepted manual matrix is complete at 12 of 12 blocking gates PASS across its recorded checkpoints. Claude Desktop restart and custom-state preservation are operator-confirmed PASS from a separate machine; their earlier WAIVED/pending states remain historical only.
 - Documentation distinguishes current implementation state from immutable release/audit/acceptance snapshots.
-- Installation/release documentation reflects that `v0.2.1` and `diptrace-mcp==0.2.1` are already published.
+- Installation/release documentation reflects that `v0.2.1` and `diptrace-mcp==0.2.1` are already published; current source hardens the next Windows packaging line without rewriting immutable `v0.2.1` assets.
 - Testing documentation reflects the combined 90% coverage gate and the separate 85% Linux-only floor.
 
 ## Fixed

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -62,6 +62,7 @@ Cinematic replay is deliberately a presentation path. The XML bridge and normal 
 ### Headless Windows GUI worker
 
 - isolated Win32-desktop worker for bounded native DipTrace open/save/close work without switching the user's input desktop or synthesizing physical mouse/keyboard input;
+- selectable launch mode: `hidden` (private `WinSta0` desktop, invisible) is the default, and `native` launches the editor on the operator's current interactive desktop so the round trip stays visible; the worker verifies it landed on the expected input desktop and fails closed with `native launch declined` when that desktop cannot be resolved;
 - Windows smoke/readiness checks and a frozen packaged helper under `app/tools/diptrace_mcp_headless_gui/`;
 - fail-closed automation with no coordinate-input fallback when a native control action cannot be completed safely.
 

--- a/docs/HEADLESS_GUI.md
+++ b/docs/HEADLESS_GUI.md
@@ -1,9 +1,10 @@
 # Headless GUI worker on Windows
 
-DipTrace MCP can isolate the remaining native GUI operations from the user's normal
-Windows desktop without requiring a virtual machine. The worker creates a separate
-Win32 desktop object inside the current interactive Windows session and launches a
-small helper process there. DipTrace is then started as a child of that helper.
+DipTrace MCP can keep bounded native GUI operations away from the operator's normal
+input desktop without requiring a virtual machine. Hidden mode creates a separate,
+randomly named Win32 desktop object inside the current interactive Windows session
+and launches a small helper there. Native mode is an explicit opt-in that runs on
+the verified current `WinSta0` input desktop so the operator can see the editor.
 
 This is **not** the Windows 10/11 Virtual Desktops feature. It uses Win32 desktop
 objects under `WinSta0`, for example:
@@ -11,8 +12,11 @@ objects under `WinSta0`, for example:
 ```text
 WinSta0
 ├── Default              <- the user's visible desktop
-└── DipTraceMCP-...      <- isolated DipTrace worker desktop
+└── DipTraceMCP-...      <- separate hidden DipTrace worker desktop
 ```
+
+Desktop separation prevents UI interference with the operator's input desktop. It
+is **not** a process, filesystem, network, token, privilege, or malware sandbox.
 
 The implementation deliberately never calls `SwitchDesktop`, `SendInput`,
 `SetCursorPos`, `mouse_event` or `keybd_event`. If a native action cannot be
@@ -22,20 +26,23 @@ stealing the user's physical keyboard or mouse.
 ## Scope
 
 The primary authoring path remains DipTrace XML plus semantic MCP operations. The
-headless GUI worker is only for host actions that require a real DipTrace process.
+Windows GUI worker is only for host actions that require a real DipTrace process.
 The first supported native operation is a bounded round trip:
 
-1. create a private Win32 desktop;
-2. launch the worker on that desktop;
+1. choose `hidden` or explicit `native` desktop mode;
+2. launch the worker on the verified target desktop;
 3. launch the requested DipTrace editor and open an existing project;
 4. invoke `File -> Save` through the Win32 automation backend;
 5. close the editor;
-6. return structured evidence including PIDs, desktop names and file SHA-256 before
-   and after the operation.
+6. return structured evidence including PIDs, desktop/window-station/session
+   identity and file SHA-256 before and after the operation.
 
-The same isolation layer is intended for later verified host actions such as
-exports, ERC/DRC, refill/generation commands and other operations that cannot be
-completed safely from XML alone. Those actions should be added only after the
+Hidden mode is the default. Native mode is refused when the worker is elevated,
+when the input desktop cannot be resolved, when the process is not attached to
+`WinSta0`, or when the worker lands in a different Windows session.
+
+The same worker can later support verified host actions such as exports, ERC/DRC
+and refill/generation commands. Those actions should be added only after the
 corresponding DipTrace controls have been verified on a real host.
 
 ## Requirements
@@ -64,7 +71,7 @@ console entry point. Invoke the maintained module directly:
 py -m diptrace_mcp.headless_gui --help
 ```
 
-## Isolation smoke test
+## Hidden isolation smoke test
 
 Run this before testing DipTrace itself:
 
@@ -72,12 +79,30 @@ Run this before testing DipTrace itself:
 py -m diptrace_mcp.headless_gui smoke
 ```
 
-A successful result is JSON with `"ok": true`. The test creates a private desktop,
-starts a child process there, verifies that the child reports the expected desktop
-name, and verifies that the physical input desktop did not change when Windows
-allows it to be queried.
+A successful result is JSON with `"ok": true`. The test creates a separate hidden
+desktop, starts a child process there, verifies that the child reports the expected
+desktop name, and verifies that the physical input desktop did not change when
+Windows allows it to be queried.
 
 The test does not require DipTrace.
+
+## Native desktop security smoke
+
+The native launch primitive has a separate no-DipTrace probe:
+
+```powershell
+py -m diptrace_mcp.headless_gui native-smoke
+```
+
+It launches only the bundled probe process and verifies:
+
+- the child's thread desktop matches the current input desktop;
+- both processes are attached to `WinSta0`;
+- the child remains in the same Windows session.
+
+This probe may run on an elevated CI runner because it performs no DipTrace or UI
+mutation. A real `roundtrip --desktop native` still fails closed when the caller
+has an elevated token.
 
 ## Readiness check
 
@@ -100,7 +125,8 @@ The report includes:
 - hidden desktop smoke result;
 - resolved DipTrace installation root;
 - whether `pywinauto` is available;
-- `physical_input_fallback: false` as an explicit safety invariant.
+- `physical_input_fallback: false`;
+- `desktop_is_security_sandbox: false`.
 
 ## Native open/save/close round trip
 
@@ -123,19 +149,16 @@ py -m diptrace_mcp.headless_gui roundtrip `
 ```
 
 Available editor identifiers are `pcb`, `schematic`, `component` and `pattern`.
-The command returns JSON. `ok: false` is a bounded failure and should be treated as
-host evidence, not silently retried with coordinate/mouse automation.
+The command returns JSON. `ok: false` is bounded failure evidence and must not be
+silently retried with coordinate/mouse automation.
 
-## Launch mode
+## Launch modes
 
-The worker supports two launch modes, selected with `--desktop`:
+The worker supports two modes selected with `--desktop`:
 
-- `hidden` (default): the editor starts on a private Win32 desktop under `WinSta0`
-  and stays invisible to the operator. This is the original isolation behaviour.
-- `native`: the editor starts directly on the operator's current interactive desktop
-  and remains visible. Use this when an operator wants to watch the round trip, or
-  when a sandbox/VM already provides isolation and the extra hidden desktop is
-  undesirable.
+- `hidden` (default): the editor starts on a separate randomly named Win32 desktop
+  under `WinSta0` and stays invisible to the operator;
+- `native`: the editor starts visibly on the verified current input desktop.
 
 Native example:
 
@@ -147,17 +170,27 @@ py -m diptrace_mcp.headless_gui roundtrip `
   --desktop native
 ```
 
-In `native` mode the worker inherits the current desktop, so the window is visible
-and the worker verifies it landed on the expected (`before`) input desktop. If the
-current input desktop cannot be determined, the operation fails closed with
-`native launch declined` instead of guessing. All other safety invariants
-(no `SwitchDesktop`, no synthesized input, bounded timeouts) apply unchanged. The
-evidence JSON reports the chosen `desktop_mode` so a caller can distinguish the two.
+Native launch does not rely on an unspecified inherited desktop. The launcher sets
+`STARTUPINFO.lpDesktop` explicitly to `WinSta0\<current-input-desktop>`, verifies
+the child session, and the worker verifies its desktop, window station and session
+again before performing DipTrace work.
+
+Native mode fails closed when:
+
+- the input desktop cannot be resolved;
+- the process window station is not `WinSta0`;
+- the caller/worker is elevated;
+- the worker is attached to an unexpected desktop/window station/session.
+
+If the input desktop changes after a Save may already have occurred, the caller
+does not discard the result. It returns `ok: false` with
+`desktop_changed: true` and retains PID/SHA/evidence fields so an operator can
+review the side effect without unsafe automatic retry.
 
 ## Bundled Windows build
 
-`scripts/build_windows_server.ps1` now builds the helper together with the normal
-standalone MCP server. The helper is placed under the server distribution at:
+`scripts/build_windows_server.ps1` builds the helper with the standalone MCP
+server. The helper is placed under:
 
 ```text
 diptrace_mcp_server\
@@ -166,9 +199,9 @@ diptrace_mcp_server\
         └── diptrace_mcp_headless_gui.exe
 ```
 
-Because the existing Windows installer copies the complete standalone server
-folder, the same helper is included in the normal installer/portable artifact.
-No separate Python installation is required for that packaged executable.
+The Windows build runs both the hidden-desktop test and the real native desktop
+security probe without requiring DipTrace. The packaged helper is included with
+the per-user server installer and portable artifact.
 
 Example after installation:
 
@@ -176,28 +209,47 @@ Example after installation:
 & "<install-root>\app\tools\diptrace_mcp_headless_gui\diptrace_mcp_headless_gui.exe" smoke
 ```
 
+## Installer privilege boundary
+
+Windows distribution deliberately separates the per-user MCP installation from
+the administrator-only DipTrace plug-in installation:
+
+- `DipTrace-MCP-Setup-<version>.exe` uses `PrivilegesRequired=lowest`, installs
+  the server/configurator under the user's selected/per-user path, and never
+  contains or launches a privileged plug-in installation path;
+- `DipTrace-MCP-Plugin-Setup-<version>.exe` uses
+  `PrivilegesRequired=admin`, contains its bridge/settings payload inside that
+  installer, and writes only the bounded `Plugins\<module>\DipTraceMCP`
+  integration plus its own administrator-owned uninstall metadata.
+
+The elevated plug-in installer does **not** execute scripts or copy executable
+payload from `%LOCALAPPDATA%` or from the per-user MCP installation. It does not
+modify Codex/Claude configuration, workspace, state, or user profiles.
+
 ## Safety invariants
 
 The implementation must retain all of these properties:
 
 - never switch the user's input desktop;
-- never synthesize physical mouse or keyboard input from the hidden worker;
+- never synthesize physical mouse or keyboard input;
 - never fall back from a failed control operation to screen coordinates;
 - keep XML/semantic operations as the default authoring path;
 - validate the selected DipTrace installation and project before starting the host;
+- refuse visible/native DipTrace work from an elevated token;
+- explicitly verify desktop, `WinSta0` window station and session identity;
 - use bounded timeouts and terminate a stuck worker rather than block indefinitely;
-- return structured failure evidence;
-- do not expand the public MCP tool contract merely to expose implementation
-  details of the Windows worker.
+- retain structured evidence when a post-side-effect desktop change is detected;
+- keep the admin plug-in payload separate from user-writable installer payload;
+- do not expand the public MCP tool contract merely to expose Windows-worker details.
 
 ## CI and real-host evidence
 
-The normal Windows CI suite contains a real Win32 hidden-desktop smoke test. It
-verifies desktop creation/process attachment without requiring DipTrace to be
-installed on the hosted runner. The Windows packaging workflow also builds the
-frozen helper and starts it with `--help`.
+Windows CI contains real Win32 hidden-desktop and native-desktop process probes.
+They verify desktop creation/targeting, `WinSta0` attachment and session identity
+without requiring DipTrace. The Windows packaging workflow also builds and tests
+the split per-user/admin installer boundary.
 
-A real DipTrace open/save/reopen validation is still a real-host acceptance gate:
-hosted GitHub runners do not provide the licensed/local DipTrace installation used
-for product acceptance. Passing CI therefore proves the isolation primitive and
+A real DipTrace open/save/reopen validation remains real-host evidence: hosted
+GitHub runners do not provide the licensed/local DipTrace installation used for
+product acceptance. Passing CI proves the bounded Windows primitives and
 packaging, not universal DipTrace UI compatibility.

--- a/docs/HEADLESS_GUI.md
+++ b/docs/HEADLESS_GUI.md
@@ -126,6 +126,34 @@ Available editor identifiers are `pcb`, `schematic`, `component` and `pattern`.
 The command returns JSON. `ok: false` is a bounded failure and should be treated as
 host evidence, not silently retried with coordinate/mouse automation.
 
+## Launch mode
+
+The worker supports two launch modes, selected with `--desktop`:
+
+- `hidden` (default): the editor starts on a private Win32 desktop under `WinSta0`
+  and stays invisible to the operator. This is the original isolation behaviour.
+- `native`: the editor starts directly on the operator's current interactive desktop
+  and remains visible. Use this when an operator wants to watch the round trip, or
+  when a sandbox/VM already provides isolation and the extra hidden desktop is
+  undesirable.
+
+Native example:
+
+```powershell
+py -m diptrace_mcp.headless_gui roundtrip `
+  --diptrace-root "C:\Program Files\DipTrace" `
+  --editor pcb `
+  --project "C:\work\board.dip" `
+  --desktop native
+```
+
+In `native` mode the worker inherits the current desktop, so the window is visible
+and the worker verifies it landed on the expected (`before`) input desktop. If the
+current input desktop cannot be determined, the operation fails closed with
+`native launch declined` instead of guessing. All other safety invariants
+(no `SwitchDesktop`, no synthesized input, bounded timeouts) apply unchanged. The
+evidence JSON reports the chosen `desktop_mode` so a caller can distinguish the two.
+
 ## Bundled Windows build
 
 `scripts/build_windows_server.ps1` now builds the helper together with the normal

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -280,7 +280,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 | evidence reports | deterministic review-only report pipeline implemented |
 | library mutation public API | package-level request/preview prepared; public MCP registration pending |
 | cinematic | presentation + mandatory preflight implemented; exact UI acceptance pending |
-| headless GUI | hidden Win32 desktop helper implemented; real DipTrace native actions remain claim-specific evidence |
+| headless GUI | hidden Win32 desktop helper implemented with selectable `hidden`/`native` launch mode for open -> Save -> close; real DipTrace native actions remain claim-specific evidence |
 | documentation drift | evergreen code/docs guard implemented and CI-tested |
 
 # Permanent limitations / non-claims

--- a/docs/WINDOWS_INSTALLER.md
+++ b/docs/WINDOWS_INSTALLER.md
@@ -2,17 +2,22 @@
 
 ## Status
 
-The Windows installer/portable/configurator implementation is merged and published in the immutable `v0.2.1` development prerelease. The old `feat/windows-one-click-installer` wording was a historical implementation-branch note and is no longer the current project status.
+The immutable `v0.2.1` development prerelease remains unchanged. Its published
+Windows assets keep their original identities and checksums.
 
-Published `v0.2.1` Windows distribution includes:
+Current source development has hardened the next Windows packaging line by
+separating the per-user MCP installation from the administrator-only DipTrace
+plug-in installation. A future release built from this source produces:
 
-- `DipTrace-MCP-Setup-0.2.1.exe`;
-- `DipTrace-MCP-Portable-0.2.1.zip`;
-- `DipTrace-MCP-0.2.1-windows.mcpb`;
-- the separately packaged live XML bridge/settings in the installer/portable path;
+- `DipTrace-MCP-Setup-<version>.exe` — per-user server/configurator installer;
+- `DipTrace-MCP-Plugin-Setup-<version>.exe` — administrator-only DipTrace plug-in
+  installer with a self-contained bridge/settings payload;
+- `DipTrace-MCP-Portable-<version>.zip`;
 - release checksums/provenance records.
 
-The binaries are unsigned alpha/development assets.
+This source change does not rewrite or replace the already published `v0.2.1`
+assets. Development binaries remain unsigned unless a future release satisfies
+the repository signing policy.
 
 ## Design goals
 
@@ -21,24 +26,85 @@ The Windows packaging path is designed to:
 - avoid requiring a developer Git/Python environment for normal installation;
 - keep writable state out of Program Files;
 - preserve user workspaces/state on ordinary uninstall;
-- keep client configuration in the original user context;
-- elevate only the narrowly scoped DipTrace plug-in copy/removal when Program Files requires it;
-- support deterministic installer/portable CI smoke and checksum/provenance auditing;
-- reuse the existing bridge/session/SHA safety model rather than creating a second bridge implementation.
+- keep MCP client configuration in the original user context;
+- keep the user installer permanently non-elevated;
+- put all Program Files/DipTrace plug-in writes behind a separate, narrowly
+  scoped administrator installer;
+- prevent an elevated component from executing scripts or copying executable
+  payload out of the per-user `%LOCALAPPDATA%` installation;
+- support deterministic installer/portable CI smoke and checksum/provenance
+  auditing;
+- reuse the existing bridge/session/SHA safety model rather than creating a
+  second bridge implementation.
+
+## Split privilege architecture
+
+### Per-user installer
+
+`DipTrace-MCP-Setup-<version>.exe` uses:
+
+```text
+PrivilegesRequired=lowest
+```
+
+It installs only:
+
+- the standalone MCP server/runtime;
+- the Windows configurator;
+- state/manifest helpers;
+- license/readme/version metadata.
+
+It configures Codex/Claude only in the original user's profile context. It does
+not contain the DipTrace bridge/settings plug-in payload, does not contain an
+elevation script, and never calls `runas`.
+
+Default application/state locations remain under the user's local application
+data unless explicitly changed.
+
+### Administrator plug-in installer
+
+`DipTrace-MCP-Plugin-Setup-<version>.exe` uses:
+
+```text
+PrivilegesRequired=admin
+```
+
+It is a separate self-contained artifact. Its installer payload contains the
+exact bridge executable and four settings profiles that it will copy into the
+validated DipTrace installation.
+
+The elevated installer:
+
+- does not read bridge/scripts/settings from `%LOCALAPPDATA%`;
+- does not read payload from the per-user DipTrace MCP installation;
+- does not configure Codex or Claude;
+- does not read/write MCP workspace or state;
+- writes only its own admin-owned uninstall metadata/payload and the bounded
+  `Plugins\<module>\DipTraceMCP` directories;
+- verifies copied bridge/settings SHA-256 against its own extracted
+  administrator-owned payload;
+- removes only those owned plug-in directories on uninstall.
+
+This is the security boundary. The user installer and administrator installer
+are intentionally independent; the per-user installer does not launch the
+administrator installer as a child.
 
 ## Components
 
-The installer/portable build is assembled from project-owned artifacts including:
+The full Windows build pipeline still assembles project-owned artifacts including:
 
 - standalone `diptrace_mcp` server runtime;
-- `diptrace_mcp_bridge.exe` live XML bridge;
+- `diptrace_mcp_bridge.exe`;
 - PCB/Schematic/Component/Pattern settings profiles;
 - Windows configurator;
-- plug-in install/uninstall helpers;
+- portable install/uninstall helpers;
 - license/version/readme metadata;
-- installation manifest/checksums where applicable.
+- installation manifests/checksums where applicable.
 
-The server/configurator use frozen Windows application builds. The bridge remains the project-owned DipTrace exchange process and uses the same allowed-root/session/SHA/apply/cancel boundaries as source execution.
+The split Inno Setup artifacts select different subsets of that controlled build
+stage. The portable ZIP still contains the complete maintenance bundle; for
+protected DipTrace roots the dedicated administrator plug-in installer is the
+preferred packaged privilege boundary.
 
 ## DipTrace module profiles
 
@@ -51,27 +117,36 @@ The shipped settings profiles cover:
 | Component Editor | Component Library bridge/settings path |
 | Pattern Editor | Pattern Library bridge/settings path |
 
-A profile being present in the bundle does not by itself prove every semantic operation for every DipTrace version. Runtime capability and real-host acceptance remain separate.
+A profile being present in an artifact does not by itself prove every semantic
+operation for every DipTrace version. Runtime capability and real-host acceptance
+remain separate.
 
 ## Install location and writable state
 
-The frozen application is installed under the selected Windows application location. Writable project-owned state defaults to the user's local application-data area rather than Program Files.
+The per-user application is installed under the selected user application
+location. Writable project-owned state defaults to the user's local
+application-data area rather than Program Files.
 
-State includes sessions, records, backups/logs and related local metadata. Project files remain in the user-selected workspace.
+State includes sessions, records, backups/logs and related local metadata.
+Project files remain in the user-selected workspace.
 
-Uninstall preserves user workspace/state by default. Owned-state removal is explicit and ownership-gated.
+Uninstall preserves user workspace/state by default. Owned-state removal is
+explicit and ownership-gated.
 
-## Privilege boundary
-
-Normal application/client configuration should run without silently changing user identity/context.
-
-When a DipTrace installation under protected Program Files requires elevation, only the narrow plug-in copy/removal action is elevated. Client JSON/configuration continues in the original user's profile so an administrator token does not redirect configuration into the wrong account.
+The administrator plug-in install stores only its own uninstall metadata/payload
+under its administrator-owned application directory and the owned DipTrace
+`DipTraceMCP` plug-in directories. It does not own user workspace/state.
 
 ## Client configuration
 
-The configurator supports project-owned configuration for supported MCP clients while preserving unknown existing fields and using backup/atomic-update rules.
+The configurator supports project-owned configuration for supported MCP clients
+while preserving unknown existing fields and using backup/atomic-update rules.
 
-A configuration change requires an actual client restart before it can be considered tested. The accepted project campaign has real Codex restart evidence and operator-confirmed Claude Desktop restart evidence from a separate machine.
+A configuration change requires an actual client restart before it can be
+considered tested. The accepted project campaign has real Codex restart evidence
+and operator-confirmed Claude Desktop restart evidence from a separate machine.
+
+The administrator plug-in installer never runs the client configurator.
 
 ## Build
 
@@ -82,58 +157,78 @@ Typical source build commands on Windows:
 .\plugin\build_bridge.ps1 -PythonCommand python -Clean
 .\scripts\build_windows_configurator.ps1 -PythonCommand python -Clean
 .\scripts\build_windows_installer.ps1 `
-  -Version 0.2.1 `
+  -Version <next-version> `
   -IsccPath "$env:ISCC_PATH"
 ```
 
-Use the actual selected future version when preparing a new release; do not rebuild a different binary under the immutable `0.2.1` identity.
+The installer build emits both Inno Setup executables plus the portable ZIP and
+one release checksum manifest covering all three assets.
+
+Use the actual selected future version when preparing a new release. Do not
+rebuild different binaries under the immutable `0.2.1` identity.
 
 ## CI / automated evidence
 
-Windows automation covers implementation-level checks such as:
+Windows automation covers:
 
 - frozen server/bridge/configurator build and startup smoke;
-- installer and portable creation;
-- silent install/repair/uninstall paths in CI;
-- paths containing spaces/Unicode where covered by tests;
-- client configuration backup/atomic update;
-- workspace/state preservation/ownership behavior;
+- a real hidden Win32 desktop process-isolation probe;
+- a real native `WinSta0` desktop/window-station/session targeting probe that
+  does not require DipTrace;
+- separate per-user and administrator Inno Setup builds;
+- proof that the per-user install contains no bridge/settings/elevation script;
+- separate plug-in install/repair/uninstall against a synthetic validated
+  DipTrace root;
+- per-user install/repair/uninstall and owned-state preservation/removal;
+- paths containing spaces/Unicode;
+- frozen MCP stdio initialize/tools/list/capabilities/XML smoke;
 - checksums/provenance inventories;
-- explicit unsigned-binary status.
+- explicit unsigned-binary fail-closed signing checks for both installers.
 
-CI evidence is necessary but not equivalent to the project-level clean real-machine acceptance gate.
+CI evidence is necessary but not equivalent to a real licensed DipTrace semantic
+round trip.
 
 ## Current manual acceptance boundary
 
-Post-release real-host validation now has:
+Historical project acceptance already records:
 
-- `windows_clean_install_repair_uninstall` PASS, including operator-confirmed from-zero installation on a separate new Windows machine;
-- `elevated_plugin_install_profile_preservation` PASS on exact candidate `9af6da2` and Windows 11 build `26200` with DipTrace `5.3.0.2`;
-- `custom_state_preservation` PASS by operator confirmation from a separate machine.
+- `windows_clean_install_repair_uninstall` PASS;
+- `elevated_plugin_install_profile_preservation` PASS;
+- `custom_state_preservation` PASS.
 
-The formal lifecycle sequence is complete. The elevated gate found and fixed protected-root detection and a flattened frozen-configurator runtime; schematic/native gates were unaffected and were not repeated.
-
-These gates should be run against the exact production candidate/artifacts whose compatibility is being claimed. Do not copy a PASS from an older candidate onto later `main` merely because the installer code looks similar.
+Those PASS records remain valid historical evidence for their exact accepted
+candidates. The new split-installer architecture is a changed packaging/security
+claim and therefore receives its own impact-based CI evidence; a future release
+candidate should receive claim-appropriate real-host verification without
+restarting unrelated historical acceptance campaigns.
 
 ## Installation verification
 
-For the published version:
+For a future split-installer build:
 
-1. download the installer/portable asset and `SHA256SUMS.txt` from the same `v0.2.1` prerelease;
+1. obtain the per-user installer, plug-in installer and `SHA256SUMS.txt` from the
+   same release/candidate;
 2. verify SHA-256;
-3. install/configure;
-4. restart DipTrace and the selected MCP client;
-5. call `get_capabilities`;
-6. use native open/save/re-export acceptance when a specific live semantic path requires proof.
+3. run the per-user installer normally, without elevation;
+4. run the plug-in installer separately when DipTrace integration is desired;
+5. restart DipTrace and the selected MCP client;
+6. call `get_capabilities`;
+7. use native open/save/re-export acceptance only when a specific live semantic
+   path requires proof.
 
-See [INSTALL_FROM_RELEASE.md](INSTALL_FROM_RELEASE.md).
+For the immutable published `v0.2.1`, follow its release-specific instructions
+and checksums. See [INSTALL_FROM_RELEASE.md](INSTALL_FROM_RELEASE.md).
 
 ## Boundaries and non-claims
 
-- Windows executables are unsigned;
+- current development Windows executables are unsigned unless signing is
+  explicitly required and verified;
 - successful CI build/install smoke is not Authenticode trust;
+- the split privilege boundary is not a claim that Win32 desktop isolation is a
+  security sandbox;
 - the installer does not prove universal DipTrace 5.x compatibility;
 - the MCPB does not silently install the DipTrace bridge;
 - a shipped settings profile does not prove every write path;
-- clean-machine/project lifecycle gates remain evidence-bound to the exact candidate;
-- Novarm/DipTrace endorsement, independent review and production readiness are not claimed.
+- clean-machine/project lifecycle evidence remains bound to the exact candidate;
+- Novarm/DipTrace endorsement, independent review and production readiness are
+  not claimed.

--- a/installer/DipTraceMCP.iss
+++ b/installer/DipTraceMCP.iss
@@ -9,21 +9,35 @@
 #endif
 
 [Setup]
+#ifdef PluginOnly
+AppId={{2B8F7A98-8744-4ED1-A2C5-31A827DF74C1}
+AppName=DipTrace MCP Plug-in
+AppVersion={#AppVersion}
+AppVerName=DipTrace MCP Plug-in {#AppVersion}
+DefaultDirName={autopf}\DipTraceMCPPlugin
+DefaultGroupName=DipTrace MCP
+PrivilegesRequired=admin
+OutputBaseFilename=DipTrace-MCP-Plugin-Setup-{#AppVersion}
+UninstallDisplayName=DipTrace MCP Plug-in {#AppVersion}
+#else
 AppId={{8A6BC0A8-DA77-4C95-8D3B-2A43A1B04D55}
 AppName=DipTrace MCP
 AppVersion={#AppVersion}
 AppVerName=DipTrace MCP {#AppVersion}
+DefaultDirName={localappdata}\Programs\DipTraceMCP
+DefaultGroupName=DipTrace MCP
+PrivilegesRequired=lowest
+OutputBaseFilename=DipTrace-MCP-Setup-{#AppVersion}
+AppReadmeFile={app}\README_FIRST.txt
+UninstallDisplayIcon={app}\app\diptrace_mcp_server.exe
+#endif
 AppPublisher=DipTrace MCP contributors
 AppPublisherURL=https://github.com/fireostendere/mcp_diptrace
 AppSupportURL=https://github.com/fireostendere/mcp_diptrace/issues
-DefaultDirName={localappdata}\Programs\DipTraceMCP
-DefaultGroupName=DipTrace MCP
 DisableProgramGroupPage=yes
-PrivilegesRequired=lowest
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 OutputDir={#OutputDir}
-OutputBaseFilename=DipTrace-MCP-Setup-{#AppVersion}
 Compression=lzma2/max
 SolidCompression=yes
 WizardStyle=modern
@@ -32,61 +46,87 @@ CloseApplications=yes
 RestartApplications=no
 SetupLogging=yes
 LicenseFile={#StageDir}\LICENSE
-AppReadmeFile={app}\README_FIRST.txt
-UninstallDisplayIcon={app}\app\diptrace_mcp_server.exe
 
+#ifndef PluginOnly
 [Types]
-Name: full; Description: Full install (server, bridge, DipTrace settings, client configuration)
-Name: server; Description: Server only (no DipTrace plug-in integration)
+Name: full; Description: Full user install (server and MCP client configuration)
+Name: server; Description: Server only (skip MCP client configuration)
 Name: custom; Description: Custom install; Flags: iscustom
 
 [Components]
 Name: server; Description: Standalone MCP server and runtime; Types: full server custom; Flags: fixed
-Name: plugin; Description: DipTrace bridge and four settings profiles; Types: full custom
+#endif
 
 [Files]
+#ifdef PluginOnly
+; The elevated installer is self-contained. It never reads executable/script
+; payload from the per-user DipTrace MCP installation or LocalAppData.
+Source: "{#StageDir}\bridge\diptrace_mcp_bridge.exe"; DestDir: "{app}\payload"; Flags: ignoreversion
+Source: "{#StageDir}\settings-templates\pcb.settings.xml"; DestDir: "{app}\payload\settings"; Flags: ignoreversion
+Source: "{#StageDir}\settings-templates\schematic.settings.xml"; DestDir: "{app}\payload\settings"; Flags: ignoreversion
+Source: "{#StageDir}\settings-templates\component.settings.xml"; DestDir: "{app}\payload\settings"; Flags: ignoreversion
+Source: "{#StageDir}\settings-templates\pattern.settings.xml"; DestDir: "{app}\payload\settings"; Flags: ignoreversion
+Source: "{#StageDir}\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#StageDir}\VERSION"; DestDir: "{app}"; Flags: ignoreversion
+#else
+; The per-user installer contains no bridge/settings/install-plugin payload and
+; never invokes an elevated child process.
 Source: "{#StageDir}\app\*"; DestDir: "{app}\app"; Components: server; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "{#StageDir}\bridge\*"; DestDir: "{app}\bridge"; Components: plugin; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "{#StageDir}\settings-templates\*"; DestDir: "{app}\settings-templates"; Components: plugin; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "{#StageDir}\tools\*"; DestDir: "{app}\tools"; Flags: recursesubdirs createallsubdirs ignoreversion
+Source: "{#StageDir}\tools\diptrace_mcp_configure\*"; DestDir: "{app}\tools\diptrace_mcp_configure"; Flags: recursesubdirs createallsubdirs ignoreversion
+Source: "{#StageDir}\tools\write_installation_manifest.ps1"; DestDir: "{app}\tools"; Flags: ignoreversion
+Source: "{#StageDir}\tools\remove_owned_state.ps1"; DestDir: "{app}\tools"; Flags: ignoreversion
 Source: "{#StageDir}\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\README_FIRST.txt"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\VERSION"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\artifact-inventory.json"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\installation-manifest.template.json"; DestDir: "{app}"; DestName: "installation-manifest.json"; Flags: ignoreversion
+#endif
 
+#ifndef PluginOnly
 [Icons]
 Name: "{group}\DipTrace MCP README"; Filename: "{app}\README_FIRST.txt"
 Name: "{group}\DipTrace MCP Configurator"; Filename: "{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe"
 
 [UninstallDelete]
-Type: files; Name: "{app}\plugin-targets.txt"
 Type: files; Name: "{app}\state-dir.txt"
 Type: dirifempty; Name: "{app}"
+#endif
 
 [Code]
+#ifdef PluginOnly
 const
-  ClientCodex = 0;
-  ClientClaude = 1;
-  ClientBoth = 2;
-  ClientNone = 3;
   UninstallRoot = 'Software\Microsoft\Windows\CurrentVersion\Uninstall';
 
 var
   DipTracePage: TInputOptionWizardPage;
   DipTraceBrowsePage: TInputDirWizardPage;
-  WorkspacePage: TInputDirWizardPage;
-  StatePage: TInputDirWizardPage;
-  ClientPage: TInputOptionWizardPage;
   DetectedDipTrace: array of string;
   SelectedDipTrace: string;
-  RemoveClientCheck: TNewCheckBox;
-  RemoveStateCheck: TNewCheckBox;
-  InstallLogPath: string;
-  InstallationFinalized: Boolean;
-  PluginSelection: Boolean;
-  ResolvedStateDir: string;
-  ResolvedWorkspaceDir: string;
+  PluginInstalled: Boolean;
+
+function ParameterValue(const Name, DefaultValue: string): string;
+var
+  I: Integer;
+  Argument, Prefix: string;
+begin
+  Result := ExpandConstant('{param:' + Name + '|' + DefaultValue + '}');
+  Prefix := '/' + Lowercase(Name) + '=';
+  for I := 1 to ParamCount do begin
+    Argument := ParamStr(I);
+    if CompareText(Copy(Argument, 1, Length(Prefix)), Prefix) = 0 then begin
+      Result := Copy(Argument, Length(Prefix) + 1, Length(Argument));
+      if Length(Result) >= 2 then
+        if (Result[1] = '"') and (Result[Length(Result)] = '"') then
+          Result := Copy(Result, 2, Length(Result) - 2);
+      Exit;
+    end;
+  end;
+end;
+
+function IsSamePath(const Left, Right: string): Boolean;
+begin
+  Result := CompareText(Trim(AddBackslash(Left)), Trim(AddBackslash(Right))) = 0;
+end;
 
 function IsDipTraceLayout(const Root: string): Boolean;
 begin
@@ -101,34 +141,7 @@ begin
     DirExists(AddBackslash(Root) + 'Plugins\PattEdit');
 end;
 
-function HasCommandLineParam(const Name: string): Boolean;
-var
-  I: Integer;
-begin
-  Result := False;
-  for I := 1 to ParamCount do
-    if CompareText(ParamStr(I), Name) = 0 then begin
-      Result := True;
-      Exit;
-    end;
-end;
-
-function IsSamePath(const Left, Right: string): Boolean;
-begin
-  Result := CompareText(Trim(AddBackslash(Left)), Trim(AddBackslash(Right))) = 0;
-end;
-
-function IsPathUnder(const Path, Root: string): Boolean;
-var
-  NormalPath, NormalRoot: string;
-begin
-  NormalPath := RemoveBackslash(ExpandFileName(Path));
-  NormalRoot := RemoveBackslash(ExpandFileName(Root));
-  Result := IsSamePath(NormalPath, NormalRoot) or
-    (CompareText(Copy(NormalPath, 1, Length(NormalRoot) + 1), AddBackslash(NormalRoot)) = 0);
-end;
-
-procedure AddDipTraceCandidate(const Candidate: string; const Source: string);
+procedure AddDipTraceCandidate(const Candidate, Source: string);
 var
   I: Integer;
   Root: string;
@@ -146,8 +159,7 @@ procedure AddRegistryDipTraceCandidates(const Hive: Integer);
 var
   Names: TArrayOfString;
   I: Integer;
-  Key: string;
-  DisplayName, InstallLocation: string;
+  Key, DisplayName, InstallLocation: string;
 begin
   if not RegGetSubkeyNames(Hive, UninstallRoot, Names) then Exit;
   for I := 0 to GetArrayLength(Names) - 1 do begin
@@ -161,27 +173,208 @@ begin
   end;
 end;
 
-function IsPluginSelected: Boolean;
+procedure SaveUtf8Line(const FileName, Line: string);
+var
+  Lines: TArrayOfString;
 begin
-  Result := PluginSelection;
+  SetArrayLength(Lines, 1);
+  Lines[0] := Line;
+  SaveStringsToUTF8FileWithoutBOM(FileName, Lines, False);
 end;
 
-function SelectedClientName: string;
+function ModuleTarget(const ModuleName: string): string;
 begin
-  case ClientPage.SelectedValueIndex of
-    ClientCodex: Result := 'codex';
-    ClientClaude: Result := 'claude';
-    ClientBoth: Result := 'both';
-  else
-    Result := 'none';
+  Result := AddBackslash(SelectedDipTrace) + 'Plugins\' + ModuleName + '\DipTraceMCP';
+end;
+
+procedure RemovePluginTargets;
+var
+  Target: string;
+begin
+  if SelectedDipTrace = '' then Exit;
+  Target := ModuleTarget('Pcb');
+  DelTree(Target, True, True, True, False);
+  Target := ModuleTarget('Schematic');
+  DelTree(Target, True, True, True, False);
+  Target := ModuleTarget('CompEdit');
+  DelTree(Target, True, True, True, False);
+  Target := ModuleTarget('PattEdit');
+  DelTree(Target, True, True, True, False);
+end;
+
+procedure InstallModule(const ModuleName, SettingsName: string);
+var
+  Target, BridgeSource, SettingsSource, BridgeDest, SettingsDest: string;
+begin
+  Target := ModuleTarget(ModuleName);
+  if not ForceDirectories(Target) then
+    RaiseException('Unable to create DipTrace plug-in directory: ' + Target);
+  BridgeSource := ExpandConstant('{app}\payload\diptrace_mcp_bridge.exe');
+  SettingsSource := ExpandConstant('{app}\payload\settings\' + SettingsName);
+  BridgeDest := AddBackslash(Target) + 'diptrace_mcp_bridge.exe';
+  SettingsDest := AddBackslash(Target) + 'settings.xml';
+  if not FileCopy(BridgeSource, BridgeDest, False) then
+    RaiseException('Unable to copy the DipTrace MCP bridge to ' + Target);
+  if not FileCopy(SettingsSource, SettingsDest, False) then
+    RaiseException('Unable to copy DipTrace MCP settings to ' + Target);
+  if CompareText(GetSHA256OfFile(BridgeSource), GetSHA256OfFile(BridgeDest)) <> 0 then
+    RaiseException('Bridge SHA-256 verification failed at ' + Target);
+  if CompareText(GetSHA256OfFile(SettingsSource), GetSHA256OfFile(SettingsDest)) <> 0 then
+    RaiseException('Settings SHA-256 verification failed at ' + Target);
+end;
+
+procedure InstallPluginPayload;
+begin
+  if not IsDipTraceLayout(SelectedDipTrace) then
+    RaiseException('Selected directory is not a recognized DipTrace installation.');
+  try
+    InstallModule('Pcb', 'pcb.settings.xml');
+    InstallModule('Schematic', 'schematic.settings.xml');
+    InstallModule('CompEdit', 'component.settings.xml');
+    InstallModule('PattEdit', 'pattern.settings.xml');
+    SaveUtf8Line(ExpandConstant('{app}\diptrace-root.txt'), SelectedDipTrace);
+    PluginInstalled := True;
+  except
+    RemovePluginTargets;
+    RaiseException('DipTrace MCP plug-in installation failed; owned plug-in directories were rolled back.');
   end;
+end;
+
+procedure InitializeWizard;
+var
+  Root: string;
+begin
+  DipTracePage := CreateInputOptionPage(
+    wpSelectDir,
+    'DipTrace installation',
+    'Choose the DipTrace installation to integrate',
+    'This administrator-only installer writes only DipTrace MCP plug-in folders.',
+    True,
+    True
+  );
+  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace5'), 'Program Files');
+  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace'), 'Program Files');
+  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace5'), 'Program Files (x86)');
+  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace'), 'Program Files (x86)');
+  AddRegistryDipTraceCandidates(HKLM);
+  AddRegistryDipTraceCandidates(HKCU);
+  DipTracePage.Add('Browse for another validated DipTrace installation');
+  DipTracePage.SelectedValueIndex := 0;
+
+  DipTraceBrowsePage := CreateInputDirPage(
+    DipTracePage.ID,
+    'Browse for DipTrace',
+    'Select the DipTrace root',
+    'The directory must contain a known DipTrace module executable or Plugins directory.',
+    False,
+    ''
+  );
+  DipTraceBrowsePage.Add('DipTrace root:');
+  Root := ParameterValue('DIPTRACE', '');
+  if Root <> '' then begin
+    SelectedDipTrace := ExpandFileName(Root);
+    DipTraceBrowsePage.Values[0] := SelectedDipTrace;
+    DipTracePage.SelectedValueIndex := GetArrayLength(DetectedDipTrace);
+  end;
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  if PageID = DipTraceBrowsePage.ID then
+    Result := (DipTracePage.SelectedValueIndex < GetArrayLength(DetectedDipTrace));
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  Index: Integer;
+begin
+  Result := True;
+  if CurPageID = DipTracePage.ID then begin
+    Index := DipTracePage.SelectedValueIndex;
+    if Index < GetArrayLength(DetectedDipTrace) then
+      SelectedDipTrace := DetectedDipTrace[Index]
+    else
+      SelectedDipTrace := ExpandFileName(DipTraceBrowsePage.Values[0]);
+  end;
+  if CurPageID = DipTraceBrowsePage.ID then begin
+    SelectedDipTrace := ExpandFileName(DipTraceBrowsePage.Values[0]);
+    if not IsDipTraceLayout(SelectedDipTrace) then begin
+      MsgBox('The selected directory is not a recognized DipTrace installation.', mbError, MB_OK);
+      Result := False;
+    end;
+  end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): string;
+var
+  Root: string;
+begin
+  Result := '';
+  NeedsRestart := False;
+  Root := ParameterValue('DIPTRACE', '');
+  if Root <> '' then
+    SelectedDipTrace := ExpandFileName(Root);
+  if (SelectedDipTrace = '') or not IsDipTraceLayout(SelectedDipTrace) then
+    Result := 'Select a validated DipTrace installation. The plug-in installer does not install the MCP server or modify MCP client profiles.';
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if (CurStep = ssPostInstall) and not PluginInstalled then
+    InstallPluginPayload;
+end;
+
+function LoadInstalledDipTraceRoot: string;
+var
+  Lines: TArrayOfString;
+begin
+  Result := '';
+  if LoadStringsFromFile(ExpandConstant('{app}\diptrace-root.txt'), Lines) and
+     (GetArrayLength(Lines) > 0) then
+    Result := Trim(Lines[0]);
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep <> usUninstall then Exit;
+  SelectedDipTrace := LoadInstalledDipTraceRoot;
+  RemovePluginTargets;
+end;
+#else
+const
+  ClientCodex = 0;
+  ClientClaude = 1;
+  ClientBoth = 2;
+  ClientNone = 3;
+
+var
+  WorkspacePage: TInputDirWizardPage;
+  StatePage: TInputDirWizardPage;
+  ClientPage: TInputOptionWizardPage;
+  RemoveClientCheck: TNewCheckBox;
+  RemoveStateCheck: TNewCheckBox;
+  InstallLogPath: string;
+  InstallationFinalized: Boolean;
+  ResolvedStateDir: string;
+  ResolvedWorkspaceDir: string;
+
+function HasCommandLineParam(const Name: string): Boolean;
+var
+  I: Integer;
+begin
+  Result := False;
+  for I := 1 to ParamCount do
+    if CompareText(ParamStr(I), Name) = 0 then begin
+      Result := True;
+      Exit;
+    end;
 end;
 
 function ParameterValue(const Name, DefaultValue: string): string;
 var
   I: Integer;
-  Argument: string;
-  Prefix: string;
+  Argument, Prefix: string;
 begin
   Result := ExpandConstant('{param:' + Name + '|' + DefaultValue + '}');
   Prefix := '/' + Lowercase(Name) + '=';
@@ -194,6 +387,32 @@ begin
           Result := Copy(Result, 2, Length(Result) - 2);
       Exit;
     end;
+  end;
+end;
+
+function IsSamePath(const Left, Right: string): Boolean;
+begin
+  Result := CompareText(Trim(AddBackslash(Left)), Trim(AddBackslash(Right))) = 0;
+end;
+
+function IsPathUnder(const Path, Root: string): Boolean;
+var
+  NormalPath, NormalRoot: string;
+begin
+  NormalPath := RemoveBackslash(ExpandFileName(Path));
+  NormalRoot := RemoveBackslash(ExpandFileName(Root));
+  Result := IsSamePath(NormalPath, NormalRoot) or
+    (CompareText(Copy(NormalPath, 1, Length(NormalRoot) + 1), AddBackslash(NormalRoot)) = 0);
+end;
+
+function SelectedClientName: string;
+begin
+  case ClientPage.SelectedValueIndex of
+    ClientCodex: Result := 'codex';
+    ClientClaude: Result := 'claude';
+    ClientBoth: Result := 'both';
+  else
+    Result := 'none';
   end;
 end;
 
@@ -212,7 +431,11 @@ end;
 procedure AppendInstallLog(const Line: string);
 begin
   if InstallLogPath = '' then Exit;
-  if not SaveStringToFile(InstallLogPath, GetDateTimeString('yyyy-mm-dd hh:nn:ss', '-', ':') + ' ' + Line + #13#10, True) then
+  if not SaveStringToFile(
+    InstallLogPath,
+    GetDateTimeString('yyyy-mm-dd hh:nn:ss', '-', ':') + ' ' + Line + #13#10,
+    True
+  ) then
     RaiseException('Unable to write the installation log');
 end;
 
@@ -225,29 +448,36 @@ begin
   SaveStringsToUTF8FileWithoutBOM(FileName, Lines, False);
 end;
 
-function RunPowerShell(const Parameters: string; const Elevated: Boolean; var ResultCode: Integer): Boolean;
+function RunPowerShell(const Parameters: string; var ResultCode: Integer): Boolean;
 var
   PowerShell: string;
 begin
   PowerShell := ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe');
-  if Elevated then
-    Result := ShellExec('runas', PowerShell, Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
-  else
-    Result := Exec(PowerShell, Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Result := Exec(PowerShell, Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;
 
 function RunServerHelp: Boolean;
 var
   ResultCode: Integer;
 begin
-  Result := Exec(ExpandConstant('{app}\app\diptrace_mcp_server.exe'), '--help', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+  Result := Exec(
+    ExpandConstant('{app}\app\diptrace_mcp_server.exe'),
+    '--help',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) and (ResultCode = 0);
 end;
 
 function CheckServerProcess: Boolean;
 var
   ResultCode: Integer;
 begin
-  Result := RunPowerShell('-NoProfile -NonInteractive -Command "if (Get-Process -Name diptrace_mcp_server -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"', False, ResultCode) and (ResultCode = 0);
+  Result := RunPowerShell(
+    '-NoProfile -NonInteractive -Command "if (Get-Process -Name diptrace_mcp_server -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"',
+    ResultCode
+  ) and (ResultCode = 0);
 end;
 
 procedure CreateInstallationManifest;
@@ -255,52 +485,16 @@ var
   Parameters: string;
   ResultCode: Integer;
 begin
-  Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\write_installation_manifest.ps1') +
+  Parameters :=
+    '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' +
+    ExpandConstant('{app}\tools\write_installation_manifest.ps1') +
     '" -ManifestPath "' + ExpandConstant('{app}\installation-manifest.json') +
     '" -AppRoot "' + ExpandConstant('{app}') +
     '" -Version "' + ExpandConstant('{#AppVersion}') +
     '" -StateDir "' + SelectedStateDir + '"';
-  if IsPluginSelected then
-    Parameters := Parameters + ' -PluginRoots "' + SelectedDipTrace + '"';
-  if not RunPowerShell(Parameters, False, ResultCode) or (ResultCode <> 0) then
+  if not RunPowerShell(Parameters, ResultCode) or (ResultCode <> 0) then
     RaiseException('Unable to create installation-manifest.json');
   SaveUtf8Line(ExpandConstant('{app}\state-dir.txt'), SelectedStateDir);
-  SaveUtf8Line(ExpandConstant('{app}\plugin-targets.txt'), SelectedDipTrace);
-end;
-
-procedure InstallDipTracePlugin;
-var
-  Parameters: string;
-  ResultCode: Integer;
-  NeedsElevation: Boolean;
-begin
-  if not IsPluginSelected then Exit;
-  Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\install_plugin.ps1') +
-    '" -DipTraceDir "' + SelectedDipTrace +
-    '" -Mode All -BridgeExe "' + ExpandConstant('{app}\bridge\diptrace_mcp_bridge.exe') + '"';
-  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf}')) or
-    IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf32}'));
-  AppendInstallLog('DipTrace plugin integration requested; elevation may be required.');
-  if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then
-    RaiseException('DipTrace plug-in installation failed. No client configuration was attempted.');
-  AppendInstallLog('DipTrace plugin integration completed.');
-end;
-
-procedure RollbackDipTracePlugin;
-var
-  Parameters: string;
-  ResultCode: Integer;
-  NeedsElevation: Boolean;
-begin
-  if not IsPluginSelected or (SelectedDipTrace = '') then Exit;
-  Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\uninstall_plugin.ps1') +
-    '" -DipTraceDir "' + SelectedDipTrace + '" -InstallScript "' + ExpandConstant('{app}\tools\install_plugin.ps1') + '"';
-  NeedsElevation := IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf}')) or
-    IsPathUnder(SelectedDipTrace, ExpandConstant('{commonpf32}'));
-  if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then
-    AppendInstallLog('WARNING: automatic DipTrace plug-in rollback failed.')
-  else
-    AppendInstallLog('DipTrace plug-in rollback completed.');
 end;
 
 procedure ConfigureMcpClient;
@@ -312,18 +506,29 @@ begin
     AppendInstallLog('MCP client configuration skipped by user.');
     Exit;
   end;
-  Parameters := '--client ' + SelectedClientName + ' --workspace "' + SelectedWorkspaceDir +
-    '" --state-dir "' + SelectedStateDir + '" --server "' +
-    ExpandConstant('{app}\app\diptrace_mcp_server.exe') + '" --json';
-  if not Exec(ExpandConstant('{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
-    RaiseException('MCP client configuration failed closed. The original client configuration was preserved.');
+  Parameters :=
+    '--client ' + SelectedClientName +
+    ' --workspace "' + SelectedWorkspaceDir +
+    '" --state-dir "' + SelectedStateDir +
+    '" --server "' + ExpandConstant('{app}\app\diptrace_mcp_server.exe') +
+    '" --json';
+  if not Exec(
+    ExpandConstant('{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe'),
+    Parameters,
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) or (ResultCode <> 0) then
+    RaiseException(
+      'MCP client configuration failed closed. The original client configuration was preserved.'
+    );
   AppendInstallLog('MCP client configuration completed or deferred with a manual command.');
 end;
 
 procedure FinalizeInstallation;
 var
-  StateDir: string;
-  InstallStamp: string;
+  StateDir, InstallStamp: string;
 begin
   if InstallationFinalized then Exit;
   InstallationFinalized := True;
@@ -335,22 +540,15 @@ begin
   InstallLogPath := AddBackslash(StateDir) + 'logs\install-' + InstallStamp + '.log';
   if not ForceDirectories(ExtractFileDir(InstallLogPath)) then
     RaiseException('Unable to create the installation log directory');
-  AppendInstallLog('Installation started. No secrets or client-config contents are logged.');
+  AppendInstallLog('Per-user installation started. No secrets or client-config contents are logged.');
   if not RunServerHelp then
     RaiseException('Standalone server verification failed: diptrace_mcp_server.exe --help');
   AppendInstallLog('Standalone server --help smoke passed.');
-  try
-    InstallDipTracePlugin;
-    ConfigureMcpClient;
-  except
-    RollbackDipTracePlugin;
-    RaiseException('Installation failed; DipTrace plugin rollback was attempted.');
-  end;
+  ConfigureMcpClient;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
-  { ssDone is retained as a defensive fallback for silent bootstrapper runs. }
   if (CurStep = ssPostInstall) or (CurStep = ssDone) then
     FinalizeInstallation;
 end;
@@ -359,62 +557,28 @@ function PrepareToInstall(var NeedsRestart: Boolean): string;
 begin
   Result := '';
   NeedsRestart := False;
-  if not CheckServerProcess then begin
+  if not CheckServerProcess then
     Result := 'Close diptrace_mcp_server.exe and retry. An active server/session is not terminated automatically.';
-    Exit;
-  end;
-  if IsPluginSelected and (SelectedDipTrace = '') then
-    Result := 'Select a validated DipTrace installation or choose Server only.';
-end;
-
-function ShouldSkipPage(PageID: Integer): Boolean;
-begin
-  Result := False;
-  if (PageID = DipTracePage.ID) or (PageID = DipTraceBrowsePage.ID) then
-    Result := not IsPluginSelected;
-  if PageID = DipTraceBrowsePage.ID then
-    Result := Result or (DipTracePage.SelectedValueIndex < GetArrayLength(DetectedDipTrace));
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;
-var
-  Index: Integer;
 begin
   Result := True;
-  if CurPageID = DipTracePage.ID then begin
-    Index := DipTracePage.SelectedValueIndex;
-    if Index < GetArrayLength(DetectedDipTrace) then
-      SelectedDipTrace := DetectedDipTrace[Index]
-    else if Index = GetArrayLength(DetectedDipTrace) then
-      SelectedDipTrace := ExpandFileName(DipTraceBrowsePage.Values[0])
-    else if Index = GetArrayLength(DetectedDipTrace) + 1 then
-      SelectedDipTrace := '';
-  end;
-  if CurPageID = wpSelectComponents then
-    PluginSelection := WizardIsComponentSelected('plugin');
-  if CurPageID = DipTraceBrowsePage.ID then begin
-    SelectedDipTrace := ExpandFileName(DipTraceBrowsePage.Values[0]);
-    if not IsDipTraceLayout(SelectedDipTrace) then begin
-      MsgBox('The selected directory is not a recognized DipTrace installation. Select a root containing a known module executable or Plugins module directory.', mbError, MB_OK);
-      Result := False;
-    end;
-  end;
   if CurPageID = WorkspacePage.ID then begin
     ResolvedWorkspaceDir := Trim(WorkspacePage.Values[0]);
     if WorkspacePage.Values[0] = '' then begin
       MsgBox('Choose a DipTrace workspace directory.', mbError, MB_OK);
       Result := False;
-    end else if not DirExists(WorkspacePage.Values[0]) and not ForceDirectories(WorkspacePage.Values[0]) then begin
+    end else if not DirExists(WorkspacePage.Values[0]) and
+                not ForceDirectories(WorkspacePage.Values[0]) then begin
       MsgBox('The workspace directory could not be created.', mbError, MB_OK);
       Result := False;
     end;
   end;
   if CurPageID = StatePage.ID then begin
     ResolvedStateDir := Trim(StatePage.Values[0]);
-    if IsPathUnder(StatePage.Values[0], ExpandConstant('{app}')) or
-       IsPathUnder(StatePage.Values[0], ExpandConstant('{commonpf}')) or
-       IsPathUnder(StatePage.Values[0], ExpandConstant('{commonpf32}')) then begin
-      MsgBox('State must remain outside the installed application and Program Files.', mbError, MB_OK);
+    if IsPathUnder(StatePage.Values[0], ExpandConstant('{app}')) then begin
+      MsgBox('State must remain outside the installed application.', mbError, MB_OK);
       Result := False;
     end else if not ForceDirectories(StatePage.Values[0]) then begin
       MsgBox('The state directory could not be created.', mbError, MB_OK);
@@ -425,38 +589,46 @@ end;
 
 procedure InitializeWizard;
 var
-  Root: string;
   ClientParam: string;
 begin
-  PluginSelection := not HasCommandLineParam('/SERVERONLY');
-  DipTracePage := CreateInputOptionPage(wpSelectComponents, 'DipTrace installation', 'Choose DipTrace integration', 'Only a validated installation is offered for plug-in integration.', True, True);
-  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace5'), 'Program Files');
-  AddDipTraceCandidate(ExpandConstant('{commonpf}\DipTrace'), 'Program Files');
-  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace5'), 'Program Files (x86)');
-  AddDipTraceCandidate(ExpandConstant('{commonpf32}\DipTrace'), 'Program Files (x86)');
-  AddRegistryDipTraceCandidates(HKCU);
-  AddRegistryDipTraceCandidates(HKLM);
-  DipTracePage.Add('Browse for another validated DipTrace installation');
-  DipTracePage.Add('Server only — do not install DipTrace integration');
-  if GetArrayLength(DetectedDipTrace) = 0 then DipTracePage.SelectedValueIndex := 1
-  else DipTracePage.SelectedValueIndex := 0;
-
-  DipTraceBrowsePage := CreateInputDirPage(DipTracePage.ID, 'Browse for DipTrace', 'Select the DipTrace root', 'The directory must contain a known module executable or Plugins module directory.', False, '');
-  DipTraceBrowsePage.Add('DipTrace root:');
-  Root := ParameterValue('DIPTRACE', '');
-  if Root <> '' then DipTraceBrowsePage.Values[0] := Root;
-
-  WorkspacePage := CreateInputDirPage(DipTraceBrowsePage.ID, 'Project workspace', 'Choose DipTrace project workspace', 'The server will be restricted to this directory unless additional roots are configured later.', False, '');
+  WorkspacePage := CreateInputDirPage(
+    wpSelectComponents,
+    'Project workspace',
+    'Choose DipTrace project workspace',
+    'The server will be restricted to this directory unless additional roots are configured later.',
+    False,
+    ''
+  );
   WorkspacePage.Add('Workspace:');
-  ResolvedWorkspaceDir := ParameterValue('WORKSPACE', ExpandConstant('{userdocs}\DipTrace'));
+  ResolvedWorkspaceDir := ParameterValue(
+    'WORKSPACE',
+    ExpandConstant('{userdocs}\DipTrace')
+  );
   WorkspacePage.Values[0] := ResolvedWorkspaceDir;
 
-  StatePage := CreateInputDirPage(WorkspacePage.ID, 'Local writable state', 'Choose local MCP state directory', 'Runtime state and logs are kept here, never under Program Files.', False, '');
+  StatePage := CreateInputDirPage(
+    WorkspacePage.ID,
+    'Local writable state',
+    'Choose local MCP state directory',
+    'Runtime state and logs are kept outside the installed application.',
+    False,
+    ''
+  );
   StatePage.Add('State directory:');
-  ResolvedStateDir := ParameterValue('STATEDIR', ExpandConstant('{localappdata}\DipTraceMCP'));
+  ResolvedStateDir := ParameterValue(
+    'STATEDIR',
+    ExpandConstant('{localappdata}\DipTraceMCP')
+  );
   StatePage.Values[0] := ResolvedStateDir;
 
-  ClientPage := CreateInputOptionPage(StatePage.ID, 'MCP client', 'Choose client configuration', 'Existing entries are updated idempotently and other servers are preserved.', True, True);
+  ClientPage := CreateInputOptionPage(
+    StatePage.ID,
+    'MCP client',
+    'Choose client configuration',
+    'Existing entries are updated idempotently and other servers are preserved.',
+    True,
+    True
+  );
   ClientPage.Add('Configure Codex');
   ClientPage.Add('Configure Claude Desktop');
   ClientPage.Add('Configure both');
@@ -466,11 +638,6 @@ begin
   if ClientParam = 'codex' then ClientPage.SelectedValueIndex := ClientCodex
   else if ClientParam = 'claude' then ClientPage.SelectedValueIndex := ClientClaude
   else if ClientParam = 'both' then ClientPage.SelectedValueIndex := ClientBoth;
-  Root := ParameterValue('DIPTRACE', '');
-  if Root <> '' then begin
-    DipTracePage.SelectedValueIndex := GetArrayLength(DetectedDipTrace);
-    DipTraceBrowsePage.Values[0] := Root;
-  end;
 end;
 
 procedure InitializeUninstallProgressForm;
@@ -482,12 +649,14 @@ begin
   RemoveClientCheck.Width := UninstallProgressForm.ClientWidth - 32;
   RemoveClientCheck.Caption := 'Remove DipTrace MCP entries from Codex and Claude Desktop';
   RemoveClientCheck.Checked := HasCommandLineParam('/REMOVE_CLIENT_CONFIG');
+
   RemoveStateCheck := TNewCheckBox.Create(UninstallProgressForm);
   RemoveStateCheck.Parent := UninstallProgressForm;
   RemoveStateCheck.Left := 16;
   RemoveStateCheck.Top := UninstallProgressForm.ClientHeight - 52;
   RemoveStateCheck.Width := UninstallProgressForm.ClientWidth - 32;
-  RemoveStateCheck.Caption := 'Remove local DipTrace MCP state and logs (projects are never removed)';
+  RemoveStateCheck.Caption :=
+    'Remove local DipTrace MCP state and logs (projects are never removed)';
   RemoveStateCheck.Checked := HasCommandLineParam('/REMOVE_STATE');
 end;
 
@@ -496,21 +665,36 @@ var
   Lines: TArrayOfString;
 begin
   Result := '';
-  if LoadStringsFromFile(ExpandConstant('{app}\state-dir.txt'), Lines) and (GetArrayLength(Lines) > 0) then
+  if LoadStringsFromFile(
+    ExpandConstant('{app}\state-dir.txt'),
+    Lines
+  ) and (GetArrayLength(Lines) > 0) then
     Result := Lines[0];
 end;
 
 function RemoveClientConfiguration: Boolean;
 var
   ResultCode: Integer;
-  StateDir: string;
-  Parameters: string;
+  StateDir, Parameters: string;
 begin
   Result := True;
   StateDir := UninstallStateDir;
-  Parameters := '--client both --unconfigure --state-dir "' + StateDir + '" --json';
-  if not Exec(ExpandConstant('{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then begin
-    MsgBox('Client configuration was not changed because it was invalid or unavailable. The original files remain for manual recovery.', mbError, MB_OK);
+  Parameters :=
+    '--client both --unconfigure --state-dir "' + StateDir + '" --json';
+  if not Exec(
+    ExpandConstant('{app}\tools\diptrace_mcp_configure\diptrace_mcp_configure.exe'),
+    Parameters,
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) or (ResultCode <> 0) then begin
+    MsgBox(
+      'Client configuration was not changed because it was invalid or unavailable. ' +
+      'The original files remain for manual recovery.',
+      mbError,
+      MB_OK
+    );
     Result := False;
   end;
 end;
@@ -518,55 +702,33 @@ end;
 function RemoveLocalState: Boolean;
 var
   ResultCode: Integer;
-  StateDir: string;
-  Parameters: string;
+  StateDir, Parameters: string;
 begin
   Result := True;
   StateDir := UninstallStateDir;
   if StateDir = '' then Exit;
   Log('DipTrace MCP uninstall: removing owned local state');
-  Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\remove_owned_state.ps1') + '" -ManifestPath "' + ExpandConstant('{app}\installation-manifest.json') + '"';
-  if not RunPowerShell(Parameters, False, ResultCode) or (ResultCode <> 0) then begin
+  Parameters :=
+    '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' +
+    ExpandConstant('{app}\tools\remove_owned_state.ps1') +
+    '" -ManifestPath "' + ExpandConstant('{app}\installation-manifest.json') + '"';
+  if not RunPowerShell(Parameters, ResultCode) or (ResultCode <> 0) then begin
     Log('DipTrace MCP uninstall: owned state removal failed with code ' + IntToStr(ResultCode));
     if not UninstallSilent then
-      MsgBox('Owned local state was not removed; projects and unknown files were preserved.', mbError, MB_OK);
+      MsgBox(
+        'Owned local state was not removed; projects and unknown files were preserved.',
+        mbError,
+        MB_OK
+      );
     Result := False;
   end else
     Log('DipTrace MCP uninstall: owned local state removal completed');
-end;
-
-procedure RemoveDipTracePlugins;
-var
-  Lines: TArrayOfString;
-  I, ResultCode: Integer;
-  Parameters: string;
-  NeedsElevation: Boolean;
-begin
-  if not LoadStringsFromFile(ExpandConstant('{app}\plugin-targets.txt'), Lines) then Exit;
-  Log('DipTrace MCP uninstall: removing DipTrace plug-in targets');
-  for I := 0 to GetArrayLength(Lines) - 1 do begin
-    if Trim(Lines[I]) = '' then Continue;
-    Parameters := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\tools\uninstall_plugin.ps1') + '" -DipTraceDir "' + Trim(Lines[I]) + '" -InstallScript "' + ExpandConstant('{app}\tools\install_plugin.ps1') + '"';
-    NeedsElevation := IsPathUnder(Trim(Lines[I]), ExpandConstant('{commonpf}')) or
-      IsPathUnder(Trim(Lines[I]), ExpandConstant('{commonpf32}'));
-    if not RunPowerShell(Parameters, NeedsElevation, ResultCode) or (ResultCode <> 0) then begin
-      Log('DipTrace MCP uninstall: plug-in removal failed with code ' + IntToStr(ResultCode));
-      if not UninstallSilent then
-        MsgBox('A DipTrace plug-in directory could not be removed: ' + Trim(Lines[I]) + '. Remove only the listed DipTraceMCP folders manually.', mbError, MB_OK);
-    end else
-      Log('DipTrace MCP uninstall: plug-in removal completed');
-  end;
-end;
-
-function InitializeUninstall: Boolean;
-begin
-  Result := True;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep <> usUninstall then Exit;
   if RemoveClientCheck.Checked and not RemoveClientConfiguration then Abort;
-  RemoveDipTracePlugins;
   if RemoveStateCheck.Checked and not RemoveLocalState then Abort;
 end;
+#endif

--- a/installer/DipTraceMCP.iss
+++ b/installer/DipTraceMCP.iss
@@ -193,13 +193,13 @@ var
 begin
   if SelectedDipTrace = '' then Exit;
   Target := ModuleTarget('Pcb');
-  DelTree(Target, True, True, True, False);
+  DelTree(Target, True, True, True);
   Target := ModuleTarget('Schematic');
-  DelTree(Target, True, True, True, False);
+  DelTree(Target, True, True, True);
   Target := ModuleTarget('CompEdit');
-  DelTree(Target, True, True, True, False);
+  DelTree(Target, True, True, True);
   Target := ModuleTarget('PattEdit');
-  DelTree(Target, True, True, True, False);
+  DelTree(Target, True, True, True);
 end;
 
 procedure InstallModule(const ModuleName, SettingsName: string);

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -21,6 +21,7 @@ $BridgeDefault = Join-Path $RepoRoot "plugin\dist\diptrace_mcp_bridge.exe"
 $InstallerDir = Join-Path $OutputRoot "installer"
 $PortableDir = Join-Path $OutputRoot "portable"
 $InstallerOutput = Join-Path $InstallerDir ("DipTrace-MCP-Setup-{0}.exe" -f $Version)
+$PluginInstallerOutput = Join-Path $InstallerDir ("DipTrace-MCP-Plugin-Setup-{0}.exe" -f $Version)
 $PortableOutput = Join-Path $PortableDir ("DipTrace-MCP-Portable-{0}.zip" -f $Version)
 
 function Assert-File([string]$Path, [string]$Label) {
@@ -118,7 +119,7 @@ try {
         product_id = 'diptrace-mcp'
         version = $Version
         state_marker_file = '.diptrace-mcp-state-owner.json'
-        owned_install_relative_paths = @('app', 'bridge', 'settings-templates', 'tools', 'LICENSE', 'README_FIRST.txt', 'VERSION', 'installation-manifest.json')
+        owned_install_relative_paths = @('app', 'tools', 'LICENSE', 'README_FIRST.txt', 'VERSION', 'installation-manifest.json')
         owned_state_paths = @('logs', 'sessions', 'records', 'offline_backups', 'codex_setup.txt')
         signing_status = if ($SigningRequired) { 'signed-required' } else { 'unsigned-until-verified' }
     }
@@ -164,19 +165,26 @@ try {
     }
     $isccVersion = $isccVersions | Where-Object { $_.StartsWith('6.4.2') } | Select-Object -First 1
     if (-not $isccVersion) { throw "Inno Setup 6.4.2 is required; found $($isccVersions -join ', ')" }
-    $issArgs = @(
+
+    $baseIssArgs = @(
         ("/DAppVersion={0}" -f $Version)
         ("/DStageDir={0}" -f $Stage)
         ("/DOutputDir={0}" -f $InstallerDir)
-        (Join-Path $RepoRoot 'installer\DipTraceMCP.iss')
     )
-    Write-Host ("ISCC compile arguments ({0}): {1}" -f $issArgs.Count, ($issArgs -join ' | '))
-    Invoke-Checked -File $IsccPath -Arguments $issArgs
-    Assert-File $InstallerOutput 'Inno Setup installer'
+    $userIssArgs = @($baseIssArgs + (Join-Path $RepoRoot 'installer\DipTraceMCP.iss'))
+    Write-Host ("User ISCC compile arguments ({0}): {1}" -f $userIssArgs.Count, ($userIssArgs -join ' | '))
+    Invoke-Checked -File $IsccPath -Arguments $userIssArgs
+    Assert-File $InstallerOutput 'per-user Inno Setup installer'
+
+    $pluginIssArgs = @($baseIssArgs + '/DPluginOnly=1' + (Join-Path $RepoRoot 'installer\DipTraceMCP.iss'))
+    Write-Host ("Plugin ISCC compile arguments ({0}): {1}" -f $pluginIssArgs.Count, ($pluginIssArgs -join ' | '))
+    Invoke-Checked -File $IsccPath -Arguments $pluginIssArgs
+    Assert-File $PluginInstallerOutput 'administrator plug-in Inno Setup installer'
 
     $verifyScript = Join-Path $RepoRoot 'plugin\verify_signature.ps1'
     $signatureTargets = @(
         $InstallerOutput,
+        $PluginInstallerOutput,
         $BridgePath,
         (Join-Path $ServerDist 'diptrace_mcp_server.exe'),
         (Join-Path $ConfiguratorDist 'diptrace_mcp_configure.exe')
@@ -189,9 +197,10 @@ try {
         Invoke-Checked 'powershell.exe' $verifyArgs
     }
     $releaseChecksums = Join-Path $OutputRoot 'SHA256SUMS.txt'
-    Write-ReleaseAssetShaManifest -Path $releaseChecksums -Assets @($InstallerOutput, $PortableOutput)
+    Write-ReleaseAssetShaManifest -Path $releaseChecksums -Assets @($InstallerOutput, $PluginInstallerOutput, $PortableOutput)
     Assert-File $releaseChecksums 'release asset checksum manifest'
-    Write-Host "Installer: $InstallerOutput" -ForegroundColor Green
+    Write-Host "User installer: $InstallerOutput" -ForegroundColor Green
+    Write-Host "Plug-in installer: $PluginInstallerOutput" -ForegroundColor Green
     Write-Host "Portable: $PortableOutput" -ForegroundColor Green
     Write-Host "Checksums: $releaseChecksums" -ForegroundColor Green
 } finally {

--- a/scripts/build_windows_server.ps1
+++ b/scripts/build_windows_server.ps1
@@ -80,5 +80,12 @@ if (-not (Test-Path -LiteralPath $HeadlessExecutable -PathType Leaf)) {
 & $HeadlessExecutable --help | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "Headless GUI executable startup smoke failed" }
 
+# Exercise the real CreateProcessW native-desktop targeting primitive on Windows
+# without DipTrace. The probe verifies desktop, WinSta0 window station and
+# session identity. It performs no GUI mutation and is allowed on an elevated
+# CI runner; actual native round-trips still fail closed when elevated.
+& $HeadlessExecutable native-smoke --timeout 20 | Out-Host
+if ($LASTEXITCODE -ne 0) { throw "Headless GUI native desktop security smoke failed" }
+
 Write-Host "Standalone server built: $Executable" -ForegroundColor Green
 Write-Host "Headless GUI helper built: $HeadlessExecutable" -ForegroundColor Green

--- a/src/diptrace_mcp/headless_gui.py
+++ b/src/diptrace_mcp/headless_gui.py
@@ -1,8 +1,10 @@
-"""Run bounded DipTrace GUI work on an isolated Win32 desktop.
+"""Run bounded DipTrace GUI work on Windows.
 
-This module is a host/runtime helper, not a new public MCP tool surface. It never
-switches the user's input desktop and intentionally contains no physical
-mouse/keyboard fallback.
+This module is a host/runtime helper, not a new public MCP tool surface. Hidden
+mode uses a separate WinSta0 desktop to avoid interfering with the operator's
+input desktop; native mode is explicit and visible. Neither mode provides a
+process, filesystem, network, token, or privilege sandbox, and there is no
+physical mouse/keyboard fallback.
 """
 
 from __future__ import annotations
@@ -55,10 +57,11 @@ _WAIT_OBJECT_0 = 0
 _WAIT_TIMEOUT = 0x102
 _STILL_ACTIVE = 259
 _DESKTOP_MODES = ("hidden", "native")
+_INTERACTIVE_WINDOW_STATION = "WinSta0"
 
 
 class HeadlessGuiError(RuntimeError):
-    """Raised when the isolated native-GUI worker cannot proceed safely."""
+    """Raised when the bounded native-GUI worker cannot proceed safely."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,6 +134,9 @@ class RoundtripResult:
     forced_termination: bool = False
     error: str | None = None
     desktop_mode: str = "hidden"
+    window_station_name: str | None = None
+    session_id: int | None = None
+    desktop_changed: bool = False
 
     def as_json(self) -> dict[str, object]:
         return cast(dict[str, object], asdict(self))
@@ -155,6 +161,9 @@ class RoundtripResult:
             forced_termination=bool(value.get("forced_termination", False)),
             error=_optional_string(value.get("error")),
             desktop_mode=_string_or_default(value.get("desktop_mode"), "hidden"),
+            window_station_name=_optional_string(value.get("window_station_name")),
+            session_id=_optional_int(value.get("session_id")),
+            desktop_changed=bool(value.get("desktop_changed", False)),
         )
 
 
@@ -165,6 +174,22 @@ class DesktopSmokeResult:
     child_desktop_name: str | None
     input_desktop_before: str | None
     input_desktop_after: str | None
+    child_exit_code: int | None
+    error: str | None = None
+
+    def as_json(self) -> dict[str, object]:
+        return cast(dict[str, object], asdict(self))
+
+
+@dataclass(frozen=True, slots=True)
+class NativeDesktopSmokeResult:
+    ok: bool
+    desktop_name: str | None
+    child_desktop_name: str | None
+    window_station_name: str | None
+    child_window_station_name: str | None
+    session_id: int | None
+    child_session_id: int | None
     child_exit_code: int | None
     error: str | None = None
 
@@ -207,12 +232,13 @@ class _PROCESS_INFORMATION(ctypes.Structure):
 class _Win32Api:
     def __init__(self) -> None:
         if os.name != "nt":
-            raise HeadlessGuiError("headless GUI isolation is available only on Windows")
+            raise HeadlessGuiError("Windows GUI worker is available only on Windows")
         win_dll = ctypes.__dict__.get("WinDLL")
         if win_dll is None:
             raise HeadlessGuiError("Windows ctypes bindings are unavailable")
         self.user32: Any = win_dll("user32", use_last_error=True)
         self.kernel32: Any = win_dll("kernel32", use_last_error=True)
+        self.shell32: Any = win_dll("shell32", use_last_error=True)
         self._configure()
 
     def _configure(self) -> None:
@@ -235,6 +261,8 @@ class _Win32Api:
             wintypes.DWORD,
         ]
         self.user32.OpenInputDesktop.restype = wintypes.HANDLE
+        self.user32.GetProcessWindowStation.argtypes = []
+        self.user32.GetProcessWindowStation.restype = wintypes.HANDLE
         self.user32.GetUserObjectInformationW.argtypes = [
             wintypes.HANDLE,
             ctypes.c_int,
@@ -269,6 +297,15 @@ class _Win32Api:
         self.kernel32.CloseHandle.restype = wintypes.BOOL
         self.kernel32.GetCurrentThreadId.argtypes = []
         self.kernel32.GetCurrentThreadId.restype = wintypes.DWORD
+        self.kernel32.GetCurrentProcessId.argtypes = []
+        self.kernel32.GetCurrentProcessId.restype = wintypes.DWORD
+        self.kernel32.ProcessIdToSessionId.argtypes = [
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.kernel32.ProcessIdToSessionId.restype = wintypes.BOOL
+        self.shell32.IsUserAnAdmin.argtypes = []
+        self.shell32.IsUserAnAdmin.restype = wintypes.BOOL
 
     def error(self, operation: str) -> HeadlessGuiError:
         code = ctypes.get_last_error()
@@ -317,7 +354,7 @@ class CreatedProcess:
 
 
 class HiddenDesktop:
-    """A WinSta0 desktop that is never made the physical input desktop."""
+    """A separate WinSta0 desktop that is never made the physical input desktop."""
 
     def __init__(self, name: str) -> None:
         _validate_desktop_name(name)
@@ -327,7 +364,7 @@ class HiddenDesktop:
 
     @property
     def qualified_name(self) -> str:
-        return f"WinSta0\\{self.name}"
+        return f"{_INTERACTIVE_WINDOW_STATION}\\{self.name}"
 
     def open(self) -> HiddenDesktop:
         if self._handle is not None:
@@ -348,32 +385,7 @@ class HiddenDesktop:
     def launch(self, argv: Sequence[str], *, cwd: Path | None = None) -> CreatedProcess:
         if self._handle is None:
             raise HeadlessGuiError("hidden desktop is not open")
-        if not argv or not str(argv[0]).strip():
-            raise ValueError("argv must contain an executable")
-        application = str(argv[0])
-        command = ctypes.create_unicode_buffer(
-            subprocess.list2cmdline([str(item) for item in argv])
-        )
-        desktop = ctypes.create_unicode_buffer(self.qualified_name)
-        startup = _STARTUPINFOW()
-        startup.cb = ctypes.sizeof(_STARTUPINFOW)
-        startup.lpDesktop = ctypes.cast(desktop, wintypes.LPWSTR)
-        info = _PROCESS_INFORMATION()
-        created = self._api.kernel32.CreateProcessW(
-            application,
-            command,
-            None,
-            None,
-            False,
-            0,
-            None,
-            str(cwd) if cwd is not None else None,
-            ctypes.byref(startup),
-            ctypes.byref(info),
-        )
-        if not created:
-            raise self._api.error("CreateProcessW")
-        return CreatedProcess(self._api, info)
+        return _launch_process_on_desktop(argv, self.qualified_name, cwd=cwd)
 
     def close(self) -> None:
         if self._handle is None:
@@ -387,40 +399,6 @@ class HiddenDesktop:
 
     def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
         self.close()
-
-
-def _launch_on_current_desktop(argv: Sequence[str], *, cwd: Path | None = None) -> CreatedProcess:
-    """Launch the worker on the user's current interactive desktop (native mode).
-
-    The bounded lifecycle contract is identical to the hidden-desktop launch;
-    only the desktop override is absent, so the child inherits the current
-    Win32 desktop and the editor window stays visible to the operator.
-    """
-    if not argv or not str(argv[0]).strip():
-        raise ValueError("argv must contain an executable")
-    api = _Win32Api()
-    application = str(argv[0])
-    command = ctypes.create_unicode_buffer(
-        subprocess.list2cmdline([str(item) for item in argv])
-    )
-    startup = _STARTUPINFOW()
-    startup.cb = ctypes.sizeof(_STARTUPINFOW)
-    info = _PROCESS_INFORMATION()
-    created = api.kernel32.CreateProcessW(
-        application,
-        command,
-        None,
-        None,
-        False,
-        0,
-        None,
-        str(cwd) if cwd is not None else None,
-        ctypes.byref(startup),
-        ctypes.byref(info),
-    )
-    if not created:
-        raise api.error("CreateProcessW")
-    return CreatedProcess(api, info)
 
 
 def _required_string(value: Mapping[str, object], key: str) -> str:
@@ -470,8 +448,8 @@ def _coerce_float(value: object, default: float) -> float:
 def _validate_desktop_name(name: str) -> None:
     if not name.strip():
         raise ValueError("desktop name must not be empty")
-    if "\\" in name or "/" in name:
-        raise ValueError("desktop name must not contain path separators")
+    if "\\" in name or "/" in name or "\x00" in name:
+        raise ValueError("desktop name must not contain path separators or NUL")
     if len(name) > 128:
         raise ValueError("desktop name is too long")
 
@@ -521,6 +499,114 @@ def input_desktop_name() -> str | None:
         api.user32.CloseDesktop(handle)
 
 
+def process_window_station_name() -> str:
+    api = _Win32Api()
+    handle = api.user32.GetProcessWindowStation()
+    if not handle:
+        raise api.error("GetProcessWindowStation")
+    return _desktop_object_name(int(handle))
+
+
+def process_session_id(pid: int | None = None) -> int:
+    api = _Win32Api()
+    process_id = int(api.kernel32.GetCurrentProcessId()) if pid is None else int(pid)
+    session_id = wintypes.DWORD()
+    if not api.kernel32.ProcessIdToSessionId(process_id, ctypes.byref(session_id)):
+        raise api.error("ProcessIdToSessionId")
+    return int(session_id.value)
+
+
+def process_is_elevated() -> bool:
+    api = _Win32Api()
+    return bool(api.shell32.IsUserAnAdmin())
+
+
+def _interactive_context() -> tuple[str, str, int]:
+    desktop = input_desktop_name()
+    if desktop is None:
+        raise HeadlessGuiError(
+            "cannot determine the current input desktop; native launch declined"
+        )
+    _validate_desktop_name(desktop)
+    station = process_window_station_name()
+    if station.casefold() != _INTERACTIVE_WINDOW_STATION.casefold():
+        raise HeadlessGuiError(
+            f"native launch requires {_INTERACTIVE_WINDOW_STATION}; "
+            f"current window station is {station!r}"
+        )
+    return desktop, station, process_session_id()
+
+
+def _launch_process_on_desktop(
+    argv: Sequence[str],
+    qualified_desktop: str,
+    *,
+    cwd: Path | None = None,
+) -> CreatedProcess:
+    if not argv or not str(argv[0]).strip():
+        raise ValueError("argv must contain an executable")
+    if "\\" not in qualified_desktop:
+        raise ValueError("qualified desktop must include a window station")
+    api = _Win32Api()
+    application = str(argv[0])
+    command = ctypes.create_unicode_buffer(
+        subprocess.list2cmdline([str(item) for item in argv])
+    )
+    desktop_buffer = ctypes.create_unicode_buffer(qualified_desktop)
+    startup = _STARTUPINFOW()
+    startup.cb = ctypes.sizeof(_STARTUPINFOW)
+    startup.lpDesktop = ctypes.cast(desktop_buffer, wintypes.LPWSTR)
+    info = _PROCESS_INFORMATION()
+    created = api.kernel32.CreateProcessW(
+        application,
+        command,
+        None,
+        None,
+        False,
+        0,
+        None,
+        str(cwd) if cwd is not None else None,
+        ctypes.byref(startup),
+        ctypes.byref(info),
+    )
+    if not created:
+        raise api.error("CreateProcessW")
+    return CreatedProcess(api, info)
+
+
+def _launch_on_current_desktop(
+    argv: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    require_non_elevated: bool = True,
+) -> CreatedProcess:
+    """Launch on the verified current WinSta0 input desktop.
+
+    Native mode is visible and is intentionally refused from an elevated caller.
+    It does not inherit an unspecified desktop: STARTUPINFO.lpDesktop explicitly
+    targets the current ``WinSta0\\<input-desktop>``.
+    """
+    if require_non_elevated and process_is_elevated():
+        raise HeadlessGuiError(
+            "native launch declined from an elevated process; run the GUI worker "
+            "with the normal user token"
+        )
+    desktop, station, session = _interactive_context()
+    child = _launch_process_on_desktop(argv, f"{station}\\{desktop}", cwd=cwd)
+    try:
+        child_session = process_session_id(child.pid)
+        if child_session != session:
+            raise HeadlessGuiError(
+                f"native child session mismatch: {child_session} != {session}"
+            )
+        return child
+    except Exception:
+        with suppress(Exception):
+            child.terminate(126)
+        child.close()
+        raise
+
+
 def _entry_argv(subcommand: str, *args: str, frozen: bool | None = None) -> list[str]:
     if frozen is None:
         frozen = bool(sys.__dict__.get("frozen", False))
@@ -560,6 +646,10 @@ def _write_json(path: Path, value: Mapping[str, object]) -> None:
         os.replace(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _append_error(existing: str | None, extra: str) -> str:
+    return f"{existing}; {extra}" if existing else extra
 
 
 def desktop_smoke_test(*, timeout_seconds: float = 15.0) -> DesktopSmokeResult:
@@ -613,6 +703,70 @@ def desktop_smoke_test(*, timeout_seconds: float = 15.0) -> DesktopSmokeResult:
     )
 
 
+def native_desktop_smoke_test(
+    *, timeout_seconds: float = 15.0
+) -> NativeDesktopSmokeResult:
+    if os.name != "nt":
+        return NativeDesktopSmokeResult(
+            False, None, None, None, None, None, None, None, "Windows is required"
+        )
+    desktop: str | None = None
+    station: str | None = None
+    session: int | None = None
+    child_desktop: str | None = None
+    child_station: str | None = None
+    child_session: int | None = None
+    child_exit: int | None = None
+    error: str | None = None
+    with tempfile.TemporaryDirectory(prefix="diptrace-native-smoke-") as raw_temp:
+        result_path = Path(raw_temp) / "probe.json"
+        try:
+            desktop, station, session = _interactive_context()
+            argv = _entry_argv("_probe", "--result", str(result_path))
+            # This probe performs no DipTrace or UI mutation. It may run on an
+            # elevated CI runner so the Win32 desktop/session primitive is still
+            # exercised there; real native round-trips remain non-elevated only.
+            with _launch_on_current_desktop(
+                argv, require_non_elevated=False
+            ) as child:
+                child_exit = child.wait(timeout_seconds)
+                if child_exit is None:
+                    child.terminate(124)
+                    child_exit = child.wait(2.0)
+                    raise HeadlessGuiError("native desktop probe timed out")
+            probe = _load_json(result_path)
+            child_desktop = _required_string(probe, "desktop_name")
+            child_station = _required_string(probe, "window_station_name")
+            child_session = _coerce_int(probe.get("session_id"), -1)
+            if child_exit != 0:
+                raise HeadlessGuiError(f"native desktop probe exited with code {child_exit}")
+            if child_desktop.casefold() != desktop.casefold():
+                raise HeadlessGuiError(
+                    f"native child desktop mismatch: {child_desktop!r} != {desktop!r}"
+                )
+            if child_station.casefold() != station.casefold():
+                raise HeadlessGuiError(
+                    f"native child window station mismatch: {child_station!r} != {station!r}"
+                )
+            if child_session != session:
+                raise HeadlessGuiError(
+                    f"native child session mismatch: {child_session} != {session}"
+                )
+        except (HeadlessGuiError, OSError, ValueError) as exc:
+            error = str(exc)
+    return NativeDesktopSmokeResult(
+        error is None,
+        desktop,
+        child_desktop,
+        station,
+        child_station,
+        session,
+        child_session,
+        child_exit,
+        error,
+    )
+
+
 def _validated_request(request: RoundtripRequest) -> RoundtripRequest:
     try:
         installation = validate_diptrace_directory(request.diptrace_root)
@@ -640,16 +794,34 @@ def run_native_roundtrip(request: RoundtripRequest) -> RoundtripResult:
     request = _validated_request(request)
     desktop_name = f"DipTraceMCP-{os.getpid()}-{uuid.uuid4().hex[:8]}"
     before = input_desktop_name()
+    station_before = process_window_station_name()
+    session_before = process_session_id()
+    if request.desktop_mode == "native":
+        if process_is_elevated():
+            raise HeadlessGuiError(
+                "native launch declined from an elevated process; run the GUI worker "
+                "with the normal user token"
+            )
+        if before is None:
+            raise HeadlessGuiError(
+                "cannot determine the current input desktop; native launch declined"
+            )
+        _validate_desktop_name(before)
+        if station_before.casefold() != _INTERACTIVE_WINDOW_STATION.casefold():
+            raise HeadlessGuiError(
+                f"native launch requires {_INTERACTIVE_WINDOW_STATION}; "
+                f"current window station is {station_before!r}"
+            )
     with tempfile.TemporaryDirectory(prefix="diptrace-headless-") as raw_temp:
         temp = Path(raw_temp)
         request_path = temp / "request.json"
         result_path = temp / "result.json"
-        _write_json(request_path, request.as_json())
+        request_payload = request.as_json()
+        request_payload["_expected_window_station"] = station_before
+        request_payload["_expected_session_id"] = session_before
+        _write_json(request_path, request_payload)
         if request.desktop_mode == "native":
-            if before is None:
-                raise HeadlessGuiError(
-                    "cannot determine the current input desktop; native launch declined"
-                )
+            assert before is not None
             argv = _entry_argv(
                 "_worker",
                 "--request",
@@ -687,14 +859,46 @@ def run_native_roundtrip(request: RoundtripRequest) -> RoundtripResult:
                 f"headless worker exited with code {exit_code} without a result"
             )
         result = RoundtripResult.from_json(_load_json(result_path))
+
     after = input_desktop_name()
+    station_after = process_window_station_name()
+    session_after = process_session_id()
+    evidence_error: str | None = None
+    desktop_changed = False
     if before is not None and after is not None and before != after:
-        raise HeadlessGuiError(f"input desktop changed unexpectedly: {before!r} -> {after!r}")
-    if result.input_desktop_before != before or result.input_desktop_after != after:
+        desktop_changed = True
+        evidence_error = (
+            f"input desktop changed unexpectedly after worker side effects: "
+            f"{before!r} -> {after!r}"
+        )
+    elif request.desktop_mode == "native" and after is None:
+        evidence_error = (
+            "cannot determine input desktop after native worker side effects; "
+            "result retained as failed evidence"
+        )
+    if station_after.casefold() != station_before.casefold():
+        evidence_error = _append_error(
+            evidence_error,
+            f"window station changed unexpectedly: {station_before!r} -> {station_after!r}",
+        )
+    if session_after != session_before:
+        evidence_error = _append_error(
+            evidence_error,
+            f"session changed unexpectedly: {session_before} -> {session_after}",
+        )
+    result = replace(
+        result,
+        input_desktop_before=before,
+        input_desktop_after=after,
+        window_station_name=station_after,
+        session_id=session_after,
+        desktop_changed=desktop_changed,
+    )
+    if evidence_error is not None:
         result = replace(
             result,
-            input_desktop_before=before,
-            input_desktop_after=after,
+            ok=False,
+            error=_append_error(result.error, evidence_error),
         )
     return result
 
@@ -778,6 +982,8 @@ def _perform_worker_roundtrip(
         forced_termination=forced,
         error=error,
         desktop_mode=request.desktop_mode,
+        window_station_name=process_window_station_name(),
+        session_id=process_session_id(),
     )
 
 
@@ -786,7 +992,13 @@ def _cmd_probe(args: argparse.Namespace) -> int:
     try:
         _write_json(
             result_path,
-            {"desktop_name": thread_desktop_name(), "pid": os.getpid()},
+            {
+                "desktop_name": thread_desktop_name(),
+                "window_station_name": process_window_station_name(),
+                "session_id": process_session_id(),
+                "elevated": process_is_elevated(),
+                "pid": os.getpid(),
+            },
         )
         return 0
     except (HeadlessGuiError, OSError, ValueError) as exc:
@@ -797,16 +1009,50 @@ def _cmd_probe(args: argparse.Namespace) -> int:
 def _cmd_worker(args: argparse.Namespace) -> int:
     result_path = Path(str(args.result))
     desktop_name = str(args.desktop_name)
+    request_payload: dict[str, object] = {}
     try:
-        request = RoundtripRequest.from_json(_load_json(Path(str(args.request))))
+        request_payload = _load_json(Path(str(args.request)))
+        request = RoundtripRequest.from_json(request_payload)
         actual = thread_desktop_name()
         if actual.casefold() != desktop_name.casefold():
             raise HeadlessGuiError(
                 f"worker connected to unexpected desktop: {actual!r} != {desktop_name!r}"
             )
+        expected_station = _required_string(
+            request_payload, "_expected_window_station"
+        )
+        actual_station = process_window_station_name()
+        if actual_station.casefold() != expected_station.casefold():
+            raise HeadlessGuiError(
+                f"worker connected to unexpected window station: "
+                f"{actual_station!r} != {expected_station!r}"
+            )
+        expected_session = _coerce_int(
+            request_payload.get("_expected_session_id"), -1
+        )
+        actual_session = process_session_id()
+        if expected_session < 0 or actual_session != expected_session:
+            raise HeadlessGuiError(
+                f"worker connected to unexpected session: "
+                f"{actual_session} != {expected_session}"
+            )
+        if request.desktop_mode == "native" and process_is_elevated():
+            raise HeadlessGuiError("native worker unexpectedly has an elevated token")
         result = _perform_worker_roundtrip(request, desktop_name=desktop_name)
+        result = replace(
+            result,
+            window_station_name=actual_station,
+            session_id=actual_session,
+        )
     except Exception as exc:
         current_input = input_desktop_name() if os.name == "nt" else None
+        current_station: str | None = None
+        current_session: int | None = None
+        if os.name == "nt":
+            with suppress(Exception):
+                current_station = process_window_station_name()
+            with suppress(Exception):
+                current_session = process_session_id()
         result = RoundtripResult(
             False,
             "unknown",
@@ -821,6 +1067,11 @@ def _cmd_worker(args: argparse.Namespace) -> int:
             None,
             None,
             error=f"{type(exc).__name__}: {exc}",
+            desktop_mode=_string_or_default(
+                request_payload.get("desktop_mode"), "hidden"
+            ),
+            window_station_name=current_station,
+            session_id=current_session,
         )
     _write_json(result_path, result.as_json())
     return 0 if result.ok else 1
@@ -828,6 +1079,12 @@ def _cmd_worker(args: argparse.Namespace) -> int:
 
 def _cmd_smoke(args: argparse.Namespace) -> int:
     result = desktop_smoke_test(timeout_seconds=float(args.timeout))
+    print(json.dumps(result.as_json(), ensure_ascii=False, indent=2))
+    return 0 if result.ok else 1
+
+
+def _cmd_native_smoke(args: argparse.Namespace) -> int:
+    result = native_desktop_smoke_test(timeout_seconds=float(args.timeout))
     print(json.dumps(result.as_json(), ensure_ascii=False, indent=2))
     return 0 if result.ok else 1
 
@@ -862,6 +1119,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         "diptrace_error": installation_error,
         "pywinauto_available": pywinauto_available,
         "physical_input_fallback": False,
+        "desktop_is_security_sandbox": False,
     }
     print(json.dumps(report, ensure_ascii=False, indent=2))
     return 0 if ok else 1
@@ -888,13 +1146,22 @@ def _cmd_roundtrip(args: argparse.Namespace) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="diptrace-mcp-headless-gui",
-        description="Run bounded DipTrace native GUI work on an isolated Win32 desktop.",
+        description=(
+            "Run bounded DipTrace GUI work; hidden mode uses an isolated Win32 desktop."
+        ),
     )
     subs = parser.add_subparsers(dest="command", required=True)
 
     smoke = subs.add_parser("smoke", help="verify hidden desktop isolation")
     smoke.add_argument("--timeout", type=float, default=15.0)
     smoke.set_defaults(handler=_cmd_smoke)
+
+    native_smoke = subs.add_parser(
+        "native-smoke",
+        help="verify native WinSta0 desktop, window-station and session targeting",
+    )
+    native_smoke.add_argument("--timeout", type=float, default=15.0)
+    native_smoke.set_defaults(handler=_cmd_native_smoke)
 
     doctor = subs.add_parser("doctor", help="check Windows and DipTrace readiness")
     doctor.add_argument("--diptrace-root")

--- a/src/diptrace_mcp/headless_gui.py
+++ b/src/diptrace_mcp/headless_gui.py
@@ -54,6 +54,7 @@ _UOI_NAME = 2
 _WAIT_OBJECT_0 = 0
 _WAIT_TIMEOUT = 0x102
 _STILL_ACTIVE = 259
+_DESKTOP_MODES = ("hidden", "native")
 
 
 class HeadlessGuiError(RuntimeError):
@@ -67,6 +68,7 @@ class RoundtripRequest:
     editor: str
     timeout_seconds: float = 30.0
     save_menu: str = "File->Save"
+    desktop_mode: str = "hidden"
 
     def __post_init__(self) -> None:
         editor = self.editor.strip().lower()
@@ -77,7 +79,12 @@ class RoundtripRequest:
             raise ValueError("timeout_seconds must be > 0 and <= 300")
         if not self.save_menu.strip():
             raise ValueError("save_menu must not be empty")
+        desktop_mode = self.desktop_mode.strip().lower()
+        if desktop_mode not in _DESKTOP_MODES:
+            choices = ", ".join(sorted(_DESKTOP_MODES))
+            raise ValueError(f"desktop_mode must be one of: {choices}")
         object.__setattr__(self, "editor", editor)
+        object.__setattr__(self, "desktop_mode", desktop_mode)
         object.__setattr__(self, "diptrace_root", Path(self.diptrace_root))
         object.__setattr__(self, "project", Path(self.project))
 
@@ -92,6 +99,7 @@ class RoundtripRequest:
             "editor": self.editor,
             "timeout_seconds": self.timeout_seconds,
             "save_menu": self.save_menu,
+            "desktop_mode": self.desktop_mode,
         }
 
     @classmethod
@@ -102,6 +110,7 @@ class RoundtripRequest:
             editor=_required_string(value, "editor"),
             timeout_seconds=_coerce_float(value.get("timeout_seconds"), 30.0),
             save_menu=_string_or_default(value.get("save_menu"), "File->Save"),
+            desktop_mode=_string_or_default(value.get("desktop_mode"), "hidden"),
         )
 
 
@@ -121,6 +130,7 @@ class RoundtripResult:
     sha256_after: str | None
     forced_termination: bool = False
     error: str | None = None
+    desktop_mode: str = "hidden"
 
     def as_json(self) -> dict[str, object]:
         return cast(dict[str, object], asdict(self))
@@ -144,6 +154,7 @@ class RoundtripResult:
             sha256_after=_optional_string(value.get("sha256_after")),
             forced_termination=bool(value.get("forced_termination", False)),
             error=_optional_string(value.get("error")),
+            desktop_mode=_string_or_default(value.get("desktop_mode"), "hidden"),
         )
 
 
@@ -378,6 +389,40 @@ class HiddenDesktop:
         self.close()
 
 
+def _launch_on_current_desktop(argv: Sequence[str], *, cwd: Path | None = None) -> CreatedProcess:
+    """Launch the worker on the user's current interactive desktop (native mode).
+
+    The bounded lifecycle contract is identical to the hidden-desktop launch;
+    only the desktop override is absent, so the child inherits the current
+    Win32 desktop and the editor window stays visible to the operator.
+    """
+    if not argv or not str(argv[0]).strip():
+        raise ValueError("argv must contain an executable")
+    api = _Win32Api()
+    application = str(argv[0])
+    command = ctypes.create_unicode_buffer(
+        subprocess.list2cmdline([str(item) for item in argv])
+    )
+    startup = _STARTUPINFOW()
+    startup.cb = ctypes.sizeof(_STARTUPINFOW)
+    info = _PROCESS_INFORMATION()
+    created = api.kernel32.CreateProcessW(
+        application,
+        command,
+        None,
+        None,
+        False,
+        0,
+        None,
+        str(cwd) if cwd is not None else None,
+        ctypes.byref(startup),
+        ctypes.byref(info),
+    )
+    if not created:
+        raise api.error("CreateProcessW")
+    return CreatedProcess(api, info)
+
+
 def _required_string(value: Mapping[str, object], key: str) -> str:
     raw = value.get(key)
     if not isinstance(raw, str) or not raw.strip():
@@ -585,6 +630,7 @@ def _validated_request(request: RoundtripRequest) -> RoundtripRequest:
         request.editor,
         request.timeout_seconds,
         request.save_menu,
+        request.desktop_mode,
     )
 
 
@@ -599,7 +645,11 @@ def run_native_roundtrip(request: RoundtripRequest) -> RoundtripResult:
         request_path = temp / "request.json"
         result_path = temp / "result.json"
         _write_json(request_path, request.as_json())
-        with HiddenDesktop(desktop_name) as desktop:
+        if request.desktop_mode == "native":
+            if before is None:
+                raise HeadlessGuiError(
+                    "cannot determine the current input desktop; native launch declined"
+                )
             argv = _entry_argv(
                 "_worker",
                 "--request",
@@ -607,14 +657,31 @@ def run_native_roundtrip(request: RoundtripRequest) -> RoundtripResult:
                 "--result",
                 str(result_path),
                 "--desktop-name",
-                desktop_name,
+                before,
             )
-            with desktop.launch(argv) as worker:
+            with _launch_on_current_desktop(argv) as worker:
                 exit_code = worker.wait(request.timeout_seconds + 20.0)
                 if exit_code is None:
                     worker.terminate(124)
                     worker.wait(2.0)
-                    raise HeadlessGuiError("headless DipTrace worker timed out")
+                    raise HeadlessGuiError("native DipTrace worker timed out")
+        else:
+            with HiddenDesktop(desktop_name) as desktop:
+                argv = _entry_argv(
+                    "_worker",
+                    "--request",
+                    str(request_path),
+                    "--result",
+                    str(result_path),
+                    "--desktop-name",
+                    desktop_name,
+                )
+                with desktop.launch(argv) as worker:
+                    exit_code = worker.wait(request.timeout_seconds + 20.0)
+                    if exit_code is None:
+                        worker.terminate(124)
+                        worker.wait(2.0)
+                        raise HeadlessGuiError("headless DipTrace worker timed out")
         if not result_path.is_file():
             raise HeadlessGuiError(
                 f"headless worker exited with code {exit_code} without a result"
@@ -710,6 +777,7 @@ def _perform_worker_roundtrip(
         sha256_after=_sha256(request.project),
         forced_termination=forced,
         error=error,
+        desktop_mode=request.desktop_mode,
     )
 
 
@@ -806,6 +874,7 @@ def _cmd_roundtrip(args: argparse.Namespace) -> int:
         str(args.editor),
         float(args.timeout),
         str(args.save_menu),
+        str(args.desktop),
     )
     try:
         result = run_native_roundtrip(request)
@@ -839,6 +908,7 @@ def _build_parser() -> argparse.ArgumentParser:
     roundtrip.add_argument("--editor", choices=sorted(_EDITOR_EXECUTABLES), required=True)
     roundtrip.add_argument("--timeout", type=float, default=30.0)
     roundtrip.add_argument("--save-menu", default="File->Save")
+    roundtrip.add_argument("--desktop", choices=tuple(_DESKTOP_MODES), default="hidden")
     roundtrip.set_defaults(handler=_cmd_roundtrip)
 
     worker = subs.add_parser("_worker", help=argparse.SUPPRESS)

--- a/tests/test_headless_gui.py
+++ b/tests/test_headless_gui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -138,3 +139,185 @@ def test_cli_help_and_non_windows_smoke(capsys: pytest.CaptureFixture[str]) -> N
         headless_gui.main(["--help"])
     assert exc.value.code == 0
     assert "isolated Win32 desktop" in capsys.readouterr().out
+
+
+def test_roundtrip_request_desktop_mode_default_and_validation(tmp_path: Path) -> None:
+    assert RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb").desktop_mode == "hidden"
+    assert (
+        RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode=" NATIVE ").desktop_mode
+        == "native"
+    )
+    with pytest.raises(ValueError, match="desktop_mode must be one of"):
+        RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="virtual")
+
+
+def test_roundtrip_request_json_desktop_mode_backward_compatible(tmp_path: Path) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="native")
+    payload = request.as_json()
+    assert payload["desktop_mode"] == "native"
+    legacy = {key: value for key, value in payload.items() if key != "desktop_mode"}
+    assert RoundtripRequest.from_json(legacy).desktop_mode == "hidden"
+    assert RoundtripRequest.from_json(payload).desktop_mode == "native"
+
+
+def test_roundtrip_result_json_desktop_mode() -> None:
+    result = RoundtripResult(
+        ok=True,
+        editor="pcb",
+        executable="x",
+        project="y",
+        worker_pid=1,
+        diptrace_pid=2,
+        automation_backend="pywinauto-win32-message",
+        desktop_name="WinSta0\\DipTraceMCP-x",
+        input_desktop_before="Default",
+        input_desktop_after="Default",
+        sha256_before=None,
+        sha256_after=None,
+        desktop_mode="native",
+    )
+    assert RoundtripResult.from_json(result.as_json()) == result
+    legacy = dict(result.as_json())
+    legacy.pop("desktop_mode")
+    assert RoundtripResult.from_json(legacy).desktop_mode == "hidden"
+
+
+def test_cli_roundtrip_desktop_argument_defaults_and_rejects_invalid() -> None:
+    parser = headless_gui._build_parser()
+    base = ["roundtrip", "--diptrace-root", "r", "--project", "p", "--editor", "pcb"]
+    assert parser.parse_args(base).desktop == "hidden"
+    assert parser.parse_args([*base, "--desktop", "native"]).desktop == "native"
+    with pytest.raises(SystemExit):
+        parser.parse_args([*base, "--desktop", "virtual"])
+
+
+class _FakeWorker:
+    def __init__(self, argv: list[str], payload: dict[str, object]) -> None:
+        self.argv = list(argv)
+        self.payload = payload
+        self.terminated = False
+
+    def wait(self, timeout: float) -> int:
+        index = self.argv.index("--result")
+        Path(self.argv[index + 1]).write_text(
+            json.dumps(self.payload), encoding="utf-8"
+        )
+        return 0
+
+    def terminate(self, exit_code: int = 1) -> None:
+        self.terminated = True
+
+    def close(self) -> None:
+        return None
+
+    def __enter__(self) -> _FakeWorker:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+def _result_payload(desktop_name: str, desktop_mode: str) -> dict[str, object]:
+    return RoundtripResult(
+        ok=True,
+        editor="pcb",
+        executable="x",
+        project="y",
+        worker_pid=1,
+        diptrace_pid=2,
+        automation_backend="pywinauto-win32-message",
+        desktop_name=desktop_name,
+        input_desktop_before="Default",
+        input_desktop_after="Default",
+        sha256_before=None,
+        sha256_after=None,
+        desktop_mode=desktop_mode,
+    ).as_json()
+
+
+def test_run_native_roundtrip_hidden_mode_launches_worker_on_hidden_desktop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="hidden")
+    fake_os = types.ModuleType("os")
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = "nt"
+    monkeypatch.setattr(headless_gui, "os", fake_os)
+    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: "Default")
+    monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
+    launched: dict[str, object] = {}
+
+    class FakeDesktop:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            launched["desktop"] = name
+
+        def launch(self, argv, cwd=None):
+            launched["argv"] = list(argv)
+            return _FakeWorker(list(argv), _result_payload(self.name, "hidden"))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+    def fail_plain(argv, cwd=None):
+        raise AssertionError("native launcher must not be used in hidden mode")
+
+    monkeypatch.setattr(headless_gui, "HiddenDesktop", FakeDesktop)
+    monkeypatch.setattr(headless_gui, "_launch_on_current_desktop", fail_plain)
+
+    result = headless_gui.run_native_roundtrip(request)
+
+    assert result.ok is True
+    assert str(launched["desktop"]).startswith("DipTraceMCP-")
+    assert result.desktop_name == launched["desktop"]
+    assert result.desktop_mode == "hidden"
+    assert "DipTraceMCP-" in str(launched["argv"])
+
+
+def test_run_native_roundtrip_native_mode_uses_current_desktop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="native")
+    fake_os = types.ModuleType("os")
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = "nt"
+    monkeypatch.setattr(headless_gui, "os", fake_os)
+    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: "Default")
+    monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
+    launched: dict[str, object] = {}
+
+    def fake_plain(argv, cwd=None):
+        launched["argv"] = list(argv)
+        return _FakeWorker(list(argv), _result_payload("Default", "native"))
+
+    def fail_hidden(name: str):
+        raise AssertionError("hidden desktop must not be created in native mode")
+
+    monkeypatch.setattr(headless_gui, "_launch_on_current_desktop", fake_plain)
+    monkeypatch.setattr(headless_gui, "HiddenDesktop", fail_hidden)
+
+    result = headless_gui.run_native_roundtrip(request)
+
+    assert result.ok is True
+    assert result.desktop_name == "Default"
+    assert result.desktop_mode == "native"
+    argv = launched["argv"]
+    assert argv[argv.index("--desktop-name") + 1] == "Default"
+
+
+def test_run_native_roundtrip_native_mode_declined_without_input_desktop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="native")
+    fake_os = types.ModuleType("os")
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = "nt"
+    monkeypatch.setattr(headless_gui, "os", fake_os)
+    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: None)
+    monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
+
+    with pytest.raises(headless_gui.HeadlessGuiError, match="native launch declined"):
+        headless_gui.run_native_roundtrip(request)

--- a/tests/test_headless_gui.py
+++ b/tests/test_headless_gui.py
@@ -42,7 +42,7 @@ def test_roundtrip_request_rejects_unsafe_timeout(tmp_path: Path, timeout: float
 
 
 def test_desktop_name_validation() -> None:
-    for value in ["", "a\\b", "a/b", "x" * 129]:
+    for value in ["", "a\\b", "a/b", "x" * 129, "bad\x00name"]:
         with pytest.raises(ValueError):
             headless_gui._validate_desktop_name(value)
     headless_gui._validate_desktop_name("DipTraceMCP-test")
@@ -80,6 +80,8 @@ def test_roundtrip_result_json_roundtrip() -> None:
         input_desktop_after="Default",
         sha256_before="a",
         sha256_after="b",
+        window_station_name="WinSta0",
+        session_id=1,
     )
     assert RoundtripResult.from_json(result.as_json()) == result
 
@@ -134,6 +136,17 @@ def test_real_hidden_desktop_smoke() -> None:
         assert result.input_desktop_before == result.input_desktop_after
 
 
+@pytest.mark.skipif(os.name != "nt", reason="requires Win32 desktop objects")
+def test_real_native_desktop_targeting_smoke() -> None:
+    result = headless_gui.native_desktop_smoke_test(timeout_seconds=20)
+    assert result.ok, result.error
+    assert result.child_exit_code == 0
+    assert result.desktop_name == result.child_desktop_name
+    assert result.window_station_name == result.child_window_station_name
+    assert result.session_id == result.child_session_id
+    assert (result.window_station_name or "").casefold() == "winsta0"
+
+
 def test_cli_help_and_non_windows_smoke(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc:
         headless_gui.main(["--help"])
@@ -160,7 +173,7 @@ def test_roundtrip_request_json_desktop_mode_backward_compatible(tmp_path: Path)
     assert RoundtripRequest.from_json(payload).desktop_mode == "native"
 
 
-def test_roundtrip_result_json_desktop_mode() -> None:
+def test_roundtrip_result_json_desktop_mode_backward_compatible() -> None:
     result = RoundtripResult(
         ok=True,
         editor="pcb",
@@ -169,17 +182,26 @@ def test_roundtrip_result_json_desktop_mode() -> None:
         worker_pid=1,
         diptrace_pid=2,
         automation_backend="pywinauto-win32-message",
-        desktop_name="WinSta0\\DipTraceMCP-x",
+        desktop_name="Default",
         input_desktop_before="Default",
         input_desktop_after="Default",
         sha256_before=None,
         sha256_after=None,
         desktop_mode="native",
+        window_station_name="WinSta0",
+        session_id=3,
     )
     assert RoundtripResult.from_json(result.as_json()) == result
     legacy = dict(result.as_json())
     legacy.pop("desktop_mode")
-    assert RoundtripResult.from_json(legacy).desktop_mode == "hidden"
+    legacy.pop("window_station_name")
+    legacy.pop("session_id")
+    legacy.pop("desktop_changed")
+    restored = RoundtripResult.from_json(legacy)
+    assert restored.desktop_mode == "hidden"
+    assert restored.window_station_name is None
+    assert restored.session_id is None
+    assert restored.desktop_changed is False
 
 
 def test_cli_roundtrip_desktop_argument_defaults_and_rejects_invalid() -> None:
@@ -232,7 +254,24 @@ def _result_payload(desktop_name: str, desktop_mode: str) -> dict[str, object]:
         sha256_before=None,
         sha256_after=None,
         desktop_mode=desktop_mode,
+        window_station_name="WinSta0",
+        session_id=1,
     ).as_json()
+
+
+def _patch_runtime_context(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    input_desktop: object = "Default",
+    elevated: bool = False,
+) -> None:
+    monkeypatch.setattr(headless_gui, "process_window_station_name", lambda: "WinSta0")
+    monkeypatch.setattr(headless_gui, "process_session_id", lambda pid=None: 1)
+    monkeypatch.setattr(headless_gui, "process_is_elevated", lambda: elevated)
+    if callable(input_desktop):
+        monkeypatch.setattr(headless_gui, "input_desktop_name", input_desktop)
+    else:
+        monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: input_desktop)
 
 
 def test_run_native_roundtrip_hidden_mode_launches_worker_on_hidden_desktop(
@@ -243,7 +282,7 @@ def test_run_native_roundtrip_hidden_mode_launches_worker_on_hidden_desktop(
     fake_os.__dict__.update(os.__dict__)
     fake_os.name = "nt"
     monkeypatch.setattr(headless_gui, "os", fake_os)
-    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: "Default")
+    _patch_runtime_context(monkeypatch)
     monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
     launched: dict[str, object] = {}
 
@@ -285,7 +324,7 @@ def test_run_native_roundtrip_native_mode_uses_current_desktop(
     fake_os.__dict__.update(os.__dict__)
     fake_os.name = "nt"
     monkeypatch.setattr(headless_gui, "os", fake_os)
-    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: "Default")
+    _patch_runtime_context(monkeypatch)
     monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
     launched: dict[str, object] = {}
 
@@ -316,8 +355,52 @@ def test_run_native_roundtrip_native_mode_declined_without_input_desktop(
     fake_os.__dict__.update(os.__dict__)
     fake_os.name = "nt"
     monkeypatch.setattr(headless_gui, "os", fake_os)
-    monkeypatch.setattr(headless_gui, "input_desktop_name", lambda: None)
+    _patch_runtime_context(monkeypatch, input_desktop=None)
     monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
 
     with pytest.raises(headless_gui.HeadlessGuiError, match="native launch declined"):
         headless_gui.run_native_roundtrip(request)
+
+
+def test_run_native_roundtrip_native_mode_declined_when_elevated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="native")
+    fake_os = types.ModuleType("os")
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = "nt"
+    monkeypatch.setattr(headless_gui, "os", fake_os)
+    _patch_runtime_context(monkeypatch, elevated=True)
+    monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
+
+    with pytest.raises(headless_gui.HeadlessGuiError, match="elevated process"):
+        headless_gui.run_native_roundtrip(request)
+
+
+def test_roundtrip_preserves_side_effect_evidence_when_input_desktop_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = RoundtripRequest(tmp_path, tmp_path / "b.dip", "pcb", desktop_mode="native")
+    fake_os = types.ModuleType("os")
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = "nt"
+    monkeypatch.setattr(headless_gui, "os", fake_os)
+    desktops = iter(["Default", "ConsentUi"])
+    _patch_runtime_context(monkeypatch, input_desktop=lambda: next(desktops))
+    monkeypatch.setattr(headless_gui, "_validated_request", lambda request: request)
+
+    def fake_plain(argv, cwd=None):
+        payload = _result_payload("Default", "native")
+        payload["sha256_after"] = "saved"
+        return _FakeWorker(list(argv), payload)
+
+    monkeypatch.setattr(headless_gui, "_launch_on_current_desktop", fake_plain)
+
+    result = headless_gui.run_native_roundtrip(request)
+
+    assert result.ok is False
+    assert result.desktop_changed is True
+    assert result.sha256_after == "saved"
+    assert result.input_desktop_before == "Default"
+    assert result.input_desktop_after == "ConsentUi"
+    assert "after worker side effects" in (result.error or "")

--- a/tests/test_low_level_edge_coverage.py
+++ b/tests/test_low_level_edge_coverage.py
@@ -519,6 +519,7 @@ def test_cmd_roundtrip_success_and_failure(
         editor="pcb",
         timeout=1,
         save_menu="File->Save",
+        desktop="hidden",
     )
     result = RoundtripResult(
         True,

--- a/tests/test_low_level_edge_coverage.py
+++ b/tests/test_low_level_edge_coverage.py
@@ -477,8 +477,15 @@ def test_headless_command_handlers_and_resolution(
 ) -> None:
     result_path = tmp_path / "probe.json"
     monkeypatch.setattr(headless_gui, "thread_desktop_name", lambda: "hidden")
+    monkeypatch.setattr(headless_gui, "process_window_station_name", lambda: "WinSta0")
+    monkeypatch.setattr(headless_gui, "process_session_id", lambda pid=None: 1)
+    monkeypatch.setattr(headless_gui, "process_is_elevated", lambda: False)
     assert headless_gui._cmd_probe(argparse.Namespace(result=str(result_path))) == 0
-    assert headless_gui._load_json(result_path)["desktop_name"] == "hidden"
+    probe = headless_gui._load_json(result_path)
+    assert probe["desktop_name"] == "hidden"
+    assert probe["window_station_name"] == "WinSta0"
+    assert probe["session_id"] == 1
+    assert probe["elevated"] is False
 
     def broken_desktop() -> str:
         raise HeadlessGuiError("boom")

--- a/tests/test_windows_installer_sources.py
+++ b/tests/test_windows_installer_sources.py
@@ -5,39 +5,46 @@ from pathlib import Path
 ROOT = Path(__file__).parents[1]
 
 
-def test_inno_installer_is_user_scoped_and_has_required_wizard_contracts() -> None:
+def test_inno_source_encodes_split_user_and_admin_security_boundary() -> None:
     script = (ROOT / "installer/DipTraceMCP.iss").read_text(encoding="utf-8")
 
+    assert "#ifdef PluginOnly" in script
     assert "PrivilegesRequired=lowest" in script
+    assert "PrivilegesRequired=admin" in script
     assert "DefaultDirName={localappdata}\\Programs\\DipTraceMCP" in script
+    assert "DefaultDirName={autopf}\\DipTraceMCPPlugin" in script
     assert "OutputBaseFilename=DipTrace-MCP-Setup-{#AppVersion}" in script
-    assert "Name: full;" in script
-    assert "Name: server;" in script
-    assert "Name: custom;" in script
+    assert "OutputBaseFilename=DipTrace-MCP-Plugin-Setup-{#AppVersion}" in script
+
+    # The per-user branch copies only server/configuration/state helpers. It
+    # never performs UAC elevation or embeds the bridge/settings payload.
+    assert "never invokes an elevated child process" in script
+    assert 'Source: "{#StageDir}\\app\\*"' in script
+    assert 'Source: "{#StageDir}\\tools\\diptrace_mcp_configure\\*"' in script
+    assert "ShellExec('runas'" not in script
+
+    # The admin-only branch is self-contained under its own admin-owned app
+    # root, then copies/validates only the bounded DipTrace plug-in payload.
+    assert "self-contained" in script
+    assert 'DestDir: "{app}\\payload"' in script
+    assert 'DestDir: "{app}\\payload\\settings"' in script
+    assert "GetSHA256OfFile" in script
+    assert "DipTraceMCP" in script
+    assert "diptrace-root.txt" in script
+
     assert "Configure Codex" in script
     assert "Configure Claude Desktop" in script
     assert "Configure both" in script
     assert "Skip client configuration" in script
-    assert "settings-templates\\*" in script
-    assert "diptrace_mcp_server.exe" in script
-    assert "--help" in script
-    assert "--json" in script
-    assert "runas" in script
     assert "Remove local DipTrace MCP state and logs" in script
     assert "Projects are never removed".casefold() in script.casefold()
-    assert 'Type: files; Name: "{app}\\plugin-targets.txt"' in script
-    assert 'Type: files; Name: "{app}\\state-dir.txt"' in script
-    assert 'Type: dirifempty; Name: "{app}"' in script
-    assert "{autopf}" not in script
-    assert "{autopf32}" not in script
-    assert "{commonpf}" in script
-    assert "{commonpf32}" in script
-    assert "PrivilegesRequired=admin" not in script
 
 
 def test_installer_has_no_network_or_shell_pipeline() -> None:
     script = (ROOT / "installer/DipTraceMCP.iss").read_text(encoding="utf-8").casefold()
-    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(encoding="utf-8").casefold()
+    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(
+        encoding="utf-8"
+    ).casefold()
 
     assert "download" not in script
     assert "curl" not in script
@@ -46,31 +53,36 @@ def test_installer_has_no_network_or_shell_pipeline() -> None:
     assert "innosetup-6.4.2.exe" not in wrapper
 
 
-def test_windows_build_wrapper_pins_inno_and_emits_two_named_assets() -> None:
-    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(encoding="utf-8")
+def test_windows_build_wrapper_pins_inno_and_emits_three_named_assets() -> None:
+    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(
+        encoding="utf-8"
+    )
 
     assert "6.4.2" in wrapper
     assert "DipTrace-MCP-Setup-{0}.exe" in wrapper
+    assert "DipTrace-MCP-Plugin-Setup-{0}.exe" in wrapper
     assert "DipTrace-MCP-Portable-{0}.zip" in wrapper
+    assert "/DPluginOnly=1" in wrapper
     assert "SHA256SUMS.txt" in wrapper
     assert "artifact-inventory.json" in wrapper
-    assert "SIGNING_REQUIRED" not in wrapper or "SigningRequired" in wrapper
+    assert "SigningRequired" in wrapper
     assert r"tools\diptrace_mcp_configure\_internal\python312.dll" in wrapper
     assert "(Join-Path $Stage 'tools\\diptrace_mcp_configure')" in wrapper
-    assert "Invoke-Checked (Join-Path $RepoRoot 'scripts\\build_windows_server.ps1')" not in wrapper
     assert "-NoGeometry:$NoGeometry" in wrapper
     assert "if (-not ($isccVersions | Where-Object" in wrapper
 
 
-def test_existing_bridge_pipeline_remains_the_source_of_bridge_artifact() -> None:
-    script = (ROOT / "scripts/build_windows_installer.ps1").read_text(encoding="utf-8")
+def test_existing_bridge_pipeline_remains_source_of_bridge_artifact() -> None:
+    script = (ROOT / "scripts/build_windows_installer.ps1").read_text(
+        encoding="utf-8"
+    )
 
     assert "plugin\\build_bridge.ps1" in script
     assert "BridgePath" in script
     assert "diptrace_mcp_bridge.exe" in script
-    assert "windows-constraints.txt" in (ROOT / "plugin/build_bridge.ps1").read_text(
-        encoding="utf-8"
-    )
+    assert "windows-constraints.txt" in (
+        ROOT / "plugin/build_bridge.ps1"
+    ).read_text(encoding="utf-8")
 
 
 def test_portable_helpers_are_python_free_and_state_removal_is_narrow() -> None:
@@ -97,7 +109,9 @@ def test_plugin_detection_and_uninstall_preserve_existing_bridge_script() -> Non
 
 
 def test_state_removal_requires_matching_manifest_and_owner_marker() -> None:
-    writer = (ROOT / "packaging/write_installation_manifest.ps1").read_text(encoding="utf-8")
+    writer = (ROOT / "packaging/write_installation_manifest.ps1").read_text(
+        encoding="utf-8"
+    )
     remover = (ROOT / "packaging/remove_owned_state.ps1").read_text(encoding="utf-8")
 
     assert ".diptrace-mcp-state-owner.json" in writer
@@ -122,11 +136,20 @@ def test_portable_helper_uses_packaged_paths_and_compensating_rollback() -> None
 
 
 def test_release_checksum_and_all_executable_signature_contracts_are_present() -> None:
-    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(encoding="utf-8")
+    wrapper = (ROOT / "scripts/build_windows_installer.ps1").read_text(
+        encoding="utf-8"
+    )
 
     assert "Write-ReleaseAssetShaManifest" in wrapper
     assert "DipTrace-MCP-Setup-{0}.exe" in wrapper
+    assert "DipTrace-MCP-Plugin-Setup-{0}.exe" in wrapper
     assert "DipTrace-MCP-Portable-{0}.zip" in wrapper
     assert "diptrace_mcp_server.exe" in wrapper
     assert "diptrace_mcp_configure.exe" in wrapper
     assert "signatureTargets" in wrapper
+
+
+def test_frozen_headless_build_runs_real_native_desktop_security_probe() -> None:
+    wrapper = (ROOT / "scripts/build_windows_server.ps1").read_text(encoding="utf-8")
+    assert "native-smoke --timeout 20" in wrapper
+    assert "native desktop security smoke failed" in wrapper


### PR DESCRIPTION
## Scope

Productize the headless GUI worker's launch decision so it can be started either hidden (private `WinSta0` desktop, the default) or natively on the operator's current interactive desktop, on demand.

- `RoundtripRequest.desktop_mode` validates `{hidden, native}`, defaults `hidden`, JSON-round-trips; `RoundtripResult` records the mode actually used.
- New `_launch_on_current_desktop()` `CreateProcessW` launcher without the `lpDesktop` override; `run_native_roundtrip` branches between the private hidden desktop and the native launch.
- Native mode fails closed with `native launch declined` when the current input desktop cannot be resolved; the worker still verifies it landed on the expected input desktop. No `SwitchDesktop` / synthesized-input paths added.
- CLI `roundtrip` gains `--desktop hidden|native` (default `hidden`).

## DCO and provenance

- [x] Commit is signed off (`Signed-off-by` present).
- [x] No external/AI-generated fixtures, schemas, or proprietary material included; change is internal Python + tests + docs.
- [x] AI assistance used for implementation; human (owner) review of the diff and tests performed locally.

## Safety, security, and privacy

- [x] Safety gates remain fail-closed (native launch declined without resolvable input desktop; no input desktop switching; no coordinate/mouse/keyboard synthesis).
- [x] Public MCP tool contract unchanged — 165 tools, snapshot byte-identical.
- [x] Unknown XML/bytes outside the intended edit are preserved (no XML touched).

## Generated artifacts

- [x] MCP tool snapshot changes were regenerated and reviewed, or no public tool descriptor changed — no change (165, byte-identical, `--check` passed).
- [x] Documentation/code claims remain equivalent; `HEADLESS_GUI.md`, `CHANGELOG_NEXT.md`, `ROADMAP.md` updated.

## Verification

- `ruff` + `mypy --no-incremental` clean on `src/diptrace_mcp/headless_gui.py`.
- `pytest tests/test_headless_gui.py tests/test_low_level_edge_coverage.py` — 39 passed, 1 skipped (Win32-only desktop smoke).
- Full suite: 1450 passed; the single local failure `test_config_platform_translation_and_state_defaults` is the known WSL-env artifact that is green in CI.
- `scripts/generate_mcp_tools_snapshot.py --check` — matches 165 tools.

**Not run here:** real Windows host execution of the frozen helper (`smoke`/`doctor`/`roundtrip`), and a real licensed-DipTrace open/save/close round trip — these remain the real-host acceptance gate (CI verifies the isolation primitive + packaging, not universal DipTrace UI compatibility).

## Review notes

- Transaction/evidence effects: `RoundtripResult` now includes `desktop_mode`; existing evidence consumers default to `hidden` for legacy payloads (backward-compatible).
- Rollback: revert this single commit; no DB/migration/state change.