### PR TITLE
Trigger v0.4.0 publication from verified annotated tag

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,4 +1,4 @@
-# v0.4.0 tag pushes are publication events; pull requests remain validation-only.
+# v0.4.0 tag pushes and successful exact-tag verification are publication events; pull requests remain validation-only.
 name: PyPI release
 
 on:
@@ -17,6 +17,11 @@ on:
   push:
     tags:
       - "v0.4.0"
+  workflow_run:
+    workflows:
+      - "Create annotated v0.4.0 tag"
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       publish:
@@ -40,7 +45,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
-          ref: "${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish)) && 'v0.4.0' || github.sha }}"
+          ref: "${{ (github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.publish)) && 'v0.4.0' || github.sha }}"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
@@ -50,7 +55,7 @@ jobs:
       - name: Verify release identity and publication ref
         shell: bash
         env:
-          PUBLISH_REQUESTED: ${{ github.event_name == 'push' || inputs.publish }}
+          PUBLISH_REQUESTED: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || inputs.publish }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -109,7 +114,7 @@ jobs:
 
   publish:
     name: Publish v0.4.0 to PyPI
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release-v0.4.0.yml
+++ b/.github/workflows/release-v0.4.0.yml
@@ -4,31 +4,39 @@ on:
   push:
     tags:
       - "v0.4.0"
+  workflow_run:
+    workflows:
+      - "Create annotated v0.4.0 tag"
+    types:
+      - completed
 
 permissions:
   contents: write
   actions: read
 
 env:
+  RELEASE_TARGET_SHA: "b4c0132283ff16a0bca81567df6704d1f6a73c7f"
   WINDOWS_RUN_ID: "31974338063"
   WINDOWS_SOURCE_SHA: "72750d195e204cf0c11c04d71364055ca7634c6b"
 
 jobs:
   publish-release:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
+          ref: v0.4.0
 
       - name: Verify exact annotated release tag
         shell: bash
         run: |
           set -euo pipefail
-          test "${GITHUB_REF_NAME}" = "v0.4.0"
           git fetch --tags --force
           test "$(git cat-file -t v0.4.0)" = tag
-          test "$(git rev-list -n 1 v0.4.0)" = "$(git rev-parse HEAD)"
+          test "$(git rev-list -n 1 v0.4.0)" = "${RELEASE_TARGET_SHA}"
+          test "$(git rev-parse HEAD)" = "${RELEASE_TARGET_SHA}"
 
       - name: Download validated Windows release assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/tag-v0.4.0-on-main.yml
+++ b/.github/workflows/tag-v0.4.0-on-main.yml
@@ -8,7 +8,10 @@ on:
       - .github/workflows/tag-v0.4.0-on-main.yml
 
 permissions:
-  contents: write
+  contents: read
+
+env:
+  RELEASE_TARGET_SHA: "b4c0132283ff16a0bca81567df6704d1f6a73c7f"
 
 jobs:
   tag:
@@ -18,18 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create exact annotated tag once
+      - name: Verify exact annotated tag without moving it
         shell: bash
         run: |
           set -euo pipefail
           git fetch --tags --force
-          if git show-ref --verify --quiet refs/tags/v0.4.0; then
-            echo 'v0.4.0 already exists; refusing to move it.' >&2
+          if ! git show-ref --verify --quiet refs/tags/v0.4.0; then
+            echo 'v0.4.0 is missing; refusing to recreate it from a post-release commit.' >&2
             exit 1
           fi
-          git config user.name fireostendere
-          git config user.email 87851878+fireostendere@users.noreply.github.com
-          git tag -a v0.4.0 "${GITHUB_SHA}" -m 'DipTrace MCP v0.4.0'
           test "$(git cat-file -t v0.4.0)" = tag
-          test "$(git rev-list -n 1 v0.4.0)" = "${GITHUB_SHA}"
-          git push origin refs/tags/v0.4.0
+          test "$(git rev-list -n 1 v0.4.0)" = "${RELEASE_TARGET_SHA}"
+          echo "v0.4.0 is an annotated tag targeting ${RELEASE_TARGET_SHA}."

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -139,12 +139,17 @@ def test_pypi_workflow_builds_before_a_minimal_oidc_publish_job() -> None:
 
     assert workflow["permissions"] == {"contents": "read"}
     assert workflow["env"] == {"RELEASE_VERSION": "0.4.0", "RELEASE_TAG": "v0.4.0"}
+    assert "workflow_run:" in workflow_text
+    assert 'Create annotated v0.4.0 tag' in workflow_text
 
     build = jobs["build"]
     build_commands = _job_commands(build)
     assert build["steps"][0]["with"]["ref"] == (
-        "${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' "
-        "&& inputs.publish)) && 'v0.4.0' || github.sha }}"
+        "${{ (github.event_name == 'push' || (github.event_name == 'workflow_run' "
+        "&& github.event.workflow_run.conclusion == 'success' "
+        "&& github.event.workflow_run.head_branch == 'main') || "
+        "(github.event_name == 'workflow_dispatch' && inputs.publish)) "
+        "&& 'v0.4.0' || github.sha }}"
     )
     assert "python -m hatchling build -d dist" in build_commands
     assert "audit_release_artifacts.py --dist-dir dist --check-allowlist" in build_commands
@@ -155,8 +160,10 @@ def test_pypi_workflow_builds_before_a_minimal_oidc_publish_job() -> None:
 
     publish = jobs["publish"]
     assert publish["if"] == (
-        "${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' "
-        "&& inputs.publish == true) }}"
+        "${{ github.event_name == 'push' || (github.event_name == 'workflow_run' "
+        "&& github.event.workflow_run.conclusion == 'success' "
+        "&& github.event.workflow_run.head_branch == 'main') || "
+        "(github.event_name == 'workflow_dispatch' && inputs.publish == true) }}"
     )
     assert publish["needs"] == "build"
     assert publish["environment"] == {


### PR DESCRIPTION
## Purpose

GitHub suppresses downstream workflow triggers when a tag is created by `GITHUB_TOKEN`. The annotated `v0.4.0` tag already exists and correctly targets `main@b4c0132283ff16a0bca81567df6704d1f6a73c7f`.

This PR makes the existing tag workflow idempotently verify that immutable tag, then uses its successful `workflow_run` as the publication event for:

- `pypi.yml` using the existing PyPI OIDC/trusted-publisher workflow;
- `release-v0.4.0.yml` using the already validated Windows/portable artifacts.

The tag is never recreated or moved. PyPI and GitHub Release both publish from the exact existing `v0.4.0` target.