### PR TITLE
Record v0.3.0 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.3.0 - 2026-08-16
 
-Version `0.3.0` is an unsigned development prerelease. These changes are not
-part of the already-published `v0.2.1` bytes.
+Version `0.3.0` is a published unsigned development prerelease following the
+immutable `v0.2.1` release.
 
 ### Added
 
@@ -38,13 +38,12 @@ part of the already-published `v0.2.1` bytes.
   its recorded checkpoints. Claude Desktop restart and custom-state preservation
   are operator-confirmed PASS from a separate machine; their earlier
   WAIVED/pending states remain historical only.
-- Evergreen documentation was reconciled with the published `v0.2.1` state and
-  current post-release implementation without rewriting dated release,
-  acceptance, or compliance snapshots.
+- Evergreen documentation records the transition from `v0.2.1` to published
+  `v0.3.0` without rewriting dated release, acceptance or compliance snapshots.
 - The operator accepted the current repository PCB/Schematic examples and both
   GIF/MP4 outputs in the current DipTrace configuration on 2026-08-16.
 
-See `CHANGELOG_NEXT.md` for the detailed post-`v0.2.1` development record.
+See `CHANGELOG_NEXT.md` for the detailed `v0.3.0` release record.
 
 ## 0.2.1 - 2026-08-05
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,9 +1,8 @@
-# 0.3.0 candidate changes
+# 0.3.0 detailed release changes
 
-This development record tracks changes after the immutable `v0.2.1` release.
-Version `0.3.0` is selected as the next unsigned development-prerelease
-candidate but is not published yet; these items are **not** part of the
-published `v0.2.1` artifacts.
+This record preserves the detailed changes included in the immutable `v0.3.0`
+unsigned development prerelease. New post-release work belongs in a new section
+above this release record.
 
 ## Added
 
@@ -115,7 +114,8 @@ The headless worker is a host-automation boundary, not a second semantic authori
 - The private/manual Q1 Component Angle campaign is PASS on its accepted production checkpoint; immutable historical release records keep the status that was true when each release was cut.
 - The accepted manual matrix is complete at 12 of 12 blocking gates PASS across its recorded checkpoints. Claude Desktop restart and custom-state preservation are operator-confirmed PASS from a separate machine; their earlier WAIVED/pending states remain historical only.
 - Documentation distinguishes current implementation state from immutable release/audit/acceptance snapshots.
-- Installation/release documentation reflects that `v0.2.1` and `diptrace-mcp==0.2.1` are already published; current source hardens the next Windows packaging line without rewriting immutable `v0.2.1` assets.
+- Installation/release documentation identifies the immutable `v0.3.0`
+  GitHub/PyPI assets and split Windows packaging without rewriting older releases.
 - Testing documentation reflects the combined 90% coverage gate and the separate 85% Linux-only floor.
 - The operator accepted the current repository PCB/Schematic designs and both
   GIF/MP4 examples in the current DipTrace configuration on 2026-08-16.
@@ -138,7 +138,8 @@ The headless worker is a host-automation boundary, not a second semantic authori
 - atomic selective schematic reroute currently rebuilds affected sheet-local explicit nets from resolved pin endpoints; it does not preserve arbitrary pre-existing manual junction topology as a visual constraint;
 - stronger sheet-level/global schematic congestion scheduling and external/reference motif ingestion remain future work;
 - the completed 18-case schematic campaign supports its tested scope only; new schematic claims such as hierarchy, topology-preserving reroute or automatic rotation/pin-facing behavior still require claim-specific evidence;
-- PCB candidate/whole-board quality remains subject to current-candidate real-DipTrace/native refill/plane/via acceptance where stronger claims are desired;
+- PCB candidate/whole-board quality remains subject to claim-specific real-DipTrace
+  native refill/plane/via acceptance where stronger claims are desired;
 - cinematic UI macros and calibration for additional DipTrace
   version/editor configurations require their own real-client verification;
 - staged cinematic playback of vias/layer transitions remains unsupported;
@@ -146,4 +147,5 @@ The headless worker is a host-automation boundary, not a second semantic authori
 - the library mutation request/preview contract remains package-level and unregistered in the public MCP tool snapshot;
 - native manufacturing generation, field-solver/PI/EMC/thermal sign-off, universal compatibility, signed-binary trust, independent review and production readiness are not claimed.
 
-This file should be folded into `CHANGELOG.md` when the next version is selected.
+The concise release summary is in `CHANGELOG.md`; do not rewrite this detailed
+published-release record when later development begins.

--- a/README.md
+++ b/README.md
@@ -51,27 +51,28 @@ DipTrace compatibility, authoritative refill geometry, or engineering sign-off.
 
 ## Current status
 
