### PR TITLE
feat: capture cinematic demos on hidden desktop

### DIFF
--- a/docs/CINEMATIC_DEMO_MODE.md
+++ b/docs/CINEMATIC_DEMO_MODE.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-Cinematic mode is implemented as an optional deterministic presentation layer for DipTrace MCP workflows. It can replay already-planned engineering actions through the visible Windows DipTrace UI and capture video/GIF output.
+Cinematic mode is implemented as an optional deterministic presentation layer for DipTrace MCP workflows. It can replay already-planned engineering actions through the Windows DipTrace UI and capture video/GIF output.
 
 It is not engineering authority:
 
 - normal planners decide what should happen;
 - semantic operations/XML bridge/transactions remain authoritative for edits;
-- cinematic mode decides how to show an already-planned action visibly;
-- visible replay is not proof of semantic acceptance without separate real-host evidence.
+- cinematic mode decides how to show an already-planned action;
+- replay is not proof of semantic acceptance without separate real-host evidence.
 
 Cinematic does not change the public MCP contract, which currently registers **165 tools**.
 
@@ -20,7 +20,7 @@ Cinematic does not change the public MCP contract, which currently registers **1
 - `cinematic_host.py` — Windows replay host and dry-run driver;
 - `cinematic_preflight.py` — deterministic manifest content identity and safety budgets;
 - `cinematic_preflight_cli.py` — standalone preflight inspection;
-- `cinematic_recording.py` — ffmpeg/Windows recording helper;
+- `cinematic_recording.py` — visible-window recording plus hidden-desktop cinematic orchestration;
 - `diptrace_ui.py` — UI profile model and design-to-client affine calibration;
 - `diptrace_profile_cli.py` — template/probe/calibrate/action/validate CLI;
 - `diptrace_cinematic_semantic.py` — semantic Schematic/PCB replay adapters;
@@ -74,7 +74,7 @@ Standalone inspection remains useful:
 python -m diptrace_mcp.cinematic_preflight_cli demo.cinematic.json
 ```
 
-The same validation is now enforced inside `cinematic_host.play_manifest()` **before any dry-run or real desktop driver action**. A caller cannot bypass the manifest safety boundary by invoking the Python playback API directly.
+The same validation is enforced before any dry-run, visible replay, or hidden capture action. A caller cannot bypass the manifest safety boundary by invoking the Python playback API directly.
 
 Preflight checks:
 
@@ -93,7 +93,7 @@ It also emits a deterministic `content_sha256`. Random/session metadata such as 
 
 The desktop command parser/driver retains its own per-command validation. Manifest preflight is an additional whole-manifest guard, not a replacement for normalized-coordinate, button, click-count, pause, hotkey or text validation.
 
-## Dry-run and real playback
+## Dry-run and visible playback
 
 Both commands automatically preflight the manifest:
 
@@ -106,7 +106,7 @@ Running the standalone preflight CLI first is optional when an operator wants th
 
 Exact action macros/calibration remain editor/version/configuration specific. Dry-run/preflight do not prove that a real UI profile is correct.
 
-## Recording
+## Visible recording
 
 ```bash
 python -m diptrace_mcp.cinematic_recording raw-demo.mp4 \
@@ -114,7 +114,37 @@ python -m diptrace_mcp.cinematic_recording raw-demo.mp4 \
 python -m diptrace_mcp.cinematic_cli ffmpeg raw-demo.mp4 demo --preset cinematic
 ```
 
-The recorder resolves a title substring to a real HWND and uses Windows ffmpeg `gdigrab`.
+The visible recorder resolves a title substring to a real HWND and uses Windows ffmpeg `gdigrab`.
+
+## Hidden Win32 desktop capture
+
+The packaged headless helper can run DipTrace, deterministic replay, and ffmpeg on the same separate hidden `WinSta0` desktop. The operator's normal input desktop remains available while the recording is produced.
+
+```powershell
+& "<install-root>\app\tools\diptrace_mcp_headless_gui\diptrace_mcp_headless_gui.exe" `
+  cinematic capture `
+  --diptrace-root "C:\Program Files\DipTrace" `
+  --editor pcb `
+  --project "C:\work\board.dip" `
+  --manifest "C:\work\demo.cinematic.json" `
+  --video "C:\work\demo.mp4" `
+  --gif "C:\work\demo.gif"
+```
+
+The hidden capture path is deliberately different from the visible cinematic driver:
+
+1. validate the DipTrace installation/project and mandatory cinematic preflight before launching the host;
+2. create a random hidden Win32 desktop under `WinSta0`;
+3. launch the worker and DipTrace explicitly on that desktop;
+4. launch ffmpeg `gdigrab` on the same desktop and capture that desktop rather than the operator's `Default` desktop;
+5. replay normalized commands with bounded `SendMessageTimeoutW` window messages;
+6. close/terminate bounded child processes and return structured evidence including manifest/video/GIF SHA-256 values, PIDs, desktop, window-station and session identity.
+
+Hidden replay never calls global `SetCursorPos`, `mouse_event`, `keybd_event`, `SendInput` or `SwitchDesktop`. It therefore does not steal the operator's physical cursor or keyboard.
+
+For safety, hidden replay currently accepts normalized click/path commands, text via window messages and message-safe single keys. Modifier/multi-key hotkeys such as `Ctrl+...` deliberately fail closed; configure an equivalent calibrated click path or another verified message-safe macro instead. Visible cinematic playback retains its existing profile semantics.
+
+`ffmpeg` must be available on `PATH` for recording/GIF conversion. The helper does not upload frames or send screenshots to a model; MP4/GIF generation is local.
 
 ## Safety/evidence boundary
 