-The selected source/package candidate is `0.3.0`; it is not published yet. The
-annotated `v0.2.1` GitHub development prerelease and `diptrace-mcp==0.2.1` on
-PyPI remain the current published distribution, released on 2026-08-05 with:
+Version `0.3.0` is the current published unsigned development prerelease:
+[`v0.3.0` on GitHub](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.3.0)
+and [`diptrace-mcp==0.3.0` on PyPI](https://pypi.org/project/diptrace-mcp/0.3.0/).
+Its immutable assets include:
 
-- `DipTrace-MCP-Setup-0.2.1.exe`;
-- `DipTrace-MCP-Portable-0.2.1.zip`;
-- `DipTrace-MCP-0.2.1-windows.mcpb`;
-- wheel, source distribution, checksums, SBOM, dependency, notice, provenance,
-  and release records.
+- `DipTrace-MCP-Setup-0.3.0.exe`;
+- `DipTrace-MCP-Plugin-Setup-0.3.0.exe`;
+- `DipTrace-MCP-Portable-0.3.0.zip`;
+- `DipTrace-MCP-0.3.0-windows.mcpb`;
+- wheel, source distribution, checksum manifest and provenance record.
 
-The `0.3.0` candidate adds the schematic layout/placement-routing foundation,
+The `0.3.0` release adds the schematic layout/placement-routing foundation,
 PCB Generations A-D, compact-footprint preference, bounded two-layer GND-pour
 and stitching helpers, silkscreen cleanup, the 90% combined
 supported-environment coverage gate, and board-framed cinematic replay. The
 initial 18-case real-DipTrace schematic authoring/readability campaign is
-complete. These later source features are not retroactively part of the
-published `v0.2.1` bytes.
+complete.
 
 The previous [`v0.2.0`](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.2.0)
-and current `v0.2.1` release identities remain immutable. Existing tags and
-published files are never replaced.
+and [`v0.2.1`](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.2.1)
+release identities remain immutable. Existing tags and published files are
+never replaced.
 
 The Windows executables are unsigned. CI, SHA-256, PyPI Trusted Publishing, and
 package attestations establish tested behaviour, byte identity, and publication
@@ -177,7 +178,7 @@ accuracy, PI/EMC sign-off, or globally optimal schematic/PCB layout.
 Python 3.10 or newer is required:
 
 ```bash
-python -m pip install diptrace-mcp==0.2.1
+python -m pip install diptrace-mcp==0.3.0
 diptrace-mcp --help
 ```
 
@@ -188,19 +189,21 @@ published package.
 
 ### Windows installer
 
-1. Download `DipTrace-MCP-Setup-0.2.1.exe` and `SHA256SUMS.txt` from the same
-   `v0.2.1` GitHub Release.
+1. Download `DipTrace-MCP-Setup-0.3.0.exe` and `SHA256SUMS.txt` from the same
+   `v0.3.0` GitHub Release.
 2. Verify the SHA-256 value.
 3. Run the installer and select the DipTrace location, workspace, state
    directory, and optional Codex/Claude configuration.
-4. Restart DipTrace and the MCP client.
-5. Call `get_capabilities`.
+4. Run `DipTrace-MCP-Plugin-Setup-0.3.0.exe` with administrator privileges when
+   machine-wide DipTrace integration is required.
+5. Restart DipTrace and the MCP client.
+6. Call `get_capabilities`.
 
 Windows may show a SmartScreen warning because the binaries are unsigned.
 
 ### Portable Windows bundle
 
-Download and verify `DipTrace-MCP-Portable-0.2.1.zip`, extract it to a stable
+Download and verify `DipTrace-MCP-Portable-0.3.0.zip`, extract it to a stable
 location, read its `README_FIRST.txt`, and use the included helper tools.
 
 ### Python source installation
@@ -219,7 +222,8 @@ complete path.
 
 ## MCPB, Registry, and Smithery
 
-Version `0.2.1` is already published through the prepared distribution route:
+Version `0.3.0` GitHub/PyPI assets are published. The distribution route also
+provides:
 
 - deterministic Windows MCPB packaging;
 - canonical Registry identity `io.github.fireostendere/diptrace-mcp`;
@@ -230,7 +234,7 @@ Version `0.2.1` is already published through the prepared distribution route:
 
 The MCPB contains the self-contained Windows stdio server. It does not silently
 install the DipTrace bridge plug-in. Live exchange requires the matching bridge
-and settings from the same GitHub release/source candidate.
+and settings from the same GitHub release/tag.
 
 See [MCP distribution and package publication](docs/MCP_DISTRIBUTION.md).
 
@@ -349,8 +353,8 @@ See [Testing](docs/TESTING.md) and [Development](docs/DEVELOPMENT.md).
 - [Security and policy](docs/SECURITY_AND_POLICY.md)
 - [Transactions](docs/TRANSACTIONS.md)
 - [Release process](docs/RELEASE_PROCESS.md)
-- [v0.3.0 candidate checklist](docs/RELEASE_0_3_0_CHECKLIST.md)
-- [v0.3.0 candidate record](docs/releases/v0.3.0.md)
+- [v0.3.0 release checklist](docs/RELEASE_0_3_0_CHECKLIST.md)
+- [v0.3.0 release record](docs/releases/v0.3.0.md)
 - [v0.2.1 release checklist](docs/RELEASE_0_2_1_CHECKLIST.md)
 - [v0.2.1 release record](docs/releases/v0.2.1.md)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,9 @@
 
 The current source/package version is `0.3.0`. The public MCP contract currently registers 167 tools (165 existing tools plus the read-only built-in-library bridge). `DipTraceService` is the stable public Facade; typed domain implementations live under `src/diptrace_mcp/services/`.
 
-`v0.2.1` is already published as an unsigned GitHub development prerelease and as `diptrace-mcp==0.2.1` on PyPI. Development on `main` has continued after that immutable release, so a source checkout may contain capabilities not present in the published `v0.2.1` artifacts.
+`v0.3.0` is published as an unsigned GitHub development prerelease and as
+`diptrace-mcp==0.3.0` on PyPI. Development on `main` continues after that
+immutable release, so use the tag when exact released bytes matter.
 
 ## Repository structure
 

--- a/docs/EDA_INTELLIGENCE.md
+++ b/docs/EDA_INTELLIGENCE.md
@@ -1,6 +1,9 @@
 # EDA Intelligence — Current Implementation
 
-This is the evergreen cross-domain map for higher-level schematic/PCB intelligence after the post-0.2.1 development work. Historical release and acceptance records remain immutable evidence snapshots and must not be rewritten to inherit later capabilities.
+This is the evergreen cross-domain map for the higher-level schematic/PCB
+intelligence published in `v0.3.0` and any later development. Historical release
+and acceptance records remain immutable evidence snapshots and must not be
+rewritten to inherit later capabilities.
 
 ## Safety model
 

--- a/docs/INSTALL_FROM_RELEASE.md
+++ b/docs/INSTALL_FROM_RELEASE.md
@@ -2,49 +2,50 @@
 
 ## Current published release
 
-Version `v0.2.1` is the current published distribution line for PyPI and the GitHub development prerelease.
-
-Source metadata may report the selected `0.3.0` candidate during release
-preparation. Do not install or advertise `0.3.0` as published until its annotated
-tag and immutable GitHub/PyPI assets exist; the commands below intentionally
-remain pinned to the current public `0.2.1` bytes.
+Version `v0.3.0` is the current published distribution line for PyPI and the
+GitHub development prerelease.
 
 Keep every downloaded artifact on the same immutable version.
 
 Windows assets:
 
 ```text
-DipTrace-MCP-Setup-0.2.1.exe
-DipTrace-MCP-Portable-0.2.1.zip
-DipTrace-MCP-0.2.1-windows.mcpb
+DipTrace-MCP-Setup-0.3.0.exe
+DipTrace-MCP-Plugin-Setup-0.3.0.exe
+DipTrace-MCP-Portable-0.3.0.zip
+DipTrace-MCP-0.3.0-windows.mcpb
 SHA256SUMS.txt
+RELEASE_PROVENANCE.txt
 ```
 
 Python assets:
 
 ```text
-diptrace_mcp-0.2.1-py3-none-any.whl
-diptrace_mcp-0.2.1.tar.gz
+diptrace_mcp-0.3.0-py3-none-any.whl
+diptrace_mcp-0.3.0.tar.gz
 ```
 
-Published release files are immutable. A corrected build requires a new version; do not mix `v0.2.0`, `v0.2.1` or future-version files.
+Published release files are immutable. A corrected build requires a new version;
+do not mix artifacts from different tags.
 
 ## PyPI
 
 Python 3.10 or newer:
 
 ```bash
-python -m pip install --no-cache-dir diptrace-mcp==0.2.1
+python -m pip install --no-cache-dir diptrace-mcp==0.3.0
 diptrace-mcp --help
 ```
 
 The Python package contains the MCP server and packaged skills. It does not install the Windows DipTrace bridge plug-in.
 
-`0.2.1` was published through GitHub OIDC Trusted Publishing. That establishes publication provenance, not Authenticode trust, universal compatibility or production readiness.
+`0.3.0` was published through GitHub OIDC Trusted Publishing. That establishes
+publication provenance, not Authenticode trust, universal compatibility or
+production readiness.
 
 ## Verify GitHub release hashes
 
-Download `SHA256SUMS.txt` from the same `v0.2.1` GitHub prerelease.
+Download `SHA256SUMS.txt` from the same `v0.3.0` GitHub prerelease.
 
 Linux/WSL:
 
@@ -55,7 +56,7 @@ sha256sum -c SHA256SUMS.txt
 PowerShell for an individual file:
 
 ```powershell
-Get-FileHash .\DipTrace-MCP-Setup-0.2.1.exe -Algorithm SHA256
+Get-FileHash .\DipTrace-MCP-Setup-0.3.0.exe -Algorithm SHA256
 ```
 
 The digest must match the release manifest. A matching SHA-256 proves byte identity, not publisher signing.
@@ -64,10 +65,13 @@ The digest must match the release manifest. A matching SHA-256 proves byte ident
 
 1. Close affected DipTrace modules and the MCP client being configured.
 2. Verify the installer hash.
-3. Run `DipTrace-MCP-Setup-0.2.1.exe`.
-4. Select the DipTrace installation, workspace, local state directory and optional MCP client configuration.
-5. Restart DipTrace and the configured MCP client.
-6. Call `get_capabilities` before relying on document-specific paths.
+3. Run `DipTrace-MCP-Setup-0.3.0.exe` for the per-user server/configurator and
+   select the workspace, local state directory and optional MCP client setup.
+4. When machine-wide DipTrace integration is required, run
+   `DipTrace-MCP-Plugin-Setup-0.3.0.exe` with administrator privileges.
+5. Select the DipTrace installation in the plug-in installer.
+6. Restart DipTrace and the configured MCP client.
+7. Call `get_capabilities` before relying on document-specific paths.
 
 The installer is unsigned, so Windows may display a SmartScreen warning. Verify the release identity and checksum before continuing.
 
@@ -75,7 +79,7 @@ Workspaces and user state are preserved by default on uninstall. State removal i
 
 ## Portable Windows installation
 
-1. Verify `DipTrace-MCP-Portable-0.2.1.zip`.
+1. Verify `DipTrace-MCP-Portable-0.3.0.zip`.
 2. Extract it to a stable local directory.
 3. Read `README_FIRST.txt` and verify the internal checksums.
 4. Run the included configuration/installation helper as appropriate.
@@ -90,7 +94,7 @@ PowerShell:
 ```powershell
 py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install `
-  .\diptrace_mcp-0.2.1-py3-none-any.whl
+  .\diptrace_mcp-0.3.0-py3-none-any.whl
 .\.venv\Scripts\diptrace-mcp.exe --help
 ```
 
@@ -99,18 +103,19 @@ Linux/WSL:
 ```bash
 python3.12 -m venv .venv
 . .venv/bin/activate
-python -m pip install ./diptrace_mcp-0.2.1-py3-none-any.whl
+python -m pip install ./diptrace_mcp-0.3.0-py3-none-any.whl
 diptrace-mcp --help
 ```
 
 ## MCPB
 
-`DipTrace-MCP-0.2.1-windows.mcpb` contains the self-contained Windows stdio server for compatible MCP clients.
+`DipTrace-MCP-0.3.0-windows.mcpb` contains the self-contained Windows stdio
+server for compatible MCP clients.
 
 Before using it:
 
 1. verify its SHA-256 from the same release;
-2. confirm version `0.2.1` and identity `io.github.fireostendere/diptrace-mcp`;
+2. confirm version `0.3.0` and identity `io.github.fireostendere/diptrace-mcp`;
 3. configure workspace/state paths;
 4. start the server and call `get_capabilities`.
 
@@ -123,26 +128,26 @@ For the exact released source:
 ```bash
 git clone https://github.com/fireostendere/mcp_diptrace.git
 cd mcp_diptrace
-git checkout v0.2.1
+git checkout v0.3.0
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install -e .
 diptrace-mcp --help
 ```
 
-A checkout of current `main` may contain post-release development that is not present in the published `v0.2.1` artifacts. Use a tag/commit when reproducibility matters.
+A checkout of current `main` may contain post-release changes not present in the
+published `v0.3.0` artifacts. Use the tag when reproducibility matters.
 
-## Post-release `main` features
+## Published release versus `main`
 
-Current `main` has additional internal schematic intelligence, PCB Generations A-D, 90% aggregate CI coverage and cinematic presentation tools after the immutable `v0.2.1` release.
-
-Installing `diptrace-mcp==0.2.1` from PyPI does not imply that every later `main` feature is included in that published package.
+The immutable `v0.3.0` package includes the schematic intelligence, PCB
+Generations A-D, 90% aggregate CI coverage gate and cinematic presentation work
+listed in its release record. Later `main` changes are not part of those bytes.
 
 ## Evidence/limitations of the released artifacts
 
-The immutable `v0.2.1` release record retains the evidence status that was true when it was cut, including Q1 Component Angle `NOT_RUN` at release time.
-
-A later manual project campaign completed Q1 as PASS on a later accepted production checkpoint. That does not retroactively modify the released artifact's evidence record.
+The immutable `v0.3.0` release record retains the exact operator acceptance,
+workflow and public-redownload evidence that was true when it was published.
 
 Similarly, an internal raw-preserving Component/Pattern Library mutation core now exists on later development and has controlled real-editor evidence, but it is not part of a newly expanded public native-library MCP write contract.
 

--- a/docs/MCP_DISTRIBUTION.md
+++ b/docs/MCP_DISTRIBUTION.md
@@ -2,25 +2,23 @@
 
 ## Current published state
 
-Version `v0.2.1` is the current published unsigned alpha/development prerelease.
+Version `v0.3.0` is the current published unsigned development prerelease.
 
 Published immutable identities:
 
-- GitHub prerelease: `v0.2.1`;
-- PyPI package: `diptrace-mcp==0.2.1`;
-- Windows installer: `DipTrace-MCP-Setup-0.2.1.exe`;
-- portable bundle: `DipTrace-MCP-Portable-0.2.1.zip`;
-- Windows MCPB: `DipTrace-MCP-0.2.1-windows.mcpb`;
+- GitHub prerelease: `v0.3.0`;
+- PyPI package: `diptrace-mcp==0.3.0`;
+- Windows installer: `DipTrace-MCP-Setup-0.3.0.exe`;
+- administrator plug-in installer: `DipTrace-MCP-Plugin-Setup-0.3.0.exe`;
+- portable bundle: `DipTrace-MCP-Portable-0.3.0.zip`;
+- Windows MCPB: `DipTrace-MCP-0.3.0-windows.mcpb`;
 - canonical registry identity: `io.github.fireostendere/diptrace-mcp`.
 
 Published tags/files are immutable. A corrected build requires a new version.
 
-Development on `main` after `v0.2.1` may contain additional internal capabilities that are not present in the published package/bundles. Track those changes in `CHANGELOG_NEXT.md` until the next release is selected.
-
-`v0.3.0` is now the selected source candidate, but it is not yet an immutable
-public distribution. Continue using the `v0.2.1` filenames above until the
-`v0.3.0` checklist, tag-bound workflows and public-download verification are
-complete.
+Development on `main` after `v0.3.0` may contain changes not present in the
+published package/bundles. Track them in `CHANGELOG_NEXT.md` until the next
+release is selected.
 
 ## Distribution roles
 
@@ -33,7 +31,8 @@ The PyPI package and MCPB do not silently install the DipTrace bridge plug-in. L
 
 ## PyPI Trusted Publishing
 
-`0.2.1` was published through the guarded tag-bound GitHub OIDC workflow.
+`0.3.0` was published through the guarded GitHub OIDC workflow after an exact
+annotated-tag checkout and target verification.
 
 Authorized identity:
 
@@ -50,7 +49,7 @@ No long-lived PyPI API token is required. Future versions should preserve the se
 Clean package smoke:
 
 ```bash
-python -m pip install --no-cache-dir diptrace-mcp==0.2.1
+python -m pip install --no-cache-dir diptrace-mcp==0.3.0
 diptrace-mcp --help
 ```
 
@@ -79,7 +78,8 @@ For each future version:
 5. redownload the public bytes and repeat checksum/install/stdio smoke;
 6. record exact public identities in the release record.
 
-The existing `v0.2.1` publication is complete; these are future-release rules, not pending `0.2.1` publication steps.
+The `v0.3.0` publication is complete; these are future-release rules, not
+pending `0.3.0` publication steps.
 
 ## Registry / Smithery metadata
 
@@ -107,8 +107,8 @@ Example acceptance pack preparation:
 
 ```bash
 python scripts/prepare_manual_acceptance.py acceptance \
-  --version 0.2.1 \
-  --commit <exact-40-character-production-commit>
+  --version 0.3.0 \
+  --commit fbbbda176043c555b04a908bb63f6fc4ac5909cb
 ```
 
 Manual evidence must remain tied to the exact candidate/artifacts tested.
@@ -117,9 +117,12 @@ Manual evidence must remain tied to the exact candidate/artifacts tested.
 
 Do not conflate these states:
 
-- `v0.2.1` / PyPI `0.2.1` are immutable published bytes;
-- later `main` includes schematic intelligence, PCB Generations A-D, aggregate 90% coverage and cinematic presentation work;
-- a future release must explicitly package/re-verify those later changes before distribution docs claim they are in published artifacts.
+- `v0.3.0` / PyPI `0.3.0` are immutable published bytes and include the
+  schematic intelligence, PCB Generations A-D, 90% coverage gate and cinematic
+  presentation work described by its release record;
+- later `main` may advance independently;
+- a future release must explicitly package/re-verify later changes before
+  distribution docs claim they are in published artifacts.
 
 ## Immutability rule
 

--- a/docs/PCB_DESIGN_ENGINE.md
+++ b/docs/PCB_DESIGN_ENGINE.md
@@ -142,7 +142,8 @@ Every non-baseline candidate comes from the existing bounded placement planner. 
 
 This is deliberately not an invented autorouter. Candidate scoring may penalize unresolved routing/reference evidence, but it does not synthesize traces, vias, stackup facts, current ratings or solver output.
 
-The selected candidate still requires ordinary semantic application, review/DRC and claim-specific real DipTrace evidence.
+Every selected candidate still requires ordinary semantic application,
+review/DRC and claim-specific real DipTrace evidence.
 
 ## DSN/SES integration
 

--- a/docs/RELEASE_0_3_0_CHECKLIST.md
+++ b/docs/RELEASE_0_3_0_CHECKLIST.md
@@ -7,8 +7,11 @@
 - [x] Release manager is the repository owner under the solo-maintainer
       exception.
 - [x] No independent reviewer is claimed.
-- [ ] Exact candidate commit frozen.
-- [ ] Annotated tag `v0.3.0` created.
+- [x] Candidate commit `2646b12bca9534cdbceec8c1808bcacc09aa26bd`
+      frozen and merged without tree changes at
+      `fbbbda176043c555b04a908bb63f6fc4ac5909cb`.
+- [x] Annotated tag `v0.3.0` created with tag object
+      `82b8beac697ae25a008f4b215e2baf33959367b5`.
 
 ## Documentation and acceptance
 
@@ -23,14 +26,14 @@
 
 ## Automated gates
 
-- [ ] Full exact-candidate CI passes on supported GitHub runners.
-- [ ] 90% combined and 85% geometry-enabled coverage gates pass.
-- [ ] Ruff, strict Mypy, documentation, service/facade and generated snapshot
+- [x] Full exact-candidate CI passes on supported GitHub runners.
+- [x] 90% combined and 85% geometry-enabled coverage gates pass.
+- [x] Ruff, strict Mypy, documentation, service/facade and generated snapshot
       checks pass.
-- [ ] Wheel and source distribution build, audit and clean-install smoke pass.
-- [ ] Windows installer, administrator plug-in installer, portable bundle and
+- [x] Wheel and source distribution build, audit and clean-install smoke pass.
+- [x] Windows installer, administrator plug-in installer, portable bundle and
       MCPB workflows pass.
-- [ ] Smithery lock regenerated only after `0.3.0` is available from PyPI.
+- [x] Smithery lock regenerated after `0.3.0` became available from PyPI.
 
 Local sandbox note: ordinary lint/document checks are usable, but this isolated
 environment does not wake `asyncio.to_thread`/AnyIO worker futures. Thread-offload
@@ -39,12 +42,15 @@ runners rather than a weakened code path or a falsely reported local PASS.
 
 ## Publication
 
-- [ ] Release preparation merged through the protected branch workflow.
-- [ ] Annotated tag points to the exact approved commit.
-- [ ] GitHub development prerelease and immutable assets published.
-- [ ] Public assets redownloaded and SHA-256 verified.
-- [ ] Tag-bound PyPI Trusted Publishing completed.
-- [ ] Public PyPI wheel/sdist installed and smoke-tested.
-- [ ] README and both GIF previews verified on GitHub and PyPI.
-- [ ] Release record updated with exact commit, workflow runs, asset sizes and
+- [x] Release preparation merged through protected PR #108.
+- [x] Annotated tag points to the exact approved merge commit.
+- [x] GitHub development prerelease and immutable assets published.
+- [x] Public assets redownloaded and SHA-256 verified.
+- [x] PyPI Trusted Publishing completed from an exact verified `v0.3.0`
+      checkout in workflow run `31915399966`.
+- [x] Public PyPI wheel/sdist redownloaded byte-for-byte; wheel installed and
+      smoke-tested in a clean environment.
+- [x] Public PyPI metadata contains both GIF references; both tagged GIF assets
+      were redownloaded and decoded successfully.
+- [x] Release record updated with exact commit, workflow runs, asset sizes and
       hashes.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,31 +2,26 @@
 
 ## Current release status
 
-Version `v0.2.1` is the current published unsigned alpha/development prerelease.
-
-Version `v0.3.0` is the selected next unsigned development-prerelease candidate.
-It is not tagged or published yet. Candidate scope, operator confirmation and
-remaining gates are tracked in [RELEASE_0_3_0_CHECKLIST.md](RELEASE_0_3_0_CHECKLIST.md)
-and [releases/v0.3.0.md](releases/v0.3.0.md).
+Version `v0.3.0` is the current published unsigned development prerelease.
+Its completed gates and immutable evidence are tracked in
+[RELEASE_0_3_0_CHECKLIST.md](RELEASE_0_3_0_CHECKLIST.md) and
+[releases/v0.3.0.md](releases/v0.3.0.md).
 
 Immutable/current published identities:
 
-- annotated tag: `v0.2.1`;
-- exact tag target / release merge commit: `1d2b7bef256cd43262b566dc2cd4050248d0145d`;
-- GitHub prerelease: `v0.2.1`;
-- PyPI package: `diptrace-mcp==0.2.1`;
-- Windows installer: `DipTrace-MCP-Setup-0.2.1.exe`;
-- portable bundle: `DipTrace-MCP-Portable-0.2.1.zip`;
-- Windows MCPB: `DipTrace-MCP-0.2.1-windows.mcpb`;
+- annotated tag: `v0.3.0`;
+- exact tag target / release merge commit: `fbbbda176043c555b04a908bb63f6fc4ac5909cb`;
+- GitHub prerelease: `v0.3.0`;
+- PyPI package: `diptrace-mcp==0.3.0`;
+- Windows installer: `DipTrace-MCP-Setup-0.3.0.exe`;
+- administrator plug-in installer: `DipTrace-MCP-Plugin-Setup-0.3.0.exe`;
+- portable bundle: `DipTrace-MCP-Portable-0.3.0.zip`;
+- Windows MCPB: `DipTrace-MCP-0.3.0-windows.mcpb`;
 - registry identity: `io.github.fireostendere/diptrace-mcp`.
 
-The immutable release record is [releases/v0.2.1.md](releases/v0.2.1.md). The old `v0.2.0` tag/assets also remain immutable.
-
-Development on `main` after `v0.2.1` is tracked in `CHANGELOG_NEXT.md` until the next version is selected. Do not describe post-release `main` features as if they were already present in the published `v0.2.1` bytes.
-
-The source/package metadata now identifies the selected `0.3.0` candidate.
-Installation instructions continue to point at `0.2.1` until immutable `0.3.0`
-assets have actually been published and redownload-verified.
+The immutable release record is [releases/v0.3.0.md](releases/v0.3.0.md).
+The older `v0.2.0` and `v0.2.1` tags/assets also remain immutable. Development
+after `v0.3.0` is tracked in `CHANGELOG_NEXT.md` until another version is selected.
 
 Windows executables remain unsigned. CI, SHA-256, PyPI Trusted Publishing and package attestations can establish tested behaviour, byte identity and publication provenance; they do not establish Authenticode trust, universal compatibility, independent review or production readiness.
 
@@ -163,7 +158,7 @@ Only after the reviewed gates pass:
 5. publish them as the appropriate development/prerelease class;
 6. publish notes that distinguish implemented, runtime-available and real-DipTrace-verified capabilities.
 
-Never reuse or move `v0.2.1` or any older tag.
+Never reuse or move an existing release tag.
 
 ## 8. Verify public downloads
 
@@ -173,7 +168,10 @@ Record the immutable release URL/tag SHA, publication date, public asset sizes/h
 
 ## 9. Publish to PyPI
 
-PyPI publication remains a separate explicit action and must use GitHub OIDC Trusted Publishing from the exact authorized tag/workflow/environment identity.
+PyPI publication remains a separate explicit action and must use GitHub OIDC
+Trusted Publishing from the authorized workflow/environment. The build checkout
+must resolve to and verify the exact annotated release-tag target before any
+artifact reaches the minimal publish job.
 
 Current authorized identity:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,9 @@ Implementation never implies universal DipTrace compatibility. Historical eviden
 
 ## Current checkpoint — 2026-08-16
 
-The current source/package version is `0.3.0`. The immutable `v0.2.1` release and PyPI package remain published; `v0.3.0` is the selected unsigned development-prerelease candidate.
+The current source/package version is `0.3.0`. The immutable `v0.3.0` unsigned
+development prerelease and PyPI package are published; older releases remain
+immutable historical identities.
 
 The schematic-quality production fixes were merged by PR #90. The production merge identity is:
 
@@ -285,7 +287,7 @@ Higher-level EDA modules should continue to prefer typed package internals and a
 | PCB Generation B | implemented/bounded |
 | PCB Generation C | implemented/bounded |
 | PCB Generation D | selector + real bounded placement candidate ensemble implemented; read-only `compare_pcb_placement_candidates` tool shipped |
-| PCB product quality | stronger current-candidate real-DipTrace acceptance pending |
+| PCB product quality | compact two-layer example and cinematic output operator-accepted for v0.3.0; stronger native-refill/manufacturing claims remain open |
 | DSN/SES analysis | bounded structural/importability analysis implemented |
 | XML semantic analysis | fingerprint/delta + property tests implemented |
 | evidence reports | deterministic review-only report pipeline implemented |

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -117,7 +117,10 @@ Historical records that said otherwise remain valid snapshots of their original 
 
 ## Documentation/evidence state policy
 
-Dated release/audit/acceptance/compliance records preserve historical facts. Evergreen docs describe current implementation and explicitly link to historical evidence. `CHANGELOG_NEXT.md` tracks post-`v0.2.1` development until the next release is selected.
+Dated release/audit/acceptance/compliance records preserve historical facts.
+Evergreen docs describe current implementation and explicitly link to historical
+evidence. `CHANGELOG_NEXT.md` tracks post-`v0.3.0` development until the next
+release is selected.
 
 `scripts/check_documentation_state.py` guards key current-state relationships against code and the frozen public-tools snapshot. It intentionally does not rewrite or reinterpret immutable historical records.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,18 +7,21 @@
 Python 3.10 or newer:
 
 ```bash
-python -m pip install diptrace-mcp==0.2.1
+python -m pip install diptrace-mcp==0.3.0
 diptrace-mcp --help
 ```
 
 ### Published Windows assets
 
-Use the immutable `v0.2.1` GitHub prerelease and keep every downloaded file on the same version:
+Use the immutable `v0.3.0` GitHub prerelease and keep every downloaded file on
+the same version:
 
-- `DipTrace-MCP-Setup-0.2.1.exe` — recommended Windows installer;
-- `DipTrace-MCP-Portable-0.2.1.zip` — portable bundle;
-- `DipTrace-MCP-0.2.1-windows.mcpb` — self-contained stdio MCP server for compatible clients;
+- `DipTrace-MCP-Setup-0.3.0.exe` — per-user Windows installer;
+- `DipTrace-MCP-Plugin-Setup-0.3.0.exe` — administrator plug-in installer;
+- `DipTrace-MCP-Portable-0.3.0.zip` — portable bundle;
+- `DipTrace-MCP-0.3.0-windows.mcpb` — self-contained stdio MCP server for compatible clients;
 - `SHA256SUMS.txt` — release checksums.
+- `RELEASE_PROVENANCE.txt` — release identity and workflow provenance.
 
 See [INSTALL_FROM_RELEASE.md](INSTALL_FROM_RELEASE.md).
 

--- a/docs/WINDOWS_INSTALLER.md
+++ b/docs/WINDOWS_INSTALLER.md
@@ -2,12 +2,9 @@
 
 ## Status
 
-The immutable `v0.2.1` development prerelease remains unchanged. Its published
-Windows assets keep their original identities and checksums.
-
-Current source development has hardened the next Windows packaging line by
-separating the per-user MCP installation from the administrator-only DipTrace
-plug-in installation. A future release built from this source produces:
+The immutable `v0.3.0` development prerelease publishes the hardened split
+Windows packaging line. It separates the per-user MCP installation from the
+administrator-only DipTrace plug-in installation:
 
 - `DipTrace-MCP-Setup-<version>.exe` — per-user server/configurator installer;
 - `DipTrace-MCP-Plugin-Setup-<version>.exe` — administrator-only DipTrace plug-in
@@ -15,9 +12,9 @@ plug-in installation. A future release built from this source produces:
 - `DipTrace-MCP-Portable-<version>.zip`;
 - release checksums/provenance records.
 
-This source change does not rewrite or replace the already published `v0.2.1`
-assets. Development binaries remain unsigned unless a future release satisfies
-the repository signing policy.
+These `v0.3.0` binaries remain unsigned. Older published assets retain their
+original identities and checksums, and a future signed/corrected build requires
+a new version.
 
 ## Design goals
 
@@ -165,7 +162,8 @@ The installer build emits both Inno Setup executables plus the portable ZIP and
 one release checksum manifest covering all three assets.
 
 Use the actual selected future version when preparing a new release. Do not
-rebuild different binaries under the immutable `0.2.1` identity.
+rebuild different binaries under any immutable published identity, including
+`0.3.0`.
 
 ## CI / automated evidence
 
@@ -204,10 +202,10 @@ restarting unrelated historical acceptance campaigns.
 
 ## Installation verification
 
-For a future split-installer build:
+For the published split-installer build:
 
 1. obtain the per-user installer, plug-in installer and `SHA256SUMS.txt` from the
-   same release/candidate;
+   same release/tag;
 2. verify SHA-256;
 3. run the per-user installer normally, without elevation;
 4. run the plug-in installer separately when DipTrace integration is desired;
@@ -216,8 +214,8 @@ For a future split-installer build:
 7. use native open/save/re-export acceptance only when a specific live semantic
    path requires proof.
 
-For the immutable published `v0.2.1`, follow its release-specific instructions
-and checksums. See [INSTALL_FROM_RELEASE.md](INSTALL_FROM_RELEASE.md).
+For immutable `v0.3.0` filenames and checksums, see
+[INSTALL_FROM_RELEASE.md](INSTALL_FROM_RELEASE.md).
 
 ## Boundaries and non-claims
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,27 +1,32 @@
 # Release Record: v0.3.0
 
-## Candidate status
+## Published identity
 
 - Version: `0.3.0`.
-- Status: **SELECTED CANDIDATE / NOT TAGGED / NOT PUBLISHED**.
-- Intended annotated tag: `v0.3.0`.
-- Release class: unsigned alpha/development prerelease.
+- Status: **PUBLISHED UNSIGNED DEVELOPMENT PRERELEASE**.
+- GitHub publication: `2026-08-15T23:28:12Z`.
+- Release preparation: [PR #108](https://github.com/fireostendere/mcp_diptrace/pull/108).
+- Frozen candidate: `2646b12bca9534cdbceec8c1808bcacc09aa26bd`.
+- Release merge and annotated-tag target:
+  `fbbbda176043c555b04a908bb63f6fc4ac5909cb`.
+- Annotated-tag object: `82b8beac697ae25a008f4b215e2baf33959367b5`.
+- GitHub prerelease:
+  [v0.3.0](https://github.com/fireostendere/mcp_diptrace/releases/tag/v0.3.0).
+- PyPI: [diptrace-mcp 0.3.0](https://pypi.org/project/diptrace-mcp/0.3.0/).
 - Release manager: repository owner `fireostendere` under the documented
   solo-maintainer exception.
 - Independent reviewer: none recorded.
-- GitHub prerelease, PyPI publication and final artifact hashes: pending.
 
-The already-published `v0.2.1` tag, GitHub assets and PyPI files remain
-immutable. This record must be updated with the exact tag target, workflow runs,
-public asset inventory and redownload verification after publication.
+The release merge tree was verified identical to the approved candidate before
+tagging. Older published tags and files remain immutable.
 
-## Intended scope
+## Scope
 
 Version `0.3.0` packages the post-`v0.2.1` schematic/PCB intelligence and
 presentation work without claiming production readiness or universal DipTrace
 compatibility.
 
-Included candidate changes:
+Included changes:
 
 - 167-tool public MCP contract with the read-only built-in-library bridge;
 - bounded schematic intent, placement, wire planning, repair, ensemble ranking
@@ -35,7 +40,7 @@ Included candidate changes:
 - complete-design PCB/Schematic framing and repository PCB/Schematic MP4/GIF
   examples.
 
-## Operator acceptance supplied for this candidate
+## Operator acceptance
 
 On 2026-08-16 the operator confirmed that the current repository schematic and
 PCB examples open correctly in the operator's current DipTrace configuration and
@@ -47,15 +52,58 @@ configuration. It is not independently captured redistributable evidence and
 does not establish authoritative copper refill geometry, manufacturing output,
 universal compatibility or independent review.
 
-## Publication gates still pending
+## Automated and publication evidence
 
-- exact candidate commit and annotated tag;
-- authoritative GitHub CI on the frozen candidate;
-- Linux/macOS/Windows tests, coverage, Ruff, Mypy and repository contract gates;
-- audited wheel/sdist and Windows installer/plug-in/portable/MCPB artifacts;
-- GitHub prerelease publication and public redownload/hash verification;
-- tag-bound PyPI Trusted Publishing and public package verification;
-- post-publication Smithery lock refresh and GitHub/PyPI GIF rendering check.
+Frozen-candidate workflows:
+
+- [CI run 31913775728](https://github.com/fireostendere/mcp_diptrace/actions/runs/31913775728):
+  Linux 3.10/3.13, geometry, no-Shapely, macOS, Windows, static analysis, DCO
+  and combined coverage passed.
+- [MCPB run 31913775725](https://github.com/fireostendere/mcp_diptrace/actions/runs/31913775725): passed.
+- [PyPI validation run 31913775751](https://github.com/fireostendere/mcp_diptrace/actions/runs/31913775751):
+  build/audit/smoke passed; publishing correctly skipped.
+- [Windows run 31913775749](https://github.com/fireostendere/mcp_diptrace/actions/runs/31913775749):
+  build, artifact audit and lifecycle smoke passed.
+
+Tag-bound artifact workflows at `fbbbda176043c555b04a908bb63f6fc4ac5909cb`:
+
+- [PyPI validation 31914157323](https://github.com/fireostendere/mcp_diptrace/actions/runs/31914157323): passed.
+- [MCPB 31914159573](https://github.com/fireostendere/mcp_diptrace/actions/runs/31914159573): passed.
+- [Windows 31914158543](https://github.com/fireostendere/mcp_diptrace/actions/runs/31914158543):
+  installer, plug-in, portable, artifact/provenance and install/upgrade/uninstall
+  MCP stdio smoke passed.
+
+The first publish attempt
+[31914837673](https://github.com/fireostendere/mcp_diptrace/actions/runs/31914837673)
+correctly failed before upload because publisher v1.14.0 did not support valid
+Core Metadata 2.5. [PR #109](https://github.com/fireostendere/mcp_diptrace/pull/109)
+upgraded the official publisher to v1.14.2/Twine 7 while preserving exact
+annotated-tag checkout verification. Trusted Publishing and attestations then
+passed in [run 31915399966](https://github.com/fireostendere/mcp_diptrace/actions/runs/31915399966).
+
+## Immutable public asset inventory
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `DipTrace-MCP-0.3.0-windows.mcpb` | 65,529,142 | `403a036b89fa07974c8a7e24ea61fa6e75105444c042127754d2465315064dee` |
+| `DipTrace-MCP-Plugin-Setup-0.3.0.exe` | 19,044,748 | `7104ff50c62fae8ddd77ed448cfd4af038fff374f48c012a4757da3b76347a49` |
+| `DipTrace-MCP-Portable-0.3.0.zip` | 95,588,923 | `c20e8ba575348898f5e3e42b3c1f90691b73eb5b54554365fd6641c99c571050` |
+| `DipTrace-MCP-Setup-0.3.0.exe` | 56,396,794 | `8dd128aad50ee39605e93a0feb17f7d7c51ded969dfb5cb8f87da65a6d730f53` |
+| `diptrace_mcp-0.3.0-py3-none-any.whl` | 626,344 | `5fad30e9770367b17acdf1d289ddc2e2cc94b6a017dcdd79598f5c71f4452243` |
+| `diptrace_mcp-0.3.0.tar.gz` | 1,285,170 | `71dc9b2ebf971bc12456f92bc637dc03ecbd5734e7d1af4067df9b6e9bb9e4f3` |
+| `SHA256SUMS.txt` | 587 | `1f2e097476678b2035582bf1c37039a41ba42d6854e0c795a814412923106fc5` |
+| `RELEASE_PROVENANCE.txt` | 1,203 | `0469548a21485c364159d7f7f77b53e7a54a85afad0c79498c96856c96b82b7b` |
+
+All GitHub assets were redownloaded after publication. The checksum manifest
+passed for all six binary/package assets, and the provenance file matched its
+staged source. The public PyPI wheel and sdist were independently downloaded and
+matched the GitHub bytes exactly; the wheel installed in a clean environment,
+`diptrace-mcp --help` passed and the imported version was `0.3.0`.
+
+Public PyPI JSON reports both files, exact sizes/hashes, Markdown README metadata
+and both GIF references. Both tagged GIF files were separately redownloaded and
+decoded as GIF89a images. The post-publication Smithery lock resolves the public
+`0.3.0` hashes.
 
 ## Known limitations
 
@@ -73,6 +121,7 @@ universal compatibility or independent review.
 
 ## Rollback and immutability
 
-Do not create or publish the tag until the frozen candidate passes its release
-gates. Once published, never move `v0.3.0` or replace its assets; publish a new
-version for any correction.
+Never move `v0.3.0`, replace its GitHub assets or replace its PyPI files. Publish
+a new version for any correction. A material issue may justify documenting,
+yanking or withdrawing affected distribution entries without reusing the
+version.

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -1,6 +1,8 @@
 # MCPB packaging
 
-This directory contains the deterministic Windows MCP Bundle build source. Version `0.2.1` has already been published as `DipTrace-MCP-0.2.1-windows.mcpb`; future builds must use a new version and must not replace the published `v0.2.1` bytes.
+This directory contains the deterministic Windows MCP Bundle build source.
+Version `0.3.0` is published as `DipTrace-MCP-0.3.0-windows.mcpb`; future builds
+must use a new version and must not replace published bytes.
 
 Build the standalone Windows server first, then run:
 

--- a/packaging/smithery/uv.lock
+++ b/packaging/smithery/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "diptrace-mcp"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp" },
@@ -249,21 +249,21 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/91/dc514db96793062bbdafe0328144c88668d0f604457b917149f32281b105/diptrace_mcp-0.2.1.tar.gz", hash = "sha256:39cc2658ca0888cc52ef583c0f6940831afc7b3af2472397001cf4e3bc5a29e0", size = 935205, upload-time = "2026-08-05T09:45:37.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1f/3c57b196f5d5f7ab822c3d9e2f740e2bdec6fba73976ceaffe632f44af22/diptrace_mcp-0.3.0.tar.gz", hash = "sha256:71dc9b2ebf971bc12456f92bc637dc03ecbd5734e7d1af4067df9b6e9bb9e4f3", size = 1285170, upload-time = "2026-08-15T23:43:04.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c0/47410fdce688fc26bc8b3a5b5ea983b48f264b6d464c7a023dafb0eca414/diptrace_mcp-0.2.1-py3-none-any.whl", hash = "sha256:325ad8b032f1014d61a5b38e2cc2af3f97105c73246edad06ca1739704e872ea", size = 437696, upload-time = "2026-08-05T09:45:35.698Z" },
+    { url = "https://files.pythonhosted.org/packages/24/24/e8eda52673975aa9b374795f49298767ae5abfe84f7ee8530e93cb1f5d32/diptrace_mcp-0.3.0-py3-none-any.whl", hash = "sha256:5fad30e9770367b17acdf1d289ddc2e2cc94b6a017dcdd79598f5c71f4452243", size = 626344, upload-time = "2026-08-15T23:43:02.595Z" },
 ]
 
 [[package]]
 name = "diptrace-mcp-smithery"
-version = "0.2.1"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "diptrace-mcp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "diptrace-mcp", specifier = "==0.2.1" }]
+requires-dist = [{ name = "diptrace-mcp", specifier = "==0.3.0" }]
 
 [[package]]
 name = "exceptiongroup"

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "pypi_project": "diptrace-mcp",
-  "pypi_workflow_run": null,
-  "release_status": "candidate-unpublished-development-prerelease",
+  "pypi_workflow_run": 31915399966,
+  "release_status": "published-unsigned-development-prerelease",
   "tag": "v0.3.0",
   "version": "0.3.0"
 }


### PR DESCRIPTION
Records the published GitHub/PyPI v0.3.0 identities, workflow evidence, public asset sizes and SHA-256 values; updates installation and evergreen documentation; refreshes the Smithery lock from public PyPI 0.3.0.\n\nValidation: release metadata check, documentation-state check, 30 focused tests, Ruff, uv lock check, git diff check.