@@ -123,8 +153,9 @@ The recorder resolves a title substring to a real HWND and uses Windows ffmpeg `
 - no guessed pixels/shortcuts by default;
 - manifest-level and command-level actions are bounded;
 - mandatory preflight executes before playback driver actions;
-- dry-run remains available before cursor movement;
+- dry-run remains available before visible cursor movement;
 - payload recording is off by default;
+- hidden replay does not synthesize global physical input;
 - cinematic replay cannot grant engineering acceptance evidence;
 - normal preview/expected-SHA/transaction/review paths remain authoritative.
 
@@ -134,15 +165,19 @@ Implemented and regression-tested:
 
 - deterministic timeline/presets;
 - capture/compile;
-- Windows cursor/click/hotkey/text/path host;
+- visible Windows cursor/click/hotkey/text/path host;
 - profile persistence/readiness and affine calibration;
 - semantic schematic part/wire replay;
 - PCB placement and same-layer trace replay;
 - content fingerprint and mandatory manifest safety preflight;
-- HWND recording and MP4/GIF helper commands.
+- visible HWND recording and MP4/GIF helper commands;
+- hidden `WinSta0` cinematic orchestration with DipTrace and ffmpeg on the same desktop;
+- bounded hidden message replay that does not use global physical-input APIs;
+- packaged-helper startup smoke for the cinematic subcommand.
 
 Still requires real-client evidence:
 
 - verified macros for the exact DipTrace PCB/Schematic configuration used for a recording;
 - end-to-end calibration against the real open document;
+- one real Windows/DipTrace proof that `gdigrab` records the intended hidden desktop on the supported host configuration;
 - staged via/layer-transition and other unverified editor gestures.

--- a/packaging/diptrace_mcp_headless_gui.spec
+++ b/packaging/diptrace_mcp_headless_gui.spec
@@ -17,6 +17,12 @@ datas.extend(copy_metadata("pywinauto"))
 
 hiddenimports = [
     *collect_submodules("pywinauto", on_error="ignore"),
+    "diptrace_mcp.cinematic",
+    "diptrace_mcp.cinematic_host",
+    "diptrace_mcp.cinematic_preflight",
+    "diptrace_mcp.cinematic_recording",
+    "diptrace_mcp.diptrace_window",
+    "diptrace_mcp.domain",
     "diptrace_mcp.headless_gui",
     "diptrace_mcp.windows_configurator",
 ]
@@ -37,7 +43,6 @@ analysis = Analysis(
         "mypy",
         "hatchling",
         "mcp",
-        "pydantic",
         "shapely",
     ],
     noarchive=False,

--- a/scripts/build_windows_server.ps1
+++ b/scripts/build_windows_server.ps1
@@ -80,6 +80,12 @@ if (-not (Test-Path -LiteralPath $HeadlessExecutable -PathType Leaf)) {
 & $HeadlessExecutable --help | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "Headless GUI executable startup smoke failed" }
 
+# The same frozen helper owns headless cinematic capture. This smoke verifies that
+# cinematic/preflight/message-driver dependencies were bundled without requiring
+# DipTrace or ffmpeg on the build runner.
+& $HeadlessExecutable cinematic --help | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Headless cinematic helper startup smoke failed" }
+
 # Exercise the real CreateProcessW native-desktop targeting primitive on Windows
 # without DipTrace. The probe verifies desktop, WinSta0 window station and
 # session identity. It performs no GUI mutation and is allowed on an elevated
@@ -88,4 +94,4 @@ if ($LASTEXITCODE -ne 0) { throw "Headless GUI executable startup smoke failed" 
 if ($LASTEXITCODE -ne 0) { throw "Headless GUI native desktop security smoke failed" }
 
 Write-Host "Standalone server built: $Executable" -ForegroundColor Green
-Write-Host "Headless GUI helper built: $HeadlessExecutable" -ForegroundColor Green
+Write-Host "Headless GUI/cinematic helper built: $HeadlessExecutable" -ForegroundColor Green

--- a/scripts/headless_gui_entry.py
+++ b/scripts/headless_gui_entry.py
@@ -1,7 +1,18 @@
 # ruff: noqa: I001
 
-from diptrace_mcp.headless_gui import main
+import sys
+
+
+def _main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "cinematic":
+        from diptrace_mcp.cinematic_recording import headless_main
+
+        return headless_main(sys.argv[2:])
+
+    from diptrace_mcp.headless_gui import main
+
+    return main()
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_main())

--- a/src/diptrace_mcp/cinematic_recording.py
+++ b/src/diptrace_mcp/cinematic_recording.py
@@ -1,13 +1,484 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
+import ctypes.wintypes as wintypes
+import json
 import os
 import shutil
 import subprocess
-from collections.abc import Sequence
+import sys
+import tempfile
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import Any, cast
 
+from .cinematic import CinematicEvent
+from .cinematic_host import DesktopCommand, desktop_commands_from_payload, play_manifest
+from .cinematic_preflight import CinematicPreflightResult, preflight_cinematic_manifest
 from .diptrace_window import find_window_handle
+from .headless_gui import (
+    HeadlessGuiError,
+    HiddenDesktop,
+    _EDITOR_EXECUTABLES,
+    _INTERACTIVE_WINDOW_STATION,
+    _coerce_float,
+    _coerce_int,
+    _launch_process_on_desktop,
+    _load_json,
+    _optional_int,
+    _optional_string,
+    _required_string,
+    _sha256,
+    _string_or_default,
+    _write_json,
+    input_desktop_name,
+    process_is_elevated,
+    process_session_id,
+    process_window_station_name,
+    thread_desktop_name,
+)
+from .windows_configurator import ConfiguratorError, validate_diptrace_directory
+
+_WM_CLOSE = 0x0010
+_WM_KEYDOWN = 0x0100
+_WM_KEYUP = 0x0101
+_WM_CHAR = 0x0102
+_WM_MOUSEMOVE = 0x0200
+_BUTTON_MESSAGES = {
+    "left": (0x0201, 0x0202, 0x0203, 0x0001),
+    "right": (0x0204, 0x0205, 0x0206, 0x0002),
+    "middle": (0x0207, 0x0208, 0x0209, 0x0010),
+}
+_VK = {
+    "enter": 0x0D,
+    "return": 0x0D,
+    "esc": 0x1B,
+    "escape": 0x1B,
+    "tab": 0x09,
+    "space": 0x20,
+    "backspace": 0x08,
+    "delete": 0x2E,
+    "home": 0x24,
+    "end": 0x23,
+    "left": 0x25,
+    "up": 0x26,
+    "right": 0x27,
+    "down": 0x28,
+}
+_SMTO_FLAGS = 0x0001 | 0x0002
+_CHILD_FLAGS = 0x0001 | 0x0002
+_CAPTURE_LEAD_SECONDS = 0.35
+
+
+@dataclass(frozen=True, slots=True)
+class HeadlessCinematicRequest:
+    diptrace_root: Path
+    project: Path
+    manifest: Path
+    video_output: Path
+    editor: str
+    window_title: str = "DipTrace"
+    fps: int = 60
+    startup_timeout_seconds: float = 30.0
+    tail_seconds: float = 0.75
+    gif_output: Path | None = None
+    gif_fps: int = 20
+    gif_width: int = 1280
+
+    def __post_init__(self) -> None:
+        editor = self.editor.strip().lower()
+        if editor not in _EDITOR_EXECUTABLES:
+            raise ValueError(
+                "editor must be one of: " + ", ".join(sorted(_EDITOR_EXECUTABLES))
+            )
+        if not self.window_title.strip():
+            raise ValueError("window_title must not be empty")
+        if not 1 <= self.fps <= 240:
+            raise ValueError("fps must be between 1 and 240")
+        if not 1 <= self.gif_fps <= 60:
+            raise ValueError("gif_fps must be between 1 and 60")
+        if not 320 <= self.gif_width <= 3840:
+            raise ValueError("gif_width must be between 320 and 3840")
+        if not 0 < self.startup_timeout_seconds <= 300:
+            raise ValueError("startup_timeout_seconds must be > 0 and <= 300")
+        if not 0 <= self.tail_seconds <= 10:
+            raise ValueError("tail_seconds must be between 0 and 10")
+        video = Path(self.video_output)
+        gif = Path(self.gif_output) if self.gif_output is not None else None
+        if video.suffix.lower() != ".mp4":
+            raise ValueError("video_output must use the .mp4 suffix")
+        if gif is not None and gif.suffix.lower() != ".gif":
+            raise ValueError("gif_output must use the .gif suffix")
+        object.__setattr__(self, "editor", editor)
+        object.__setattr__(self, "diptrace_root", Path(self.diptrace_root))
+        object.__setattr__(self, "project", Path(self.project))
+        object.__setattr__(self, "manifest", Path(self.manifest))
+        object.__setattr__(self, "video_output", video)
+        object.__setattr__(self, "gif_output", gif)
+
+    @property
+    def executable(self) -> Path:
+        return self.diptrace_root / _EDITOR_EXECUTABLES[self.editor]
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "diptrace_root": str(self.diptrace_root),
+            "project": str(self.project),
+            "manifest": str(self.manifest),
+            "video_output": str(self.video_output),
+            "editor": self.editor,
+            "window_title": self.window_title,
+            "fps": self.fps,
+            "startup_timeout_seconds": self.startup_timeout_seconds,
+            "tail_seconds": self.tail_seconds,
+            "gif_output": str(self.gif_output) if self.gif_output else None,
+            "gif_fps": self.gif_fps,
+            "gif_width": self.gif_width,
+        }
+
+    @classmethod
+    def from_json(cls, value: Mapping[str, object]) -> HeadlessCinematicRequest:
+        gif = _optional_string(value.get("gif_output"))
+        return cls(
+            diptrace_root=Path(_required_string(value, "diptrace_root")),
+            project=Path(_required_string(value, "project")),
+            manifest=Path(_required_string(value, "manifest")),
+            video_output=Path(_required_string(value, "video_output")),
+            editor=_required_string(value, "editor"),
+            window_title=_string_or_default(value.get("window_title"), "DipTrace"),
+            fps=_coerce_int(value.get("fps"), 60),
+            startup_timeout_seconds=_coerce_float(
+                value.get("startup_timeout_seconds"), 30.0
+            ),
+            tail_seconds=_coerce_float(value.get("tail_seconds"), 0.75),
+            gif_output=Path(gif) if gif else None,
+            gif_fps=_coerce_int(value.get("gif_fps"), 20),
+            gif_width=_coerce_int(value.get("gif_width"), 1280),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeadlessCinematicResult:
+    ok: bool
+    desktop_name: str
+    worker_pid: int
+    diptrace_pid: int | None
+    ffmpeg_pid: int | None
+    project: str
+    manifest: str
+    manifest_sha256: str | None
+    video_output: str
+    video_sha256: str | None
+    gif_output: str | None = None
+    gif_sha256: str | None = None
+    input_desktop_before: str | None = None
+    input_desktop_after: str | None = None
+    window_station_name: str | None = None
+    session_id: int | None = None
+    forced_termination: bool = False
+    error: str | None = None
+
+    def as_json(self) -> dict[str, object]:
+        return cast(dict[str, object], asdict(self))
+
+    @classmethod
+    def from_json(cls, value: Mapping[str, object]) -> HeadlessCinematicResult:
+        return cls(
+            ok=bool(value.get("ok", False)),
+            desktop_name=_string_or_default(value.get("desktop_name"), "unknown"),
+            worker_pid=_coerce_int(value.get("worker_pid"), 0),
+            diptrace_pid=_optional_int(value.get("diptrace_pid")),
+            ffmpeg_pid=_optional_int(value.get("ffmpeg_pid")),
+            project=_string_or_default(value.get("project"), ""),
+            manifest=_string_or_default(value.get("manifest"), ""),
+            manifest_sha256=_optional_string(value.get("manifest_sha256")),
+            video_output=_string_or_default(value.get("video_output"), ""),
+            video_sha256=_optional_string(value.get("video_sha256")),
+            gif_output=_optional_string(value.get("gif_output")),
+            gif_sha256=_optional_string(value.get("gif_sha256")),
+            input_desktop_before=_optional_string(value.get("input_desktop_before")),
+            input_desktop_after=_optional_string(value.get("input_desktop_after")),
+            window_station_name=_optional_string(value.get("window_station_name")),
+            session_id=_optional_int(value.get("session_id")),
+            forced_termination=bool(value.get("forced_termination", False)),
+            error=_optional_string(value.get("error")),
+        )
+
+
+class HiddenMessageDesktopDriver:
+    """Replay cinematic commands via bounded window messages, never global input."""
+
+    def __init__(self, *, expected_pid: int, default_window: str = "DipTrace") -> None:
+        if os.name != "nt":
+            raise RuntimeError("hidden cinematic playback is available only on Windows")
+        if expected_pid <= 0:
+            raise ValueError("expected_pid must be positive")
+        windll = getattr(ctypes, "windll", None)
+        if windll is None:
+            raise RuntimeError("Windows user32 bindings are unavailable")
+        self.user32: Any = windll.user32
+        self.expected_pid = expected_pid
+        self.default_window = default_window
+        self._last_target: int | None = None
+
+    def handle(self, event: CinematicEvent) -> None:
+        commands = desktop_commands_from_payload(
+            event.payload, default_window=self.default_window
+        )
+        if not commands:
+            if event.kind == "focus":
+                self._window(self.default_window)
+            return
+        for command in commands:
+            self._execute(command)
+
+    def _execute(self, command: DesktopCommand) -> None:
+        hwnd = self._window(command.window_title_contains)
+        if command.hotkey:
+            self._hotkey(hwnd, command.hotkey)
+        if command.text:
+            self._text(self._last_target or hwnd, command.text)
+        if command.path:
+            for x, y in command.path:
+                target, point = self._target(hwnd, x, y)
+                self._mouse_move(target, point)
+                self._click(target, point, command.click or "left", command.click_count)
+        else:
+            target = hwnd
+            point: tuple[int, int] | None = None
+            if command.move_to is not None:
+                target, point = self._target(hwnd, *command.move_to)
+                self._mouse_move(target, point)
+            if command.click is not None:
+                self._click(
+                    target,
+                    point or self._center(target),
+                    command.click,
+                    command.click_count,
+                )
+        if command.pause_ms:
+            time.sleep(command.pause_ms / 1000.0)
+
+    def _window(self, title: str) -> int:
+        hwnd = _find_window_handle_for_pid(self.user32, self.expected_pid, title)
+        if hwnd is None:
+            raise RuntimeError(f"DipTrace window was not found for pid {self.expected_pid}")
+        return hwnd
+
+    def _target(
+        self, hwnd: int, normalized_x: float, normalized_y: float
+    ) -> tuple[int, tuple[int, int]]:
+        rect = wintypes.RECT()
+        if not self.user32.GetClientRect(hwnd, ctypes.byref(rect)):
+            raise RuntimeError("cannot read DipTrace client rectangle")
+        width, height = rect.right - rect.left, rect.bottom - rect.top
+        if width <= 0 or height <= 0:
+            raise RuntimeError("DipTrace client rectangle is empty")
+        point = wintypes.POINT(
+            min(max(round(width * normalized_x), 0), width - 1),
+            min(max(round(height * normalized_y), 0), height - 1),
+        )
+        current = hwnd
+        for _ in range(8):
+            child = int(self.user32.ChildWindowFromPointEx(current, point, _CHILD_FLAGS))
+            if not child or child == current:
+                break
+            mapped = wintypes.POINT(point.x, point.y)
+            self.user32.MapWindowPoints(current, child, ctypes.byref(mapped), 1)
+            current, point = child, mapped
+        self._last_target = current
+        return current, (int(point.x), int(point.y))
+
+    def _center(self, hwnd: int) -> tuple[int, int]:
+        rect = wintypes.RECT()
+        if not self.user32.GetClientRect(hwnd, ctypes.byref(rect)):
+            raise RuntimeError("cannot read target client rectangle")
+        return max((rect.right - rect.left) // 2, 0), max(
+            (rect.bottom - rect.top) // 2, 0
+        )
+
+    def _send(self, hwnd: int, message: int, wparam: int, lparam: int) -> None:
+        result = ctypes.c_size_t()
+        if not self.user32.SendMessageTimeoutW(
+            hwnd,
+            message,
+            wparam,
+            lparam,
+            _SMTO_FLAGS,
+            2_000,
+            ctypes.byref(result),
+        ):
+            raise RuntimeError(f"bounded Win32 message failed: 0x{message:04x}")
+
+    def _mouse_move(self, hwnd: int, point: tuple[int, int]) -> None:
+        self._send(hwnd, _WM_MOUSEMOVE, 0, _pack_point(*point))
+
+    def _click(
+        self, hwnd: int, point: tuple[int, int], button: str, count: int
+    ) -> None:
+        down, up, double, mask = _BUTTON_MESSAGES[button]
+        packed = _pack_point(*point)
+        self._send(hwnd, down, mask, packed)
+        self._send(hwnd, up, 0, packed)
+        if count >= 2:
+            self._send(hwnd, double, mask, packed)
+            self._send(hwnd, up, 0, packed)
+        if count == 3:
+            self._send(hwnd, down, mask, packed)
+            self._send(hwnd, up, 0, packed)
+
+    def _hotkey(self, hwnd: int, keys: Sequence[str]) -> None:
+        if len(keys) != 1:
+            raise RuntimeError(
+                "hidden cinematic mode refuses modifier/multi-key hotkeys; "
+                "configure a message-safe click macro"
+            )
+        virtual_key = _virtual_key(keys[0])
+        self._send(hwnd, _WM_KEYDOWN, virtual_key, 0)
+        self._send(hwnd, _WM_KEYUP, virtual_key, 0)
+
+    def _text(self, hwnd: int, text: str) -> None:
+        encoded = text.encode("utf-16-le")
+        for offset in range(0, len(encoded), 2):
+            self._send(
+                hwnd,
+                _WM_CHAR,
+                int.from_bytes(encoded[offset : offset + 2], "little"),
+                0,
+            )
+
+
+def _virtual_key(key: str) -> int:
+    normalized = key.strip().lower()
+    if normalized in _VK:
+        return _VK[normalized]
+    if len(normalized) == 1 and normalized.isascii() and normalized.isalnum():
+        return ord(normalized.upper())
+    if normalized.startswith("f") and normalized[1:].isdigit():
+        number = int(normalized[1:])
+        if 1 <= number <= 24:
+            return 0x70 + number - 1
+    raise ValueError(f"unsupported message-safe key name: {key}")
+
+
+def _pack_point(x: int, y: int) -> int:
+    return (x & 0xFFFF) | ((y & 0xFFFF) << 16)
+
+
+def _find_window_handle_for_pid(user32: Any, pid: int, title: str) -> int | None:
+    needle = title.casefold()
+    matches: list[int] = []
+    callback_type: Any = getattr(ctypes, "WINFUNCTYPE")(
+        ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p
+    )
+
+    def callback(hwnd: int, _lparam: int) -> bool:
+        if not user32.IsWindowVisible(hwnd):
+            return True
+        process_id = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(process_id))
+        if int(process_id.value) != pid:
+            return True
+        length = int(user32.GetWindowTextLengthW(hwnd))
+        if length <= 0:
+            return True
+        buffer = ctypes.create_unicode_buffer(length + 1)
+        user32.GetWindowTextW(hwnd, buffer, len(buffer))
+        if needle in buffer.value.casefold():
+            matches.append(int(hwnd))
+            return False
+        return True
+
+    user32.EnumWindows(callback_type(callback), 0)
+    return matches[0] if matches else None
+
+
+def _wait_for_window(user32: Any, pid: int, title: str, timeout: float) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        hwnd = _find_window_handle_for_pid(user32, pid, title)
+        if hwnd is not None:
+            return hwnd
+        time.sleep(0.1)
+    raise RuntimeError(f"DipTrace window did not appear within {timeout:g}s")
+
+
+def _read_manifest(path: Path) -> tuple[dict[str, Any], CinematicPreflightResult]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read cinematic manifest: {path}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("cinematic manifest root must be an object")
+    manifest = cast(dict[str, Any], raw)
+    return manifest, preflight_cinematic_manifest(manifest)
+
+
+def _validate_headless_request(
+    request: HeadlessCinematicRequest,
+) -> tuple[HeadlessCinematicRequest, dict[str, Any], CinematicPreflightResult]:
+    try:
+        root = validate_diptrace_directory(request.diptrace_root).root
+    except ConfiguratorError as exc:
+        raise HeadlessGuiError(str(exc)) from exc
+    request = replace(
+        request,
+        diptrace_root=root,
+        project=request.project.expanduser().resolve(strict=False),
+        manifest=request.manifest.expanduser().resolve(strict=False),
+        video_output=request.video_output.expanduser().resolve(strict=False),
+        gif_output=(
+            request.gif_output.expanduser().resolve(strict=False)
+            if request.gif_output is not None
+            else None
+        ),
+    )
+    if not request.executable.is_file():
+        raise HeadlessGuiError(f"selected DipTrace editor is missing: {request.executable}")
+    if not request.project.is_file():
+        raise HeadlessGuiError(f"project file does not exist: {request.project}")
+    if not request.manifest.is_file():
+        raise HeadlessGuiError(f"cinematic manifest does not exist: {request.manifest}")
+    protected = {request.project, request.manifest}
+    if request.video_output in protected or request.gif_output in protected:
+        raise HeadlessGuiError("capture output must not overwrite project or manifest")
+    if request.gif_output is not None and request.gif_output == request.video_output:
+        raise HeadlessGuiError("video and GIF outputs must be different files")
+    manifest, preflight = _read_manifest(request.manifest)
+    return request, manifest, preflight
+
+
+def _capture_seconds(
+    manifest: Mapping[str, Any],
+    preflight: CinematicPreflightResult,
+    tail: float,
+) -> float:
+    pause_ms = 0
+    cues = manifest.get("cues")
+    if isinstance(cues, list):
+        for cue in cues:
+            if not isinstance(cue, Mapping):
+                continue
+            event = cue.get("event")
+            if not isinstance(event, Mapping):
+                continue
+            payload = event.get("payload")
+            if isinstance(payload, Mapping):
+                pause_ms += sum(
+                    command.pause_ms for command in desktop_commands_from_payload(payload)
+                )
+    return max(
+        1.0,
+        _CAPTURE_LEAD_SECONDS
+        + preflight.duration_ms / 1000.0
+        + pause_ms / 1000.0
+        + tail,
+    )
 
 
 def build_windows_capture_command(
@@ -30,7 +501,9 @@ def build_windows_capture_command(
         raise ValueError("window_handle must be a positive integer")
     if desktop and (window_handle is not None or window_title not in {None, "DipTrace"}):
         raise ValueError("desktop capture cannot also select a window")
-    if not desktop and window_handle is None and (window_title is None or not window_title.strip()):
+    if not desktop and window_handle is None and (
+        window_title is None or not window_title.strip()
+    ):
         raise ValueError("window_title or window_handle is required for window capture")
 
     if desktop:
@@ -100,8 +573,338 @@ def record_windows(
         duration_seconds=duration_seconds,
         draw_mouse=draw_mouse,
     )
-    completed = subprocess.run(command, check=False)
-    return completed.returncode
+    return subprocess.run(command, check=False).returncode
+
+
+def _convert_video_to_gif(video: Path, gif: Path, *, fps: int, width: int) -> None:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required for GIF conversion")
+    gif.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="diptrace-cinematic-gif-") as raw_temp:
+        palette = Path(raw_temp) / "palette.png"
+        base = f"fps={fps},scale={width}:-1:flags=lanczos"
+        commands = [
+            [ffmpeg, "-y", "-i", str(video), "-vf", f"{base},palettegen", str(palette)],
+            [
+                ffmpeg,
+                "-y",
+                "-i",
+                str(video),
+                "-i",
+                str(palette),
+                "-lavfi",
+                f"{base}[x];[x][1:v]paletteuse",
+                str(gif),
+            ],
+        ]
+        for command in commands:
+            completed = subprocess.run(command, check=False)
+            if completed.returncode != 0:
+                raise RuntimeError(
+                    f"GIF conversion failed with code {completed.returncode}"
+                )
+    if not gif.is_file() or gif.stat().st_size <= 0:
+        raise RuntimeError("GIF conversion produced no output")
+
+
+def _cinematic_worker_argv(*args: str) -> list[str]:
+    if bool(sys.__dict__.get("frozen", False)):
+        return [sys.executable, "cinematic", *args]
+    return [
+        sys.executable,
+        "-m",
+        "diptrace_mcp.cinematic_recording",
+        "headless-capture",
+        *args,
+    ]
+
+
+def _perform_hidden_capture(
+    request: HeadlessCinematicRequest,
+    *,
+    desktop_name: str,
+    expected_session: int,
+) -> HeadlessCinematicResult:
+    request, manifest, preflight = _validate_headless_request(request)
+    if process_is_elevated():
+        raise HeadlessGuiError("headless cinematic worker must not be elevated")
+    if thread_desktop_name().casefold() != desktop_name.casefold():
+        raise HeadlessGuiError("cinematic worker landed on the wrong desktop")
+    station = process_window_station_name()
+    session = process_session_id()
+    if station.casefold() != _INTERACTIVE_WINDOW_STATION.casefold():
+        raise HeadlessGuiError("cinematic worker is not attached to WinSta0")
+    if session != expected_session:
+        raise HeadlessGuiError("cinematic worker landed in the wrong Windows session")
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise HeadlessGuiError("ffmpeg is required for headless cinematic capture")
+
+    qualified = f"{station}\\{desktop_name}"
+    request.video_output.parent.mkdir(parents=True, exist_ok=True)
+    request.video_output.unlink(missing_ok=True)
+    diptrace = _launch_process_on_desktop(
+        [str(request.executable), str(request.project)], qualified
+    )
+    ffmpeg_process = None
+    ffmpeg_pid: int | None = None
+    hwnd: int | None = None
+    forced = False
+    error: str | None = None
+    try:
+        windll = getattr(ctypes, "windll", None)
+        if windll is None:
+            raise HeadlessGuiError("Windows user32 bindings are unavailable")
+        user32: Any = windll.user32
+        hwnd = _wait_for_window(
+            user32, diptrace.pid, request.window_title, request.startup_timeout_seconds
+        )
+        user32.ShowWindow(hwnd, 3)
+        capture_seconds = _capture_seconds(manifest, preflight, request.tail_seconds)
+        command = build_windows_capture_command(
+            request.video_output,
+            window_title=None,
+            desktop=True,
+            fps=request.fps,
+            duration_seconds=capture_seconds,
+            draw_mouse=False,
+        )
+        command[0] = ffmpeg_path
+        ffmpeg_process = _launch_process_on_desktop(command, qualified)
+        ffmpeg_pid = ffmpeg_process.pid
+        time.sleep(_CAPTURE_LEAD_SECONDS)
+        play_manifest(
+            manifest,
+            HiddenMessageDesktopDriver(
+                expected_pid=diptrace.pid, default_window=request.window_title
+            ),
+        )
+        exit_code = ffmpeg_process.wait(capture_seconds + 15.0)
+        if exit_code is None:
+            ffmpeg_process.terminate(124)
+            ffmpeg_process.wait(2.0)
+            raise HeadlessGuiError("headless cinematic ffmpeg capture timed out")
+        if exit_code != 0:
+            raise HeadlessGuiError(f"headless cinematic ffmpeg exited with code {exit_code}")
+        if not request.video_output.is_file() or request.video_output.stat().st_size <= 0:
+            raise HeadlessGuiError("headless cinematic capture produced no video")
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        if ffmpeg_process is not None:
+            with suppress(Exception):
+                if ffmpeg_process.wait(0) is None:
+                    ffmpeg_process.terminate(125)
+            ffmpeg_process.close()
+        if hwnd is not None:
+            with suppress(Exception):
+                windll = getattr(ctypes, "windll", None)
+                if windll is not None:
+                    windll.user32.PostMessageW(hwnd, _WM_CLOSE, 0, 0)
+        with suppress(Exception):
+            if diptrace.wait(2.0) is None:
+                forced = True
+                diptrace.terminate(126)
+        diptrace.close()
+
+    return HeadlessCinematicResult(
+        ok=error is None,
+        desktop_name=desktop_name,
+        worker_pid=os.getpid(),
+        diptrace_pid=diptrace.pid,
+        ffmpeg_pid=ffmpeg_pid,
+        project=str(request.project),
+        manifest=str(request.manifest),
+        manifest_sha256=preflight.content_sha256,
+        video_output=str(request.video_output),
+        video_sha256=_sha256(request.video_output),
+        window_station_name=station,
+        session_id=session,
+        forced_termination=forced,
+        error=error,
+    )
+
+
+def run_headless_cinematic(
+    request: HeadlessCinematicRequest,
+) -> HeadlessCinematicResult:
+    if os.name != "nt":
+        raise HeadlessGuiError("headless cinematic capture is available only on Windows")
+    if process_is_elevated():
+        raise HeadlessGuiError("headless cinematic capture must not be elevated")
+    request, manifest, preflight = _validate_headless_request(request)
+    if shutil.which("ffmpeg") is None:
+        raise HeadlessGuiError("ffmpeg is required for headless cinematic capture")
+
+    before = input_desktop_name()
+    station_before = process_window_station_name()
+    session_before = process_session_id()
+    desktop_name = f"DipTraceMCP-Cinematic-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    timeout = (
+        request.startup_timeout_seconds
+        + _capture_seconds(manifest, preflight, request.tail_seconds)
+        + 45.0
+    )
+    with tempfile.TemporaryDirectory(prefix="diptrace-headless-cinematic-") as raw_temp:
+        request_path = Path(raw_temp) / "request.json"
+        result_path = Path(raw_temp) / "result.json"
+        payload = request.as_json()
+        payload["_expected_session_id"] = session_before
+        _write_json(request_path, payload)
+        with HiddenDesktop(desktop_name) as desktop:
+            argv = _cinematic_worker_argv(
+                "_worker",
+                "--request",
+                str(request_path),
+                "--result",
+                str(result_path),
+                "--desktop-name",
+                desktop_name,
+            )
+            with desktop.launch(argv) as worker:
+                exit_code = worker.wait(timeout)
+                if exit_code is None:
+                    worker.terminate(124)
+                    raise HeadlessGuiError("headless cinematic worker timed out")
+        if not result_path.is_file():
+            raise HeadlessGuiError(
+                f"cinematic worker exited with code {exit_code} without a result"
+            )
+        result = HeadlessCinematicResult.from_json(_load_json(result_path))
+
+    after = input_desktop_name()
+    station_after = process_window_station_name()
+    session_after = process_session_id()
+    errors: list[str] = []
+    if before is not None and after is not None and before != after:
+        errors.append(f"input desktop changed unexpectedly: {before!r} -> {after!r}")
+    if station_after.casefold() != station_before.casefold():
+        errors.append("window station changed unexpectedly")
+    if session_after != session_before:
+        errors.append("Windows session changed unexpectedly")
+    result = replace(
+        result,
+        input_desktop_before=before,
+        input_desktop_after=after,
+        window_station_name=station_after,
+        session_id=session_after,
+    )
+    if errors:
+        result = replace(
+            result,
+            ok=False,
+            error="; ".join(filter(None, [result.error, *errors])),
+        )
+    if result.ok and request.gif_output is not None:
+        try:
+            _convert_video_to_gif(
+                request.video_output,
+                request.gif_output,
+                fps=request.gif_fps,
+                width=request.gif_width,
+            )
+            result = replace(
+                result,
+                gif_output=str(request.gif_output),
+                gif_sha256=_sha256(request.gif_output),
+            )
+        except Exception as exc:
+            result = replace(
+                result,
+                ok=False,
+                gif_output=str(request.gif_output),
+                gif_sha256=_sha256(request.gif_output),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+    return result
+
+
+def _cmd_headless_worker(args: argparse.Namespace) -> int:
+    result_path = Path(str(args.result))
+    payload: dict[str, object] = {}
+    try:
+        payload = _load_json(Path(str(args.request)))
+        result = _perform_hidden_capture(
+            HeadlessCinematicRequest.from_json(payload),
+            desktop_name=str(args.desktop_name),
+            expected_session=_coerce_int(payload.get("_expected_session_id"), -1),
+        )
+    except Exception as exc:
+        result = HeadlessCinematicResult(
+            False,
+            str(args.desktop_name),
+            os.getpid(),
+            None,
+            None,
+            _string_or_default(payload.get("project"), ""),
+            _string_or_default(payload.get("manifest"), ""),
+            None,
+            _string_or_default(payload.get("video_output"), ""),
+            None,
+            gif_output=_optional_string(payload.get("gif_output")),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    _write_json(result_path, result.as_json())
+    return 0 if result.ok else 1
+
+
+def _cmd_headless_capture(args: argparse.Namespace) -> int:
+    request = HeadlessCinematicRequest(
+        Path(str(args.diptrace_root)),
+        Path(str(args.project)),
+        Path(str(args.manifest)),
+        Path(str(args.video)),
+        str(args.editor),
+        str(args.window_title),
+        int(args.fps),
+        float(args.startup_timeout),
+        float(args.tail),
+        Path(str(args.gif)) if args.gif else None,
+        int(args.gif_fps),
+        int(args.gif_width),
+    )
+    try:
+        result = run_headless_cinematic(request)
+    except (HeadlessGuiError, OSError, ValueError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False, indent=2))
+        return 1
+    print(json.dumps(result.as_json(), ensure_ascii=False, indent=2))
+    return 0 if result.ok else 1
+
+
+def _build_headless_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="diptrace-mcp-headless-gui cinematic",
+        description="Capture DipTrace cinematic playback on a hidden Win32 desktop.",
+    )
+    subs = parser.add_subparsers(dest="command", required=True)
+    capture = subs.add_parser("capture")
+    capture.add_argument("--diptrace-root", required=True)
+    capture.add_argument("--project", required=True)
+    capture.add_argument("--editor", choices=sorted(_EDITOR_EXECUTABLES), required=True)
+    capture.add_argument("--manifest", required=True)
+    capture.add_argument("--video", required=True)
+    capture.add_argument("--gif")
+    capture.add_argument("--window-title", default="DipTrace")
+    capture.add_argument("--fps", type=int, default=60)
+    capture.add_argument("--gif-fps", type=int, default=20)
+    capture.add_argument("--gif-width", type=int, default=1280)
+    capture.add_argument("--startup-timeout", type=float, default=30.0)
+    capture.add_argument("--tail", type=float, default=0.75)
+    capture.set_defaults(handler=_cmd_headless_capture)
+
+    worker = subs.add_parser("_worker", help=argparse.SUPPRESS)
+    worker.add_argument("--request", required=True)
+    worker.add_argument("--result", required=True)
+    worker.add_argument("--desktop-name", required=True)
+    worker.set_defaults(handler=_cmd_headless_worker)
+    return parser
+
+
+def headless_main(argv: Sequence[str] | None = None) -> int:
+    args = _build_headless_parser().parse_args(argv)
+    return int(args.handler(args))
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -124,7 +927,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _build_parser().parse_args(argv)
+    effective = list(argv) if argv is not None else list(sys.argv[1:])
+    if effective and effective[0] == "headless-capture":
+        return headless_main(effective[1:])
+    args = _build_parser().parse_args(effective)
     window_title = None if args.desktop else args.window_title
     if args.print_command:
         command = build_windows_capture_command(

--- a/src/diptrace_mcp/cinematic_recording.py
+++ b/src/diptrace_mcp/cinematic_recording.py
@@ -230,14 +230,14 @@ class HiddenMessageDesktopDriver:
                 self._click(target, point, command.click or "left", command.click_count)
         else:
             target = hwnd
-            point: tuple[int, int] | None = None
+            click_point: tuple[int, int] | None = None
             if command.move_to is not None:
-                target, point = self._target(hwnd, *command.move_to)
-                self._send(target, _WM_MOUSEMOVE, 0, _pack_point(*point))
+                target, click_point = self._target(hwnd, *command.move_to)
+                self._send(target, _WM_MOUSEMOVE, 0, _pack_point(*click_point))
             if command.click is not None:
                 self._click(
                     target,
-                    point if point is not None else self._center(target),
+                    click_point if click_point is not None else self._center(target),
                     command.click,
                     command.click_count,
                 )
@@ -356,7 +356,8 @@ def _pack_point(x: int, y: int) -> int:
 def _find_window_handle_for_pid(user32: Any, pid: int, title: str) -> int | None:
     needle = title.casefold()
     matches: list[int] = []
-    callback_type: Any = ctypes.WINFUNCTYPE(
+    ctypes_any: Any = ctypes
+    callback_type: Any = ctypes_any.WINFUNCTYPE(
         ctypes.c_bool,
         ctypes.c_void_p,
         ctypes.c_void_p,
@@ -666,13 +667,11 @@ def _perform_hidden_capture(
         ffmpeg_process = hg._launch_process_on_desktop(command, qualified)
         ffmpeg_pid = ffmpeg_process.pid
         time.sleep(_CAPTURE_LEAD_SECONDS)
-        play_manifest(
-            manifest,
-            HiddenMessageDesktopDriver(
-                expected_pid=diptrace.pid,
-                default_window=request.window_title,
-            ),
+        message_driver: Any = HiddenMessageDesktopDriver(
+            expected_pid=diptrace.pid,
+            default_window=request.window_title,
         )
+        play_manifest(manifest, message_driver)
         exit_code = ffmpeg_process.wait(capture_seconds + 15.0)
         if exit_code is None:
             ffmpeg_process.terminate(124)

--- a/src/diptrace_mcp/cinematic_recording.py
+++ b/src/diptrace_mcp/cinematic_recording.py
@@ -17,31 +17,11 @@ from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
+from . import headless_gui as hg
 from .cinematic import CinematicEvent
 from .cinematic_host import DesktopCommand, desktop_commands_from_payload, play_manifest
 from .cinematic_preflight import CinematicPreflightResult, preflight_cinematic_manifest
 from .diptrace_window import find_window_handle
-from .headless_gui import (
-    HeadlessGuiError,
-    HiddenDesktop,
-    _EDITOR_EXECUTABLES,
-    _INTERACTIVE_WINDOW_STATION,
-    _coerce_float,
-    _coerce_int,
-    _launch_process_on_desktop,
-    _load_json,
-    _optional_int,
-    _optional_string,
-    _required_string,
-    _sha256,
-    _string_or_default,
-    _write_json,
-    input_desktop_name,
-    process_is_elevated,
-    process_session_id,
-    process_window_station_name,
-    thread_desktop_name,
-)
 from .windows_configurator import ConfiguratorError, validate_diptrace_directory
 
 _WM_CLOSE = 0x0010
@@ -54,7 +34,7 @@ _BUTTON_MESSAGES = {
     "right": (0x0204, 0x0205, 0x0206, 0x0002),
     "middle": (0x0207, 0x0208, 0x0209, 0x0010),
 }
-_VK = {
+_SINGLE_KEYS = {
     "enter": 0x0D,
     "return": 0x0D,
     "esc": 0x1B,
@@ -70,7 +50,7 @@ _VK = {
     "right": 0x27,
     "down": 0x28,
 }
-_SMTO_FLAGS = 0x0001 | 0x0002
+_SEND_TIMEOUT_FLAGS = 0x0001 | 0x0002
 _CHILD_FLAGS = 0x0001 | 0x0002
 _CAPTURE_LEAD_SECONDS = 0.35
 
@@ -92,10 +72,9 @@ class HeadlessCinematicRequest:
 
     def __post_init__(self) -> None:
         editor = self.editor.strip().lower()
-        if editor not in _EDITOR_EXECUTABLES:
-            raise ValueError(
-                "editor must be one of: " + ", ".join(sorted(_EDITOR_EXECUTABLES))
-            )
+        if editor not in hg._EDITOR_EXECUTABLES:
+            choices = ", ".join(sorted(hg._EDITOR_EXECUTABLES))
+            raise ValueError(f"editor must be one of: {choices}")
         if not self.window_title.strip():
             raise ValueError("window_title must not be empty")
         if not 1 <= self.fps <= 240:
@@ -123,7 +102,7 @@ class HeadlessCinematicRequest:
 
     @property
     def executable(self) -> Path:
-        return self.diptrace_root / _EDITOR_EXECUTABLES[self.editor]
+        return self.diptrace_root / hg._EDITOR_EXECUTABLES[self.editor]
 
     def as_json(self) -> dict[str, object]:
         return {
@@ -143,22 +122,22 @@ class HeadlessCinematicRequest:
 
     @classmethod
     def from_json(cls, value: Mapping[str, object]) -> HeadlessCinematicRequest:
-        gif = _optional_string(value.get("gif_output"))
+        gif = hg._optional_string(value.get("gif_output"))
         return cls(
-            diptrace_root=Path(_required_string(value, "diptrace_root")),
-            project=Path(_required_string(value, "project")),
-            manifest=Path(_required_string(value, "manifest")),
-            video_output=Path(_required_string(value, "video_output")),
-            editor=_required_string(value, "editor"),
-            window_title=_string_or_default(value.get("window_title"), "DipTrace"),
-            fps=_coerce_int(value.get("fps"), 60),
-            startup_timeout_seconds=_coerce_float(
+            diptrace_root=Path(hg._required_string(value, "diptrace_root")),
+            project=Path(hg._required_string(value, "project")),
+            manifest=Path(hg._required_string(value, "manifest")),
+            video_output=Path(hg._required_string(value, "video_output")),
+            editor=hg._required_string(value, "editor"),
+            window_title=hg._string_or_default(value.get("window_title"), "DipTrace"),
+            fps=hg._coerce_int(value.get("fps"), 60),
+            startup_timeout_seconds=hg._coerce_float(
                 value.get("startup_timeout_seconds"), 30.0
             ),
-            tail_seconds=_coerce_float(value.get("tail_seconds"), 0.75),
+            tail_seconds=hg._coerce_float(value.get("tail_seconds"), 0.75),
             gif_output=Path(gif) if gif else None,
-            gif_fps=_coerce_int(value.get("gif_fps"), 20),
-            gif_width=_coerce_int(value.get("gif_width"), 1280),
+            gif_fps=hg._coerce_int(value.get("gif_fps"), 20),
+            gif_width=hg._coerce_int(value.get("gif_width"), 1280),
         )
 
 
@@ -190,28 +169,28 @@ class HeadlessCinematicResult:
     def from_json(cls, value: Mapping[str, object]) -> HeadlessCinematicResult:
         return cls(
             ok=bool(value.get("ok", False)),
-            desktop_name=_string_or_default(value.get("desktop_name"), "unknown"),
-            worker_pid=_coerce_int(value.get("worker_pid"), 0),
-            diptrace_pid=_optional_int(value.get("diptrace_pid")),
-            ffmpeg_pid=_optional_int(value.get("ffmpeg_pid")),
-            project=_string_or_default(value.get("project"), ""),
-            manifest=_string_or_default(value.get("manifest"), ""),
-            manifest_sha256=_optional_string(value.get("manifest_sha256")),
-            video_output=_string_or_default(value.get("video_output"), ""),
-            video_sha256=_optional_string(value.get("video_sha256")),
-            gif_output=_optional_string(value.get("gif_output")),
-            gif_sha256=_optional_string(value.get("gif_sha256")),
-            input_desktop_before=_optional_string(value.get("input_desktop_before")),
-            input_desktop_after=_optional_string(value.get("input_desktop_after")),
-            window_station_name=_optional_string(value.get("window_station_name")),
-            session_id=_optional_int(value.get("session_id")),
+            desktop_name=hg._string_or_default(value.get("desktop_name"), "unknown"),
+            worker_pid=hg._coerce_int(value.get("worker_pid"), 0),
+            diptrace_pid=hg._optional_int(value.get("diptrace_pid")),
+            ffmpeg_pid=hg._optional_int(value.get("ffmpeg_pid")),
+            project=hg._string_or_default(value.get("project"), ""),
+            manifest=hg._string_or_default(value.get("manifest"), ""),
+            manifest_sha256=hg._optional_string(value.get("manifest_sha256")),
+            video_output=hg._string_or_default(value.get("video_output"), ""),
+            video_sha256=hg._optional_string(value.get("video_sha256")),
+            gif_output=hg._optional_string(value.get("gif_output")),
+            gif_sha256=hg._optional_string(value.get("gif_sha256")),
+            input_desktop_before=hg._optional_string(value.get("input_desktop_before")),
+            input_desktop_after=hg._optional_string(value.get("input_desktop_after")),
+            window_station_name=hg._optional_string(value.get("window_station_name")),
+            session_id=hg._optional_int(value.get("session_id")),
             forced_termination=bool(value.get("forced_termination", False)),
-            error=_optional_string(value.get("error")),
+            error=hg._optional_string(value.get("error")),
         )
 
 
 class HiddenMessageDesktopDriver:
-    """Replay cinematic commands via bounded window messages, never global input."""
+    """Replay through window messages without touching global physical input."""
 
     def __init__(self, *, expected_pid: int, default_window: str = "DipTrace") -> None:
         if os.name != "nt":
@@ -228,7 +207,8 @@ class HiddenMessageDesktopDriver:
 
     def handle(self, event: CinematicEvent) -> None:
         commands = desktop_commands_from_payload(
-            event.payload, default_window=self.default_window
+            event.payload,
+            default_window=self.default_window,
         )
         if not commands:
             if event.kind == "focus":
@@ -246,18 +226,18 @@ class HiddenMessageDesktopDriver:
         if command.path:
             for x, y in command.path:
                 target, point = self._target(hwnd, x, y)
-                self._mouse_move(target, point)
+                self._send(target, _WM_MOUSEMOVE, 0, _pack_point(*point))
                 self._click(target, point, command.click or "left", command.click_count)
         else:
             target = hwnd
             point: tuple[int, int] | None = None
             if command.move_to is not None:
                 target, point = self._target(hwnd, *command.move_to)
-                self._mouse_move(target, point)
+                self._send(target, _WM_MOUSEMOVE, 0, _pack_point(*point))
             if command.click is not None:
                 self._click(
                     target,
-                    point or self._center(target),
+                    point if point is not None else self._center(target),
                     command.click,
                     command.click_count,
                 )
@@ -271,12 +251,16 @@ class HiddenMessageDesktopDriver:
         return hwnd
 
     def _target(
-        self, hwnd: int, normalized_x: float, normalized_y: float
+        self,
+        hwnd: int,
+        normalized_x: float,
+        normalized_y: float,
     ) -> tuple[int, tuple[int, int]]:
         rect = wintypes.RECT()
         if not self.user32.GetClientRect(hwnd, ctypes.byref(rect)):
             raise RuntimeError("cannot read DipTrace client rectangle")
-        width, height = rect.right - rect.left, rect.bottom - rect.top
+        width = rect.right - rect.left
+        height = rect.bottom - rect.top
         if width <= 0 or height <= 0:
             raise RuntimeError("DipTrace client rectangle is empty")
         point = wintypes.POINT(
@@ -290,7 +274,8 @@ class HiddenMessageDesktopDriver:
                 break
             mapped = wintypes.POINT(point.x, point.y)
             self.user32.MapWindowPoints(current, child, ctypes.byref(mapped), 1)
-            current, point = child, mapped
+            current = child
+            point = mapped
         self._last_target = current
         return current, (int(point.x), int(point.y))
 
@@ -298,8 +283,9 @@ class HiddenMessageDesktopDriver:
         rect = wintypes.RECT()
         if not self.user32.GetClientRect(hwnd, ctypes.byref(rect)):
             raise RuntimeError("cannot read target client rectangle")
-        return max((rect.right - rect.left) // 2, 0), max(
-            (rect.bottom - rect.top) // 2, 0
+        return (
+            max((rect.right - rect.left) // 2, 0),
+            max((rect.bottom - rect.top) // 2, 0),
         )
 
     def _send(self, hwnd: int, message: int, wparam: int, lparam: int) -> None:
@@ -309,17 +295,18 @@ class HiddenMessageDesktopDriver:
             message,
             wparam,
             lparam,
-            _SMTO_FLAGS,
+            _SEND_TIMEOUT_FLAGS,
             2_000,
             ctypes.byref(result),
         ):
             raise RuntimeError(f"bounded Win32 message failed: 0x{message:04x}")
 
-    def _mouse_move(self, hwnd: int, point: tuple[int, int]) -> None:
-        self._send(hwnd, _WM_MOUSEMOVE, 0, _pack_point(*point))
-
     def _click(
-        self, hwnd: int, point: tuple[int, int], button: str, count: int
+        self,
+        hwnd: int,
+        point: tuple[int, int],
+        button: str,
+        count: int,
     ) -> None:
         down, up, double, mask = _BUTTON_MESSAGES[button]
         packed = _pack_point(*point)
@@ -345,18 +332,14 @@ class HiddenMessageDesktopDriver:
     def _text(self, hwnd: int, text: str) -> None:
         encoded = text.encode("utf-16-le")
         for offset in range(0, len(encoded), 2):
-            self._send(
-                hwnd,
-                _WM_CHAR,
-                int.from_bytes(encoded[offset : offset + 2], "little"),
-                0,
-            )
+            code_unit = int.from_bytes(encoded[offset : offset + 2], "little")
+            self._send(hwnd, _WM_CHAR, code_unit, 0)
 
 
 def _virtual_key(key: str) -> int:
     normalized = key.strip().lower()
-    if normalized in _VK:
-        return _VK[normalized]
+    if normalized in _SINGLE_KEYS:
+        return _SINGLE_KEYS[normalized]
     if len(normalized) == 1 and normalized.isascii() and normalized.isalnum():
         return ord(normalized.upper())
     if normalized.startswith("f") and normalized[1:].isdigit():
@@ -373,8 +356,10 @@ def _pack_point(x: int, y: int) -> int:
 def _find_window_handle_for_pid(user32: Any, pid: int, title: str) -> int | None:
     needle = title.casefold()
     matches: list[int] = []
-    callback_type: Any = getattr(ctypes, "WINFUNCTYPE")(
-        ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p
+    callback_type: Any = ctypes.WINFUNCTYPE(
+        ctypes.c_bool,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
     )
 
     def callback(hwnd: int, _lparam: int) -> bool:
@@ -425,7 +410,7 @@ def _validate_headless_request(
     try:
         root = validate_diptrace_directory(request.diptrace_root).root
     except ConfiguratorError as exc:
-        raise HeadlessGuiError(str(exc)) from exc
+        raise hg.HeadlessGuiError(str(exc)) from exc
     request = replace(
         request,
         diptrace_root=root,
@@ -439,16 +424,18 @@ def _validate_headless_request(
         ),
     )
     if not request.executable.is_file():
-        raise HeadlessGuiError(f"selected DipTrace editor is missing: {request.executable}")
+        raise hg.HeadlessGuiError(f"selected DipTrace editor is missing: {request.executable}")
     if not request.project.is_file():
-        raise HeadlessGuiError(f"project file does not exist: {request.project}")
+        raise hg.HeadlessGuiError(f"project file does not exist: {request.project}")
     if not request.manifest.is_file():
-        raise HeadlessGuiError(f"cinematic manifest does not exist: {request.manifest}")
-    protected = {request.project, request.manifest}
-    if request.video_output in protected or request.gif_output in protected:
-        raise HeadlessGuiError("capture output must not overwrite project or manifest")
-    if request.gif_output is not None and request.gif_output == request.video_output:
-        raise HeadlessGuiError("video and GIF outputs must be different files")
+        raise hg.HeadlessGuiError(f"cinematic manifest does not exist: {request.manifest}")
+    if request.video_output in {request.project, request.manifest}:
+        raise hg.HeadlessGuiError("capture output must not overwrite project or manifest")
+    if request.gif_output is not None:
+        if request.gif_output in {request.project, request.manifest}:
+            raise hg.HeadlessGuiError("capture output must not overwrite project or manifest")
+        if request.gif_output == request.video_output:
+            raise hg.HeadlessGuiError("video and GIF outputs must be different files")
     manifest, preflight = _read_manifest(request.manifest)
     return request, manifest, preflight
 
@@ -470,7 +457,8 @@ def _capture_seconds(
             payload = event.get("payload")
             if isinstance(payload, Mapping):
                 pause_ms += sum(
-                    command.pause_ms for command in desktop_commands_from_payload(payload)
+                    command.pause_ms
+                    for command in desktop_commands_from_payload(payload)
                 )
     return max(
         1.0,
@@ -583,9 +571,9 @@ def _convert_video_to_gif(video: Path, gif: Path, *, fps: int, width: int) -> No
     gif.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="diptrace-cinematic-gif-") as raw_temp:
         palette = Path(raw_temp) / "palette.png"
-        base = f"fps={fps},scale={width}:-1:flags=lanczos"
+        scale = f"fps={fps},scale={width}:-1:flags=lanczos"
         commands = [
-            [ffmpeg, "-y", "-i", str(video), "-vf", f"{base},palettegen", str(palette)],
+            [ffmpeg, "-y", "-i", str(video), "-vf", f"{scale},palettegen", str(palette)],
             [
                 ffmpeg,
                 "-y",
@@ -594,7 +582,7 @@ def _convert_video_to_gif(video: Path, gif: Path, *, fps: int, width: int) -> No
                 "-i",
                 str(palette),
                 "-lavfi",
-                f"{base}[x];[x][1:v]paletteuse",
+                f"{scale}[x];[x][1:v]paletteuse",
                 str(gif),
             ],
         ]
@@ -627,27 +615,28 @@ def _perform_hidden_capture(
     expected_session: int,
 ) -> HeadlessCinematicResult:
     request, manifest, preflight = _validate_headless_request(request)
-    if process_is_elevated():
-        raise HeadlessGuiError("headless cinematic worker must not be elevated")
-    if thread_desktop_name().casefold() != desktop_name.casefold():
-        raise HeadlessGuiError("cinematic worker landed on the wrong desktop")
-    station = process_window_station_name()
-    session = process_session_id()
-    if station.casefold() != _INTERACTIVE_WINDOW_STATION.casefold():
-        raise HeadlessGuiError("cinematic worker is not attached to WinSta0")
+    if hg.process_is_elevated():
+        raise hg.HeadlessGuiError("headless cinematic worker must not be elevated")
+    if hg.thread_desktop_name().casefold() != desktop_name.casefold():
+        raise hg.HeadlessGuiError("cinematic worker landed on the wrong desktop")
+    station = hg.process_window_station_name()
+    session = hg.process_session_id()
+    if station.casefold() != hg._INTERACTIVE_WINDOW_STATION.casefold():
+        raise hg.HeadlessGuiError("cinematic worker is not attached to WinSta0")
     if session != expected_session:
-        raise HeadlessGuiError("cinematic worker landed in the wrong Windows session")
+        raise hg.HeadlessGuiError("cinematic worker landed in the wrong Windows session")
     ffmpeg_path = shutil.which("ffmpeg")
     if ffmpeg_path is None:
-        raise HeadlessGuiError("ffmpeg is required for headless cinematic capture")
+        raise hg.HeadlessGuiError("ffmpeg is required for headless cinematic capture")
 
     qualified = f"{station}\\{desktop_name}"
     request.video_output.parent.mkdir(parents=True, exist_ok=True)
     request.video_output.unlink(missing_ok=True)
-    diptrace = _launch_process_on_desktop(
-        [str(request.executable), str(request.project)], qualified
+    diptrace = hg._launch_process_on_desktop(
+        [str(request.executable), str(request.project)],
+        qualified,
     )
-    ffmpeg_process = None
+    ffmpeg_process: hg.CreatedProcess | None = None
     ffmpeg_pid: int | None = None
     hwnd: int | None = None
     forced = False
@@ -655,10 +644,13 @@ def _perform_hidden_capture(
     try:
         windll = getattr(ctypes, "windll", None)
         if windll is None:
-            raise HeadlessGuiError("Windows user32 bindings are unavailable")
+            raise hg.HeadlessGuiError("Windows user32 bindings are unavailable")
         user32: Any = windll.user32
         hwnd = _wait_for_window(
-            user32, diptrace.pid, request.window_title, request.startup_timeout_seconds
+            user32,
+            diptrace.pid,
+            request.window_title,
+            request.startup_timeout_seconds,
         )
         user32.ShowWindow(hwnd, 3)
         capture_seconds = _capture_seconds(manifest, preflight, request.tail_seconds)
@@ -671,24 +663,27 @@ def _perform_hidden_capture(
             draw_mouse=False,
         )
         command[0] = ffmpeg_path
-        ffmpeg_process = _launch_process_on_desktop(command, qualified)
+        ffmpeg_process = hg._launch_process_on_desktop(command, qualified)
         ffmpeg_pid = ffmpeg_process.pid
         time.sleep(_CAPTURE_LEAD_SECONDS)
         play_manifest(
             manifest,
             HiddenMessageDesktopDriver(
-                expected_pid=diptrace.pid, default_window=request.window_title
+                expected_pid=diptrace.pid,
+                default_window=request.window_title,
             ),
         )
         exit_code = ffmpeg_process.wait(capture_seconds + 15.0)
         if exit_code is None:
             ffmpeg_process.terminate(124)
             ffmpeg_process.wait(2.0)
-            raise HeadlessGuiError("headless cinematic ffmpeg capture timed out")
+            raise hg.HeadlessGuiError("headless cinematic ffmpeg capture timed out")
         if exit_code != 0:
-            raise HeadlessGuiError(f"headless cinematic ffmpeg exited with code {exit_code}")
+            raise hg.HeadlessGuiError(
+                f"headless cinematic ffmpeg exited with code {exit_code}"
+            )
         if not request.video_output.is_file() or request.video_output.stat().st_size <= 0:
-            raise HeadlessGuiError("headless cinematic capture produced no video")
+            raise hg.HeadlessGuiError("headless cinematic capture produced no video")
     except Exception as exc:
         error = f"{type(exc).__name__}: {exc}"
     finally:
@@ -718,7 +713,7 @@ def _perform_hidden_capture(
         manifest=str(request.manifest),
         manifest_sha256=preflight.content_sha256,
         video_output=str(request.video_output),
-        video_sha256=_sha256(request.video_output),
+        video_sha256=hg._sha256(request.video_output),
         window_station_name=station,
         session_id=session,
         forced_termination=forced,
@@ -730,16 +725,16 @@ def run_headless_cinematic(
     request: HeadlessCinematicRequest,
 ) -> HeadlessCinematicResult:
     if os.name != "nt":
-        raise HeadlessGuiError("headless cinematic capture is available only on Windows")
-    if process_is_elevated():
-        raise HeadlessGuiError("headless cinematic capture must not be elevated")
+        raise hg.HeadlessGuiError("headless cinematic capture is available only on Windows")
+    if hg.process_is_elevated():
+        raise hg.HeadlessGuiError("headless cinematic capture must not be elevated")
     request, manifest, preflight = _validate_headless_request(request)
     if shutil.which("ffmpeg") is None:
-        raise HeadlessGuiError("ffmpeg is required for headless cinematic capture")
+        raise hg.HeadlessGuiError("ffmpeg is required for headless cinematic capture")
 
-    before = input_desktop_name()
-    station_before = process_window_station_name()
-    session_before = process_session_id()
+    before = hg.input_desktop_name()
+    station_before = hg.process_window_station_name()
+    session_before = hg.process_session_id()
     desktop_name = f"DipTraceMCP-Cinematic-{os.getpid()}-{uuid.uuid4().hex[:8]}"
     timeout = (
         request.startup_timeout_seconds
@@ -751,8 +746,8 @@ def run_headless_cinematic(
         result_path = Path(raw_temp) / "result.json"
         payload = request.as_json()
         payload["_expected_session_id"] = session_before
-        _write_json(request_path, payload)
-        with HiddenDesktop(desktop_name) as desktop:
+        hg._write_json(request_path, payload)
+        with hg.HiddenDesktop(desktop_name) as desktop:
             argv = _cinematic_worker_argv(
                 "_worker",
                 "--request",
@@ -766,16 +761,16 @@ def run_headless_cinematic(
                 exit_code = worker.wait(timeout)
                 if exit_code is None:
                     worker.terminate(124)
-                    raise HeadlessGuiError("headless cinematic worker timed out")
+                    raise hg.HeadlessGuiError("headless cinematic worker timed out")
         if not result_path.is_file():
-            raise HeadlessGuiError(
+            raise hg.HeadlessGuiError(
                 f"cinematic worker exited with code {exit_code} without a result"
             )
-        result = HeadlessCinematicResult.from_json(_load_json(result_path))
+        result = HeadlessCinematicResult.from_json(hg._load_json(result_path))
 
-    after = input_desktop_name()
-    station_after = process_window_station_name()
-    session_after = process_session_id()
+    after = hg.input_desktop_name()
+    station_after = hg.process_window_station_name()
+    session_after = hg.process_session_id()
     errors: list[str] = []
     if before is not None and after is not None and before != after:
         errors.append(f"input desktop changed unexpectedly: {before!r} -> {after!r}")
@@ -791,11 +786,8 @@ def run_headless_cinematic(
         session_id=session_after,
     )
     if errors:
-        result = replace(
-            result,
-            ok=False,
-            error="; ".join(filter(None, [result.error, *errors])),
-        )
+        combined = [value for value in [result.error, *errors] if value]
+        result = replace(result, ok=False, error="; ".join(combined))
     if result.ok and request.gif_output is not None:
         try:
             _convert_video_to_gif(
@@ -807,14 +799,14 @@ def run_headless_cinematic(
             result = replace(
                 result,
                 gif_output=str(request.gif_output),
-                gif_sha256=_sha256(request.gif_output),
+                gif_sha256=hg._sha256(request.gif_output),
             )
         except Exception as exc:
             result = replace(
                 result,
                 ok=False,
                 gif_output=str(request.gif_output),
-                gif_sha256=_sha256(request.gif_output),
+                gif_sha256=hg._sha256(request.gif_output),
                 error=f"{type(exc).__name__}: {exc}",
             )
     return result
@@ -824,11 +816,11 @@ def _cmd_headless_worker(args: argparse.Namespace) -> int:
     result_path = Path(str(args.result))
     payload: dict[str, object] = {}
     try:
-        payload = _load_json(Path(str(args.request)))
+        payload = hg._load_json(Path(str(args.request)))
         result = _perform_hidden_capture(
             HeadlessCinematicRequest.from_json(payload),
             desktop_name=str(args.desktop_name),
-            expected_session=_coerce_int(payload.get("_expected_session_id"), -1),
+            expected_session=hg._coerce_int(payload.get("_expected_session_id"), -1),
         )
     except Exception as exc:
         result = HeadlessCinematicResult(
@@ -837,15 +829,15 @@ def _cmd_headless_worker(args: argparse.Namespace) -> int:
             os.getpid(),
             None,
             None,
-            _string_or_default(payload.get("project"), ""),
-            _string_or_default(payload.get("manifest"), ""),
+            hg._string_or_default(payload.get("project"), ""),
+            hg._string_or_default(payload.get("manifest"), ""),
             None,
-            _string_or_default(payload.get("video_output"), ""),
+            hg._string_or_default(payload.get("video_output"), ""),
             None,
-            gif_output=_optional_string(payload.get("gif_output")),
+            gif_output=hg._optional_string(payload.get("gif_output")),
             error=f"{type(exc).__name__}: {exc}",
         )
-    _write_json(result_path, result.as_json())
+    hg._write_json(result_path, result.as_json())
     return 0 if result.ok else 1
 
 
@@ -866,7 +858,7 @@ def _cmd_headless_capture(args: argparse.Namespace) -> int:
     )
     try:
         result = run_headless_cinematic(request)
-    except (HeadlessGuiError, OSError, ValueError) as exc:
+    except (hg.HeadlessGuiError, OSError, ValueError) as exc:
         print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False, indent=2))
         return 1
     print(json.dumps(result.as_json(), ensure_ascii=False, indent=2))
@@ -882,7 +874,7 @@ def _build_headless_parser() -> argparse.ArgumentParser:
     capture = subs.add_parser("capture")
     capture.add_argument("--diptrace-root", required=True)
     capture.add_argument("--project", required=True)
-    capture.add_argument("--editor", choices=sorted(_EDITOR_EXECUTABLES), required=True)
+    capture.add_argument("--editor", choices=sorted(hg._EDITOR_EXECUTABLES), required=True)
     capture.add_argument("--manifest", required=True)
     capture.add_argument("--video", required=True)
     capture.add_argument("--gif")

--- a/tests/test_cinematic_recording.py
+++ b/tests/test_cinematic_recording.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import argparse
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from diptrace_mcp import cinematic_recording as recording
-from diptrace_mcp.cinematic_recording import build_windows_capture_command, main
+from diptrace_mcp.cinematic import CinematicTimeline
+from diptrace_mcp.cinematic_recording import (
+    HeadlessCinematicRequest,
+    HeadlessCinematicResult,
+    HiddenMessageDesktopDriver,
+    build_windows_capture_command,
+    main,
+)
 
 
 def test_window_capture_command_targets_arbitrary_window() -> None:
@@ -163,3 +173,329 @@ def test_recording_cli_live_branch_delegates_to_recorder(
     assert captured["window_title"] is None
     assert captured["fps"] == 24
     assert captured["draw_mouse"] is False
+
+
+def _manifest(tmp_path: Path) -> Path:
+    timeline = CinematicTimeline(title="Hidden", preset="gif")
+    timeline.operation(
+        "route_trace",
+        payload={"desktop": {"move_to": [0.4, 0.5], "click": "left"}},
+    )
+    path = tmp_path / "demo.cinematic.json"
+    path.write_text(json.dumps(timeline.manifest()), encoding="utf-8")
+    return path
+
+
+def test_headless_request_and_result_json_contract(tmp_path: Path) -> None:
+    request = HeadlessCinematicRequest(
+        tmp_path / "DipTrace",
+        tmp_path / "board.dip",
+        tmp_path / "manifest.json",
+        tmp_path / "demo.mp4",
+        "PCB",
+        gif_output=tmp_path / "demo.gif",
+    )
+    assert request.editor == "pcb"
+    assert HeadlessCinematicRequest.from_json(request.as_json()) == request
+
+    result = HeadlessCinematicResult(
+        True,
+        "hidden",
+        1,
+        2,
+        3,
+        "board.dip",
+        "manifest.json",
+        "m",
+        "demo.mp4",
+        "v",
+        gif_output="demo.gif",
+        gif_sha256="g",
+    )
+    assert HeadlessCinematicResult.from_json(result.as_json()) == result
+
+    for kwargs, message in [
+        ({"editor": "bad"}, "editor"),
+        ({"fps": 0}, "fps"),
+        ({"gif_fps": 0}, "gif_fps"),
+        ({"gif_width": 100}, "gif_width"),
+        ({"startup_timeout_seconds": 0}, "startup_timeout"),
+        ({"tail_seconds": -1}, "tail_seconds"),
+        ({"video_output": tmp_path / "demo.avi"}, "mp4"),
+        ({"gif_output": tmp_path / "demo.png"}, "gif"),
+        ({"window_title": " "}, "window_title"),
+    ]:
+        values = dict(
+            diptrace_root=tmp_path,
+            project=tmp_path / "board.dip",
+            manifest=tmp_path / "manifest.json",
+            video_output=tmp_path / "demo.mp4",
+            editor="pcb",
+        )
+        values.update(kwargs)
+        with pytest.raises(ValueError, match=message):
+            HeadlessCinematicRequest(**values)
+
+
+def test_capture_seconds_includes_manifest_timing_and_command_pause(tmp_path: Path) -> None:
+    manifest_path = _manifest(tmp_path)
+    manifest, preflight = recording._read_manifest(manifest_path)
+    cues = manifest["cues"]
+    assert isinstance(cues, list)
+    event = cues[0]["event"]
+    event["payload"]["desktop"]["pause_ms"] = 250
+    preflight = recording.preflight_cinematic_manifest(manifest)
+    seconds = recording._capture_seconds(manifest, preflight, 0.5)
+    assert seconds >= 1.0
+    assert seconds >= preflight.duration_ms / 1000 + 0.75
+
+
+def test_headless_validation_rejects_overwrite_and_missing_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "DipTrace"
+    root.mkdir()
+    (root / "Pcb.exe").write_bytes(b"exe")
+    project = tmp_path / "project.mp4"
+    project.write_bytes(b"project")
+    manifest = _manifest(tmp_path)
+    monkeypatch.setattr(
+        recording,
+        "validate_diptrace_directory",
+        lambda _root: SimpleNamespace(root=root),
+    )
+    request = HeadlessCinematicRequest(root, project, manifest, project, "pcb")
+    with pytest.raises(recording.HeadlessGuiError, match="overwrite"):
+        recording._validate_headless_request(request)
+
+    missing = HeadlessCinematicRequest(
+        root, tmp_path / "missing.dip", manifest, tmp_path / "demo.mp4", "pcb"
+    )
+    with pytest.raises(recording.HeadlessGuiError, match="project file"):
+        recording._validate_headless_request(missing)
+
+
+def test_hidden_driver_rejects_global_input_and_modifier_hotkeys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class User32:
+        def SendMessageTimeoutW(self, *_args):
+            result = _args[-1]._obj
+            result.value = 1
+            return 1
+
+    monkeypatch.setattr(recording.os, "name", "nt")
+    monkeypatch.setattr(
+        recording.ctypes,
+        "windll",
+        SimpleNamespace(user32=User32()),
+        raising=False,
+    )
+    driver = HiddenMessageDesktopDriver(expected_pid=10)
+    with pytest.raises(RuntimeError, match="modifier/multi-key"):
+        driver._hotkey(22, ("ctrl", "s"))
+    driver._hotkey(22, ("esc",))
+    driver._text(22, "A")
+
+
+def test_hidden_driver_window_and_click_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    class User32:
+        def __init__(self) -> None:
+            self.messages: list[int] = []
+
+        def EnumWindows(self, callback, _lparam):
+            callback(22, 0)
+            return 1
+
+        def IsWindowVisible(self, _hwnd):
+            return True
+
+        def GetWindowThreadProcessId(self, _hwnd, pointer):
+            pointer._obj.value = 10
+            return 1
+
+        def GetWindowTextLengthW(self, _hwnd):
+            return len("DipTrace")
+
+        def GetWindowTextW(self, _hwnd, buffer, _length):
+            buffer.value = "DipTrace"
+            return len(buffer.value)
+
+        def GetClientRect(self, _hwnd, pointer):
+            rect = pointer._obj
+            rect.left = 0
+            rect.top = 0
+            rect.right = 1000
+            rect.bottom = 800
+            return 1
+
+        def ChildWindowFromPointEx(self, hwnd, _point, _flags):
+            return hwnd
+
+        def SendMessageTimeoutW(self, _hwnd, message, _w, _l, _flags, _timeout, result):
+            self.messages.append(message)
+            result._obj.value = 1
+            return 1
+
+    user32 = User32()
+    monkeypatch.setattr(recording.os, "name", "nt")
+    monkeypatch.setattr(
+        recording.ctypes,
+        "windll",
+        SimpleNamespace(user32=user32),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        recording.ctypes,
+        "WINFUNCTYPE",
+        lambda *_types: lambda callback: callback,
+        raising=False,
+    )
+    driver = HiddenMessageDesktopDriver(expected_pid=10)
+    event = SimpleNamespace(
+        payload={"desktop": {"move_to": [0.5, 0.5], "click": "left"}},
+        kind="operation",
+    )
+    driver.handle(event)
+    assert recording._WM_MOUSEMOVE in user32.messages
+    assert recording._BUTTON_MESSAGES["left"][0] in user32.messages
+    assert recording._BUTTON_MESSAGES["left"][1] in user32.messages
+
+
+def test_window_lookup_filters_pid_and_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    class User32:
+        def EnumWindows(self, callback, _lparam):
+            for hwnd in (11, 22):
+                if not callback(hwnd, 0):
+                    break
+            return 1
+
+        def IsWindowVisible(self, _hwnd):
+            return True
+
+        def GetWindowThreadProcessId(self, hwnd, pointer):
+            pointer._obj.value = 10 if hwnd == 22 else 99
+            return 1
+
+        def GetWindowTextLengthW(self, _hwnd):
+            return len("Board - DipTrace")
+
+        def GetWindowTextW(self, _hwnd, buffer, _length):
+            buffer.value = "Board - DipTrace"
+            return len(buffer.value)
+
+    monkeypatch.setattr(
+        recording.ctypes,
+        "WINFUNCTYPE",
+        lambda *_types: lambda callback: callback,
+        raising=False,
+    )
+    assert recording._find_window_handle_for_pid(User32(), 10, "DipTrace") == 22
+    assert recording._find_window_handle_for_pid(User32(), 12, "DipTrace") is None
+
+
+def test_message_helpers_are_bounded() -> None:
+    assert recording._virtual_key("escape") == 0x1B
+    assert recording._virtual_key("f24") == 0x87
+    assert recording._virtual_key("a") == ord("A")
+    with pytest.raises(ValueError, match="unsupported"):
+        recording._virtual_key("ctrl")
+    assert recording._pack_point(1, 2) == 0x00020001
+
+
+def test_gif_conversion_uses_shell_free_two_pass_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+    video = tmp_path / "demo.mp4"
+    video.write_bytes(b"video")
+    gif = tmp_path / "demo.gif"
+    monkeypatch.setattr(recording.shutil, "which", lambda _name: "ffmpeg")
+
+    def fake_run(command: list[str], *, check: bool):
+        assert check is False
+        calls.append(command)
+        Path(command[-1]).write_bytes(b"artifact")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(recording.subprocess, "run", fake_run)
+    recording._convert_video_to_gif(video, gif, fps=20, width=800)
+    assert len(calls) == 2
+    assert "palettegen" in " ".join(calls[0])
+    assert "paletteuse" in " ".join(calls[1])
+    assert gif.is_file()
+
+
+def test_headless_worker_argv_supports_source_and_frozen(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(recording.sys.__dict__, "frozen", False)
+    source = recording._cinematic_worker_argv("_worker", "--x")
+    assert "diptrace_mcp.cinematic_recording" in source
+    monkeypatch.setitem(recording.sys.__dict__, "frozen", True)
+    frozen = recording._cinematic_worker_argv("_worker", "--x")
+    assert frozen[1] == "cinematic"
+
+
+def test_run_headless_cinematic_guards_platform_and_elevation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = HeadlessCinematicRequest(
+        tmp_path,
+        tmp_path / "board.dip",
+        tmp_path / "manifest.json",
+        tmp_path / "demo.mp4",
+        "pcb",
+    )
+    monkeypatch.setattr(recording.os, "name", "posix")
+    with pytest.raises(recording.HeadlessGuiError, match="only on Windows"):
+        recording.run_headless_cinematic(request)
+
+    monkeypatch.setattr(recording.os, "name", "nt")
+    monkeypatch.setattr(recording, "process_is_elevated", lambda: True)
+    with pytest.raises(recording.HeadlessGuiError, match="must not be elevated"):
+        recording.run_headless_cinematic(request)
+
+
+def test_headless_cli_delegates_and_prints_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = HeadlessCinematicResult(
+        True,
+        "hidden",
+        1,
+        2,
+        3,
+        "board.dip",
+        "manifest.json",
+        "m",
+        str(tmp_path / "demo.mp4"),
+        "v",
+    )
+    monkeypatch.setattr(recording, "run_headless_cinematic", lambda _request: result)
+    code = recording.headless_main(
+        [
+            "capture",
+            "--diptrace-root",
+            str(tmp_path),
+            "--project",
+            str(tmp_path / "board.dip"),
+            "--editor",
+            "pcb",
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--video",
+            str(tmp_path / "demo.mp4"),
+        ]
+    )
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_cmd_headless_worker_records_failure(tmp_path: Path) -> None:
+    request = tmp_path / "request.json"
+    result = tmp_path / "result.json"
+    request.write_text("{}", encoding="utf-8")
+    code = recording._cmd_headless_worker(
+        argparse.Namespace(request=str(request), result=str(result), desktop_name="hidden")
+    )
+    assert code == 1
+    assert json.loads(result.read_text(encoding="utf-8"))["ok"] is False

--- a/tests/test_cinematic_recording.py
+++ b/tests/test_cinematic_recording.py
@@ -16,6 +16,7 @@ from diptrace_mcp.cinematic_recording import (
     build_windows_capture_command,
     main,
 )
+from diptrace_mcp.headless_gui import HeadlessGuiError
 
 
 def test_window_capture_command_targets_arbitrary_window() -> None:
@@ -197,7 +198,6 @@ def test_headless_request_and_result_json_contract(tmp_path: Path) -> None:
     )
     assert request.editor == "pcb"
     assert HeadlessCinematicRequest.from_json(request.as_json()) == request
-
     result = HeadlessCinematicResult(
         True,
         "hidden",
@@ -265,13 +265,13 @@ def test_headless_validation_rejects_overwrite_and_missing_inputs(
         lambda _root: SimpleNamespace(root=root),
     )
     request = HeadlessCinematicRequest(root, project, manifest, project, "pcb")
-    with pytest.raises(recording.HeadlessGuiError, match="overwrite"):
+    with pytest.raises(HeadlessGuiError, match="overwrite"):
         recording._validate_headless_request(request)
 
     missing = HeadlessCinematicRequest(
         root, tmp_path / "missing.dip", manifest, tmp_path / "demo.mp4", "pcb"
     )
-    with pytest.raises(recording.HeadlessGuiError, match="project file"):
+    with pytest.raises(HeadlessGuiError, match="project file"):
         recording._validate_headless_request(missing)
 
 
@@ -446,12 +446,12 @@ def test_run_headless_cinematic_guards_platform_and_elevation(
         "pcb",
     )
     monkeypatch.setattr(recording.os, "name", "posix")
-    with pytest.raises(recording.HeadlessGuiError, match="only on Windows"):
+    with pytest.raises(HeadlessGuiError, match="only on Windows"):
         recording.run_headless_cinematic(request)
 
     monkeypatch.setattr(recording.os, "name", "nt")
-    monkeypatch.setattr(recording, "process_is_elevated", lambda: True)
-    with pytest.raises(recording.HeadlessGuiError, match="must not be elevated"):
+    monkeypatch.setattr(recording.hg, "process_is_elevated", lambda: True)
+    with pytest.raises(HeadlessGuiError, match="must not be elevated"):
         recording.run_headless_cinematic(request)
 
 


### PR DESCRIPTION
## Scope

Integrate the existing cinematic replay/MP4/GIF layer with the hidden Win32 desktop worker so a DipTrace demo can be replayed and recorded without occupying the operator's normal desktop.

- run DipTrace, cinematic worker, and ffmpeg on the same random hidden `WinSta0` desktop;
- mandatory cinematic preflight before GUI side effects;
- hidden replay uses bounded `SendMessageTimeoutW` window messages rather than global cursor/keyboard APIs;
- modifier/multi-key hotkeys fail closed in hidden mode; calibrated click paths, text, and message-safe single keys remain available;
- local ffmpeg `gdigrab` MP4 capture with optional two-pass GIF conversion;
- structured evidence includes manifest/video/GIF SHA-256 values, PIDs, desktop/window-station/session identity;
- package the cinematic subcommand into the existing frozen headless helper and smoke its startup in the Windows build.

## Safety boundary

Hidden cinematic replay does not call `SetCursorPos`, `mouse_event`, `keybd_event`, `SendInput`, or `SwitchDesktop`. It does not upload screenshots/frames or invoke a model. Engineering XML/semantic operations remain authoritative; cinematic replay remains presentation-only.

## Compatibility

- public MCP contract unchanged: expected 165 tools;
- no installer privilege-boundary change;
- existing visible cinematic recorder remains supported;
- exact DipTrace UI macros/calibration and one real hidden `gdigrab` capture remain real-host acceptance evidence.

## Validation

Regression coverage is added for request/result contracts, bounded message replay, PID/title window matching, capture timing, GIF pipeline, source/frozen worker argv, platform/elevation refusal and CLI failure/success paths. Windows packaging now verifies the frozen helper contains the cinematic subcommand.

Signed-off-by: fireostendere <87851878+fireostendere@users.noreply.github.com>