### PR TITLE
fix(eda): Astra platform review, electrical identity and PCB handoff hardening

### DIFF
--- a/.github/workflows/native-platform.yml
+++ b/.github/workflows/native-platform.yml
@@ -15,6 +15,9 @@ concurrency:
   group: native-platform-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PYTHONUTF8: '1'
+
 jobs:
   native-windows:
     runs-on: windows-latest
@@ -41,56 +44,63 @@ jobs:
           if (-not (Test-Path "$root\Pcb.exe")) { throw 'DipTrace Pcb.exe is missing' }
           "DIPTRACE_ROOT=$root" >> $env:GITHUB_ENV
           python -m pip install -e ".[dev,geometry,headless-gui]"
-      - name: Inspect native menus without editing project sources
+          python -m pip install Pillow
+      - name: Inspect native dialogs without writing project sources
         shell: python
         run: |
           import json, os, pathlib, shutil, subprocess, time
           from contextlib import suppress
+          import win32api
           from pywinauto.application import Application
+          from diptrace_mcp.headless_gui import _post_menu_item, _main_window
           output = pathlib.Path('native-evidence')
           output.mkdir(exist_ok=True)
+          executable = pathlib.Path(os.environ['DIPTRACE_ROOT']) / 'Pcb.exe'
+          module = win32api.LoadLibraryEx(str(executable), 0, 2)
+          names = win32api.EnumResourceNames(module, 10)
+          (output / 'resource-names.json').write_text(json.dumps(names), encoding='utf-8')
+          for name in names:
+              if str(name).upper() in {'TFORM1', 'TEXPFORM', 'TDRILLFORM', 'TFORM60', 'TG_FILES', 'TFORM54'}:
+                  (output / (str(name) + '.dfm')).write_bytes(win32api.LoadResource(module, 10, name))
+          win32api.FreeLibrary(module)
           source = pathlib.Path('i2c-level-shifter-pcb.dipxml')
           target = output / source.name
           shutil.copyfile(source, target)
-          app = Application(backend='win32').start(subprocess.list2cmdline([os.environ['DIPTRACE_ROOT'] + '\\Pcb.exe', str(target.resolve())]), timeout=60)
-          report = {'phase': 'ui_inspection_only', 'acceptance': 'not_run', 'windows': []}
+          app = Application(backend='win32').start(subprocess.list2cmdline([str(executable), str(target.resolve())]), timeout=60)
+          report = {'phase': 'ui_inspection_only', 'acceptance': 'not_run', 'probes': []}
           def describe(window):
-              result = {'title': window.window_text(), 'class': window.class_name(), 'handle': window.handle, 'controls': []}
+              result = {'title': window.window_text(), 'class': window.class_name(), 'handle': window.handle, 'visible': window.is_visible(), 'controls': []}
               for child in window.descendants()[:250]:
                   with suppress(Exception):
-                      result['controls'].append({'title': child.window_text(), 'class': child.class_name(), 'id': child.control_id()})
-              return result
-          def menu_items(menu, prefix=''):
-              result = []
-              for i, item in enumerate(menu.items()):
-                  path = prefix + '#' + str(i)
-                  value = {'path': path, 'text': item.text(), 'id': item.item_id(), 'enabled': item.is_enabled()}
-                  submenu = item.sub_menu()
-                  if submenu is not None:
-                      value['children'] = menu_items(submenu, path + '->')
-                  result.append(value)
+                      item = {'title': child.window_text(), 'class': child.class_name(), 'id': child.control_id(), 'visible': child.is_visible(), 'enabled': child.is_enabled(), 'rect': list(child.rectangle())}
+                      if child.class_name() in ('TComboBox', 'ComboBox', 'TListBox', 'ListBox'):
+                          item['items'] = child.texts()
+                      result['controls'].append(item)
               return result
           try:
-              time.sleep(8)
-              for attempt in range(3):
-                  for window in app.windows():
-                      report['windows'].append(describe(window))
-                      title = window.window_text().casefold()
-                      if any(word in title for word in ('color', 'graphics', 'welcome', 'starting')):
-                          for child in window.descendants():
-                              if child.window_text().replace('&', '').strip() in ('OK', 'Close', 'Continue'):
-                                  child.post_message(0x00F5)
-                                  time.sleep(1)
-                                  break
-                  time.sleep(2)
-              for window in app.windows():
-                  with suppress(Exception):
-                      if window.menu() is not None:
-                          report['main_window'] = describe(window)
-                          report['menu'] = menu_items(window.menu())
-              print(json.dumps(report, ensure_ascii=False, indent=2))
+              window = _main_window(app, target, 60)
+              time.sleep(5)
+              for menu in ['#7->#0', '#7->#4', '#0->#9->#0', '#0->#9->#1', '#0->#9->#3', '#0->#9->#4', '#0->#9->#5', '#0->#9->#6', '#0->#4']:
+                  value = {'menu': menu, 'windows': []}
+                  try:
+                      _post_menu_item(window, window.menu_item(menu))
+                      time.sleep(3)
+                      for opened in app.windows(visible_only=True):
+                          if int(opened.handle) == int(window.handle):
+                              continue
+                          value['windows'].append(describe(opened))
+                          with suppress(Exception):
+                              opened.capture_as_image().save(output / (menu.replace('#', '').replace('->','-') + '-' + opened.class_name() + '.png'))
+                      for opened in app.windows(visible_only=True):
+                          if int(opened.handle) != int(window.handle):
+                              opened.post_message(0x0010)
+                      time.sleep(1)
+                  except Exception as exc:
+                      value['error'] = str(exc)
+                  report['probes'].append(value)
+              print(json.dumps(report, ensure_ascii=True, indent=2))
           finally:
-              (output / 'native-ui.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
+              (output / 'dialog-probe.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
               app.kill(soft=False)
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()

--- a/.github/workflows/native-platform.yml
+++ b/.github/workflows/native-platform.yml
@@ -1,0 +1,100 @@
+name: Native PCB platform acceptance
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/native-platform.yml'
+      - 'src/diptrace_mcp/native_cad.py'
+      - 'scripts/validate_native_platform.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-platform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.12'
+      - name: Install pinned test-only DipTrace Freeware
+        shell: pwsh
+        run: |
+          $installer = Join-Path $env:RUNNER_TEMP 'dipfree.exe'
+          curl.exe --fail --location --retry 3 --max-time 180 https://diptrace.com/downloads/dipfree_en64.exe --output $installer
+          if ($LASTEXITCODE -ne 0) { throw 'DipTrace download failed' }
+          $actual = (Get-FileHash $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne '87a9d4cb14e01b0561d6a88d540a5775d92d011359b465d12c7c5d0f0e527e74') { throw "Pinned DipTrace installer mismatch: $actual" }
+          $process = Start-Process $installer -ArgumentList '/silent','/hide' -PassThru
+          if (-not $process.WaitForExit(180000)) { $process.Kill(); throw 'Installer timeout' }
+          if ($process.ExitCode -ne 0) { throw "Installer failed: $($process.ExitCode)" }
+          $root = 'C:\Program Files\DipTrace'
+          if (-not (Test-Path "$root\Pcb.exe")) { throw 'DipTrace Pcb.exe is missing' }
+          "DIPTRACE_ROOT=$root" >> $env:GITHUB_ENV
+          python -m pip install -e ".[dev,geometry,headless-gui]"
+      - name: Inspect native menus without editing project sources
+        shell: python
+        run: |
+          import json, os, pathlib, shutil, subprocess, time
+          from contextlib import suppress
+          from pywinauto.application import Application
+          output = pathlib.Path('native-evidence')
+          output.mkdir(exist_ok=True)
+          source = pathlib.Path('i2c-level-shifter-pcb.dipxml')
+          target = output / source.name
+          shutil.copyfile(source, target)
+          app = Application(backend='win32').start(subprocess.list2cmdline([os.environ['DIPTRACE_ROOT'] + '\\Pcb.exe', str(target.resolve())]), timeout=60)
+          report = {'phase': 'ui_inspection_only', 'acceptance': 'not_run', 'windows': []}
+          def describe(window):
+              result = {'title': window.window_text(), 'class': window.class_name(), 'handle': window.handle, 'controls': []}
+              for child in window.descendants()[:250]:
+                  with suppress(Exception):
+                      result['controls'].append({'title': child.window_text(), 'class': child.class_name(), 'id': child.control_id()})
+              return result
+          def menu_items(menu, prefix=''):
+              result = []
+              for i, item in enumerate(menu.items()):
+                  path = prefix + '#' + str(i)
+                  value = {'path': path, 'text': item.text(), 'id': item.item_id(), 'enabled': item.is_enabled()}
+                  submenu = item.sub_menu()
+                  if submenu is not None:
+                      value['children'] = menu_items(submenu, path + '->')
+                  result.append(value)
+              return result
+          try:
+              time.sleep(8)
+              for attempt in range(3):
+                  for window in app.windows():
+                      report['windows'].append(describe(window))
+                      title = window.window_text().casefold()
+                      if any(word in title for word in ('color', 'graphics', 'welcome', 'starting')):
+                          for child in window.descendants():
+                              if child.window_text().replace('&', '').strip() in ('OK', 'Close', 'Continue'):
+                                  child.post_message(0x00F5)
+                                  time.sleep(1)
+                                  break
+                  time.sleep(2)
+              for window in app.windows():
+                  with suppress(Exception):
+                      if window.menu() is not None:
+                          report['main_window'] = describe(window)
+                          report['menu'] = menu_items(window.menu())
+              print(json.dumps(report, ensure_ascii=False, indent=2))
+          finally:
+              (output / 'native-ui.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
+              app.kill(soft=False)
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: native-platform-evidence
+          path: native-evidence/
+          retention-days: 7

--- a/.github/workflows/native-platform.yml
+++ b/.github/workflows/native-platform.yml
@@ -45,63 +45,9 @@ jobs:
           "DIPTRACE_ROOT=$root" >> $env:GITHUB_ENV
           python -m pip install -e ".[dev,geometry,headless-gui]"
           python -m pip install Pillow
-      - name: Inspect native dialogs without writing project sources
-        shell: python
-        run: |
-          import json, os, pathlib, shutil, subprocess, time
-          from contextlib import suppress
-          import win32api
-          from pywinauto.application import Application
-          from diptrace_mcp.headless_gui import _post_menu_item, _main_window
-          output = pathlib.Path('native-evidence')
-          output.mkdir(exist_ok=True)
-          executable = pathlib.Path(os.environ['DIPTRACE_ROOT']) / 'Pcb.exe'
-          module = win32api.LoadLibraryEx(str(executable), 0, 2)
-          names = win32api.EnumResourceNames(module, 10)
-          (output / 'resource-names.json').write_text(json.dumps(names), encoding='utf-8')
-          for name in names:
-              if str(name).upper() in {'TFORM1', 'TEXPFORM', 'TDRILLFORM', 'TFORM60', 'TG_FILES', 'TFORM54'}:
-                  (output / (str(name) + '.dfm')).write_bytes(win32api.LoadResource(module, 10, name))
-          win32api.FreeLibrary(module)
-          source = pathlib.Path('i2c-level-shifter-pcb.dipxml')
-          target = output / source.name
-          shutil.copyfile(source, target)
-          app = Application(backend='win32').start(subprocess.list2cmdline([str(executable), str(target.resolve())]), timeout=60)
-          report = {'phase': 'ui_inspection_only', 'acceptance': 'not_run', 'probes': []}
-          def describe(window):
-              result = {'title': window.window_text(), 'class': window.class_name(), 'handle': window.handle, 'visible': window.is_visible(), 'controls': []}
-              for child in window.descendants()[:250]:
-                  with suppress(Exception):
-                      item = {'title': child.window_text(), 'class': child.class_name(), 'id': child.control_id(), 'visible': child.is_visible(), 'enabled': child.is_enabled(), 'rect': list(child.rectangle())}
-                      if child.class_name() in ('TComboBox', 'ComboBox', 'TListBox', 'ListBox'):
-                          item['items'] = child.texts()
-                      result['controls'].append(item)
-              return result
-          try:
-              window = _main_window(app, target, 60)
-              time.sleep(5)
-              for menu in ['#7->#0', '#7->#4', '#0->#9->#0', '#0->#9->#1', '#0->#9->#3', '#0->#9->#4', '#0->#9->#5', '#0->#9->#6', '#0->#4']:
-                  value = {'menu': menu, 'windows': []}
-                  try:
-                      _post_menu_item(window, window.menu_item(menu))
-                      time.sleep(3)
-                      for opened in app.windows(visible_only=True):
-                          if int(opened.handle) == int(window.handle):
-                              continue
-                          value['windows'].append(describe(opened))
-                          with suppress(Exception):
-                              opened.capture_as_image().save(output / (menu.replace('#', '').replace('->','-') + '-' + opened.class_name() + '.png'))
-                      for opened in app.windows(visible_only=True):
-                          if int(opened.handle) != int(window.handle):
-                              opened.post_message(0x0010)
-                      time.sleep(1)
-                  except Exception as exc:
-                      value['error'] = str(exc)
-                  report['probes'].append(value)
-              print(json.dumps(report, ensure_ascii=True, indent=2))
-          finally:
-              (output / 'dialog-probe.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
-              app.kill(soft=False)
+      - name: Run real native save-reopen and manufacturing export
+        shell: pwsh
+        run: python scripts/validate_native_platform.py --diptrace-root "$env:DIPTRACE_ROOT" --output native-evidence
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()
         with:

--- a/docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md
+++ b/docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md
@@ -1,0 +1,214 @@
+# DipTrace MCP platform review — 2026-09-09
+
+## Scope and provenance
+
+Baseline: `main` at `24d4106ca7436cc2f1a052885b289bb48bffe734`.
+Work is isolated on `astra`; no main-branch merge or native release is implied.
+This is an AI-assisted engineering review and implementation, not independent
+human approval. New test cases are synthetic and do not promote fixture trust.
+No files under `tests/fixtures/acceptance/` or trusted provenance entries were changed.
+
+The review covered the platform architecture and public contract, selected
+high-risk implementations, the complete automated regression suite, packaging
+and static gates. It is not a claim that every line has been independently
+certified or that native DipTrace/Windows/macOS acceptance was executed here.
+
+## Architectural assessment
+
+The existing repository is a substantial guarded EDA backend, not an empty MCP
+wrapper. Keep its secure XML/raw-tree writer, source-SHA transactions, rollback,
+policy/allowed-root enforcement, provenance boundary, bounded process jobs,
+read-only installed-library bridge and deterministic PCB/schematic engines.
+Replacing these with a second framework would increase risk without improving
+PCB correctness.
+
+| Area | Evidence inspected | Assessment / decision |
+| --- | --- | --- |
+| MCP and application layer | `server_runtime.py`, `service.py`, `services/`, tools snapshot and event-loop tests | Keep the stable facade and 167-tool default contract. Do not publish a tool per heuristic. |
+| XML and writes | `xml_document.py`, semantic compiler, transactions, sessions, source-SHA tests | Retain preview/apply boundaries, raw unknown XML preservation and stale-input rejection. |
+| Engineering evidence | provenance registry, rule packs, trust/evidence tests | A caller-supplied fact is not native acceptance. Preserve missing facts as unknown. |
+| Libraries and electrical identity | `library_mutation.py`, `library_mutation_api.py`, `synchronization.py`, `design_compare.py` | Correct explicit pin/pad validation; remove positional mapping guesses and false match paths. |
+| PCB generation | A-D intent/placement/routing layers, `pcb_whole_board.py`, quality tests | Retain bounded candidate planning; fix outline compaction before adding more optimizers. |
+| Assembly handoff | BOM, readiness, export services and resource store | Unify population semantics; add source-bound preflight and artifact integrity. |
+| External tools/runtime | process runner, jobs, cache, headless/bridge and installer tests | Keep bounded output/cancellation and per-platform tests. Native execution remains separate evidence. |
+| Presentation | optional cinematic subsystem and repository house rules | Keep optional; recordings are not engineering or manufacturing acceptance. |
+| Distribution/docs | pyproject, allowlist/build audit, development guide, CI | Remove stale commands/version text; preserve package, privacy, provenance and discovery gates. |
+
+## Reproduced defects and corrective changes
+
+Severity is engineering impact, not a CVSS score.
+
+### P1 — Pin/pad validation accepted inconsistent pairs
+
+`validate_explicit_pin_pad_mapping` separately checked whether PadId and
+PadNumber existed anywhere in the footprint. A pin could therefore reference
+one pad ID and another pad's number and still pass validation. Duplicate pattern
+styles were silently reduced to the last definition.
+
+The shared `pin_mapping.py` now checks the ID/number pair on the same pad,
+rejects ambiguous definitions, accepts the documented PadIndex alias, and
+rejects conflicting PadId/PadIndex values. A malformed section is not partially
+certified. The library mutation preview uses this same validator.
+
+### P1 — Single-part synchronization guessed electrical mapping
+
+`build_sync_plan` assigned the Nth schematic pin to the Nth footprint pad. A
+single-part component can have any pin-to-pad permutation; having the same pin
+count does not make that mapping correct. It also invented pad numbers when
+neither footprint data nor explicit numbers were available.
+
+Connected pins now require exact embedded-cache bindings or caller-supplied
+`pin_map` entries. The cache resolver uses ComponentStyle/ComponentPart, validates
+pin counts and actual PadId/PadNumber pairs, and supports section-local indices
+for multi-unit components. Missing or ambiguous evidence does not fall back to
+pin order. Existing explicit mappings and guarded transactions remain available.
+
+**Compatibility change:** older callers relying on implicit positional mapping
+must provide a reviewed `pin_map`. See `DEVELOPMENT.md` for a synthetic example.
+Unconnected component placement is still possible when footprint data is present.
+
+### P1 — Comparison could report false electrical matches
+
+The previous comparator overwrote duplicate/empty net names, collapsed unknown
+endpoint owners to `?`, and compared symbol pin indices directly with PCB pad
+IDs. Two equally malformed inputs could therefore appear to match.
+
+Comparison now uses verified physical pad numbers, preserves all duplicate-name
+endpoint data while marking it ambiguous, rejects unresolved owners/mappings,
+checks explicitly declared NetId/no-connect contradictions, and reports both
+source hashes. `matches=true` requires a complete comparison. Ambiguity output
+is bounded to 200 entries with an exact total and truncation flag.
+
+This remains comparison of exported logical membership, not a proof of routed
+copper continuity, hierarchy alias equivalence, ERC, or correct datasheet intent.
+
+### P1 — Board-outline compaction could cut away occupied geometry
+
+Compaction omitted via annuli, existing pours and text bounds. A synthetic
+freestanding via was left outside the resulting board. The rectangle detector
+also accepted a self-crossing bowtie with the same four extrema.
+
+The occupied-bound calculation now includes vias, pours and markings; incomplete
+bounds or cutouts cause a conservative skip. Rectangle edges must be nonzero and
+axis-aligned. Compaction never expands the mechanical boundary. Existing corner
+order, winding and point-container metadata are preserved instead of clearing
+and rebuilding the point list. Returned bounds describe the serialized result.
+Non-finite dimensions are rejected at the package-function boundary as well.
+
+Bounding boxes can still be approximate when source geometry is incomplete;
+these candidate edits do not replace mechanical review or native DipTrace DRC.
+
+### P2 — Assembly population disagreed across outputs
+
+`include_dnp=false` filtered the BOM but not placement CSV. Readiness used a
+second DNP parser that ignored `DNP=dnp` and `Populate=no`, and did not recognize
+the BOM's manufacturer aliases.
+
+BOM extraction is now the population/procurement source for readiness and
+placement. Both outputs honor the same include-DNP flag. Missing assembly
+reference designators are explicit blockers rather than silently usable rows.
+The manifest records included component count and excluded reference designators.
+
+### P2 — CSV escaping corrupted negative numeric coordinates
+
+A leading minus sign was escaped even on actual floats/integers, producing
+non-numeric placement cells. Conversely, whitespace-prefixed spreadsheet
+expressions could bypass the text guard.
+
+Finite numeric cells retain numeric syntax. Untrusted text receives the formula
+prefix guard, including leading whitespace/control-character cases. NaN and
+infinity are rejected. Spreadsheet re-saving is not claimed to preserve this
+protection, and the generic placement format still needs assembler convention
+review.
+
+### P2 — Export integrity and read bounds were incomplete
+
+Release data had no byte-identity inventory and artifact size was checked only
+after reading the whole file. Version-2 review manifests now carry per-artifact
+SHA-256 and byte sizes; resource reads detect changed content and use bounded
+reads. The manifest is checked against the saved export record, not self-hashed.
+Legacy records remain readable. This protects against accidental artifact edits,
+not an attacker able to replace both the record and its checksums.
+
+### P3 — Stale development instructions
+
+The development guide still named 0.3.0 and two scripts that no longer exist.
+It now names 0.4.0, identifies the server shim/runtime correctly, removes dead
+commands, and documents the changed electrical and handoff contracts.
+
+## Added functionality, without additional MCP tools
+
+Existing assembly/fabrication export calls now return a coherent review bundle:
+BOM, placement, stackup, board geometry, `preflight.json`, and a versioned manifest.
+The preflight joins existing readiness checks with explicit ratlines and source
+identity. Known blockers produce `blocked`; otherwise it returns
+`manual_review_required`, never a fabrication approval. Offline geometric DRC
+and native acceptance are explicitly marked not run by this export operation.
+
+Electrical comparison and synchronization share the same explicit cache resolver,
+including multi-unit section indices and non-positional pin permutations. This
+adds useful automatic operation where evidence exists while refusing guesses.
+
+No embeddings, RAG search, web scraping, model inference or agent loop was added.
+OpenCode/mcp-rag owns retrieval, interpretation and orchestration. DipTrace MCP
+owns typed operations, deterministic checks, guarded state changes and evidence
+about what the tools actually did.
+
+## What still separates this from an ultimate PCB platform
+
+| Priority | Next capability | Required acceptance, not just more code |
+| --- | --- | --- |
+| P0 | Claim-specific native regression for changed electrical and outline paths | Open/save/reopen/re-export real two-layer and multi-unit samples; preserve nets, pin maps, vias, cutouts and winding; retain exact source/result hashes. |
+| P1 | Native manufacturing export adapter | Real DipTrace Gerber/NC drill/assembly export on a version-pinned host, file inventory, origin/layer mapping and independent CAM review. Existing generic manifests must never masquerade as these files. |
+| P1 | Public library-authoring decision | Reuse the existing internal raw-preserving writer, define permissions and preview/apply semantics, then deliberately update public schemas and native-host evidence. Do not build another library editor from scratch. |
+| P1 | Resumable project-level PCB build workflow | Compose the existing gate order, source-bound rules, whole-board plan/apply and native acceptance into one state/evidence report. Reuse transactions instead of maintaining a second mutable project state. |
+| P1 | Real-board end-to-end benchmark set | Measure schematic-to-PCB fidelity, mechanical constraints, routing completion, return paths, DRC deltas and engineering readability across representative circuits. Synthetic optimizer scores alone are insufficient. |
+| P2 | Fabricator/assembler profiles and richer assembly variants | Versioned caller-approved process limits, side/origin/rotation conversions and explicit population rules; test actual vendor outputs rather than invent universal thresholds. |
+| P2 | Broader electrical/geometry semantics | Add verified hierarchy aliases, internally shorted/multi-pad pins, arbitrary outlines and complex stackups only with fixtures and native round trips for each supported claim. |
+| P2 | Optional narrower discovery/presentation profile | Preserve the existing default contract; measure client token/runtime cost before introducing profiles or removing historical user-requested tools. |
+
+No broad deletion of tested routing, cinematic, installer or evidence subsystems
+was justified merely by size. This change removes demonstrably incorrect or
+redundant logic and stale instructions instead of replacing it with abstractions.
+
+## Validation record
+
+Executed locally on Linux with CPython 3.13.5 and the declared dev/geometry
+dependencies (including the Shapely/GEOS backend):
+
+- Complete regression: **1615 passed, 6 skipped** in 71.19 seconds. This adds
+  **45 passing regression cases** against the original baseline. The six skips
+  require native Windows Job Objects, desktop objects, PID/path semantics or
+  PowerShell; none is counted as a pass.
+- Global Ruff check passed across `src`, `tests`, `benchmarks`, `scripts` and
+  `plugin`; strict Mypy passed for **136 source files**.
+- **19/19 additional gate commands passed**: release metadata, skill-script and
+  PCB-skill consistency, public privacy, provenance inventory, compliance
+  inventory, event-loop audit, coverage-badge consistency, discovery-size budget,
+  complete tools/list snapshot, XML-spec inventory, format coverage, probe-pack
+  consistency, synthetic-only fixture-ingest dry run, acceptance-seed audit,
+  actual GEOS-backend selection, process-level bridge handshake, wheel/sdist
+  build, and release-artifact/allowlist audit.
+- The public discovery snapshot remains **167 tools**; this change adds no new
+  model-facing tool schemas. Package audit verifies allowlisted files and RECORD
+  hashes, not native CAD compatibility.
+
+Native DipTrace open/save/reopen/re-export, native DRC/refill and manufacturing
+export acceptance were **not run** in this local environment. The process-level
+bridge handshake does not substitute for them. Local Windows/macOS execution was
+not performed. A successful coverage-badge consistency check is not a new code
+coverage measurement. The PR's final-head CI checks provide the separate
+cross-platform and coverage results; they must not be inferred from these local
+results or from an earlier commit's green status.
+
+## Primary format/security references
+
+- DipTrace Component Editor XML specification, serializer revision 7276:
+  https://diptrace.com/support/tutorials/xml_specs_CompEdit_html/
+- DipTrace Schematic XML specification, serializer revision 7276:
+  https://diptrace.com/support/tutorials/xml_specs_Schematic_html/
+- OWASP CSV Injection guidance:
+  https://owasp.org/www-community/attacks/CSV_Injection
+
+These references inform bounded parsing/validation. Reading a newer specification
+does not establish compatibility with every DipTrace version.

--- a/docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md
+++ b/docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md
@@ -60,8 +60,9 @@ neither footprint data nor explicit numbers were available.
 Connected pins now require exact embedded-cache bindings or caller-supplied
 `pin_map` entries. The cache resolver uses ComponentStyle/ComponentPart, validates
 pin counts and actual PadId/PadNumber pairs, and supports section-local indices
-for multi-unit components. Missing or ambiguous evidence does not fall back to
-pin order. Existing explicit mappings and guarded transactions remain available.
+for multi-unit components. Literal cache-key lookup rejects malformed, Unicode
+and oversized index strings without integer coercion. Missing or ambiguous
+evidence does not fall back to pin order. Existing explicit mappings and guarded transactions remain available.
 
 **Compatibility change:** older callers relying on implicit positional mapping
 must provide a reviewed `pin_map`. See `DEVELOPMENT.md` for a synthetic example.
@@ -176,8 +177,8 @@ redundant logic and stale instructions instead of replacing it with abstractions
 Executed locally on Linux with CPython 3.13.5 and the declared dev/geometry
 dependencies (including the Shapely/GEOS backend):
 
-- Complete regression: **1615 passed, 6 skipped** in 71.19 seconds. This adds
-  **45 passing regression cases** against the original baseline. The six skips
+- Complete regression: **1619 passed, 6 skipped** in 67.83 seconds. This adds
+  **49 passing regression cases** against the original baseline. The six skips
   require native Windows Job Objects, desktop objects, PID/path semantics or
   PowerShell; none is counted as a pass.
 - Global Ruff check passed across `src`, `tests`, `benchmarks`, `scripts` and

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,17 +2,18 @@
 
 ## Current baseline
 
-The current source/package version is `0.3.0`. The public MCP contract currently registers 167 tools (165 existing tools plus the read-only built-in-library bridge). `DipTraceService` is the stable public Facade; typed domain implementations live under `src/diptrace_mcp/services/`.
+The current source/package version is `0.4.0`. The public MCP contract currently registers 167 tools (165 existing tools plus the read-only built-in-library bridge). `DipTraceService` is the stable public Facade; typed domain implementations live under `src/diptrace_mcp/services/`.
 
-`v0.3.0` is published as an unsigned GitHub development prerelease and as
-`diptrace-mcp==0.3.0` on PyPI. Development on `main` continues after that
+`v0.4.0` is published as an unsigned GitHub development prerelease and as
+`diptrace-mcp==0.4.0` on PyPI. Development on `main` continues after that
 immutable release, so use the tag when exact released bytes matter.
 
 ## Repository structure
 
 ```text
 src/diptrace_mcp/
-  server.py                     FastMCP registration, transport, errors, offload
+  server.py                     stable server entry-point shim
+  server_runtime.py             FastMCP registration, transport, errors, offload
   service.py                    stable DipTraceService Facade
   services/                     typed application/domain services
   adapters.py                   XML-to-domain adapters
@@ -92,8 +93,6 @@ python -m mypy --no-incremental src/diptrace_mcp plugin
 python scripts/sync_skill_scripts.py --check
 python scripts/generate_pcb_skills.py --check
 python scripts/generate_mcp_tools_snapshot.py --check
-python scripts/check_service_facade_contract.py --check
-python scripts/validate_service_decomposition.py --check
 python scripts/audit_event_loop.py --json
 python scripts/generate_coverage_badge.py --check
 python scripts/extract_spec_inventory.py \
@@ -118,8 +117,6 @@ Do not treat the old `v0.1.2` ~86% measurement as the current target. See [TESTI
 
 ```bash
 python scripts/generate_mcp_tools_snapshot.py --check
-python scripts/check_service_facade_contract.py --check
-python scripts/validate_service_decomposition.py --check
 ```
 
 Current expected values:
@@ -257,3 +254,43 @@ Current generic release procedure:
 - [RELEASE_PROCESS.md](RELEASE_PROCESS.md)
 
 Do not move an existing tag, replace published bytes or claim signed/production-ready status from CI alone.
+
+
+## Assembly handoff and electrical synchronization
+
+`export_assembly_outputs` and `export_fabrication_outputs` produce review bundles,
+not native manufacturing artwork. Their version-2 manifests contain a consistent
+`include_dnp` population, placement-coordinate conventions, a source-SHA-bound
+`preflight.json`, and SHA-256/byte lengths for every data artifact. The manifest
+itself is excluded from its digest table; reads compare it with the saved export
+record. Digests detect modified export bytes, not engineering correctness or a
+trusted signature. Existing version-1 export records remain readable.
+
+Preflight combines the existing BOM/readiness rules with explicitly exported
+ratlines. It is `blocked` on known blockers and otherwise
+`manual_review_required`; it never approves fabrication. Offline geometric DRC
+is a separate registered review operation, and native DipTrace acceptance must
+still be run. No RAG/LLM or external solver is invoked by export.
+
+Connected schematic pins now require either exact embedded ComponentStyle /
+ComponentPart / PadId + PadNumber bindings or explicit `component_mappings.pin_map`.
+A list of footprint pad numbers alone is not a pin map. Migrating an old positional
+mapping requires an explicit reviewed mapping, for example:
+
+```json
+{
+  "refdes": "R1",
+  "pattern_style": "PatType0",
+  "pin_map": [
+    {"part_id": "0", "pin": 0, "pad_number": "1"},
+    {"part_id": "0", "pin": 1, "pad_number": "2"}
+  ]
+}
+```
+
+That example is synthetic, not a generic mapping for arbitrary parts. Use the
+actual source Part ID, section-local pin index, and verified physical pad number.
+Synchronization still uses the existing dry-run, expected-SHA, backup and
+transaction path. Compare results report source hashes, `comparison_complete`,
+ambiguities, and physical-pad-number endpoint differences. Missing mappings or
+ambiguous identifiers return `status=inconclusive`, never `matches=true`.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -20,8 +20,9 @@ Repository tests prove deterministic bounded behaviour, not that complete real s
 `schematic_atomic_reroute.py` closes the former dangerous gap where moving a symbol could leave stale existing wire geometry. Remaining optimisation debt is broader rather than transactional:
 
 - global same-net Steiner-tree optimisation beyond the current bounded endpoint selection and literal multi-junction preservation for proven acyclic existing wire graphs;
-- arbitrary PDF/application-note extraction beyond the validated structured
-  engineering-rule-pack boundary;
+- broader reviewed engineering-rule-pack coverage and caller-supplied evidence
+  bindings; arbitrary PDF retrieval/extraction and model interpretation belong to
+  OpenCode/mcp-rag, not this deterministic server;
 - broader real-project tuning without hiding score terms.
 
 ### 3. Schematic rotation/pin-facing authority

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -28,6 +28,7 @@ benchmarks/synthetic_board.py
 docs/ACCEPTANCE_SEED_AUDIT.md
 docs/API_ERRORS.md
 docs/ARCHITECTURE.md
+docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md
 docs/ASYNC_EXECUTION.md
 docs/AUTOMATABLE_ROADMAP_CLOSURE.md
 docs/CINEMATIC_DEMO_MODE.md
@@ -287,6 +288,7 @@ src/diptrace_mcp/pcb_quality.py
 src/diptrace_mcp/pcb_routing_policy.py
 src/diptrace_mcp/pcb_whole_board.py
 src/diptrace_mcp/physics_estimates.py
+src/diptrace_mcp/pin_mapping.py
 src/diptrace_mcp/placement.py
 src/diptrace_mcp/plans.py
 src/diptrace_mcp/policy.py
@@ -466,6 +468,7 @@ tests/test_pcb_quality_gate.py
 tests/test_pcb_routing_policy.py
 tests/test_phase4.py
 tests/test_physics_estimates.py
+tests/test_pin_mapping.py
 tests/test_placement.py
 tests/test_plugin_settings.py
 tests/test_policy.py

--- a/scripts/release_artifact_allowlist.txt
+++ b/scripts/release_artifact_allowlist.txt
@@ -9,6 +9,7 @@
 .github/workflows/linux-clean-install.yml
 .github/workflows/macos-clean-install.yml
 .github/workflows/mcpb.yml
+.github/workflows/native-platform.yml
 .github/workflows/pypi.yml
 .github/workflows/release.yml
 .github/workflows/windows-installer.yml
@@ -203,6 +204,7 @@ scripts/spec_inventory_integrity.py
 scripts/summarize_pyinstaller_inventory.py
 scripts/summarize_scancode.py
 scripts/sync_skill_scripts.py
+scripts/validate_native_platform.py
 scripts/verify_geometry_backend.py
 skills/README.md
 skills/SOURCES.sha256
@@ -273,6 +275,7 @@ src/diptrace_mcp/library_mutation_api.py
 src/diptrace_mcp/manual_acceptance.py
 src/diptrace_mcp/model_cache.py
 src/diptrace_mcp/multirouter.py
+src/diptrace_mcp/native_cad.py
 src/diptrace_mcp/numeric_inputs.py
 src/diptrace_mcp/operations.py
 src/diptrace_mcp/pattern_recommendation.py

--- a/scripts/validate_native_platform.py
+++ b/scripts/validate_native_platform.py
@@ -1,0 +1,41 @@
+"""Run actual DipTrace on isolated copies; retain evidence even when a gate fails."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from diptrace_mcp.native_cad import NativeCadRequest, run_native_cad
+from diptrace_mcp.xml_document import DipTraceDocument
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diptrace-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    source = Path("i2c-level-shifter-pcb.dipxml").resolve()
+    document = DipTraceDocument.load(source, 64 * 1024 * 1024)
+    result = run_native_cad(
+        NativeCadRequest(
+            source=source,
+            output_dir=args.output.resolve() / "i2c-board",
+            diptrace_root=args.diptrace_root,
+            expected_sha256=document.sha256,
+            timeout_seconds=180.0,
+            export_manufacturing=True,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=True, indent=2))
+    if not result["completed"]:
+        raise SystemExit("Native execution incomplete; inspect retained evidence")
+    # This initial integration checks actual native output, not PCB approval.
+    output = args.output.resolve() / "i2c-board"
+    for name in ("saved.dip", "reexport.dipxml", "native-fabrication.zip"):
+        if not (output / name).is_file():
+            raise SystemExit(f"Missing native output: {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/diptrace_mcp/design_compare.py
+++ b/src/diptrace_mcp/design_compare.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from typing import Any
 
 from .adapters import DocumentSnapshot
 from .errors import DocumentError
+from .pin_mapping import schematic_pin_pad_numbers
 
 
 def _component_values(snapshot: DocumentSnapshot) -> dict[str, set[str]]:
@@ -20,33 +21,113 @@ def _component_values(snapshot: DocumentSnapshot) -> dict[str, set[str]]:
     return result
 
 
-def _net_endpoints(snapshot: DocumentSnapshot) -> dict[str, set[str]]:
+def _net_endpoints(
+    snapshot: DocumentSnapshot, issues: list[dict[str, str]]
+) -> tuple[dict[str, set[tuple[str, str]]], int]:
     container = snapshot.document.container
-    if snapshot.schematic is not None:
-        owners = {
-            part.get("Id", ""): (part.findtext("./RefDes") or "").strip()
-            for part in container.findall("./Components/Part")
-        }
-        return {
-            (net.findtext("./Name") or "").strip().casefold(): {
-                f"{owners.get(item.get('Part', ''), '?')}:{item.get('Pin', '?')}"
-                for item in net.findall("./Pins/Item")
-            }
-            for net in container.findall("./Nets/Net")
-        }
-    if snapshot.board is None:
-        raise DocumentError("Schematic/PCB comparison requires design documents")
-    owners = {
-        component.get("Id", ""): (component.findtext("./RefDes") or "").strip()
-        for component in container.findall("./Components/Component")
-    }
-    return {
-        (net.findtext("./Name") or "").strip().casefold(): {
-            f"{owners.get(item.get('Comp', ''), '?')}:{item.get('Pad', '?')}"
-            for item in net.findall("./Pads/Item")
-        }
-        for net in container.findall("./Nets/Net")
-    }
+    schematic = snapshot.schematic is not None
+    source = "schematic" if schematic else "pcb"
+
+    issue_count = 0
+
+    def issue(code: str, object_id: str) -> None:
+        nonlocal issue_count
+        issue_count += 1
+        if len(issues) < 200:
+            issues.append({"source": source, "code": code, "object_id": object_id})
+
+    owner_tag, item_tag, owner_key, endpoint_key = (
+        ("Part", "Pins", "Part", "Pin") if schematic else ("Component", "Pads", "Comp", "Pad")
+    )
+    owner_elements = container.findall(f"./Components/{owner_tag}")
+    ids = Counter(owner.get("Id", "") for owner in owner_elements)
+    refs = Counter((owner.findtext("./RefDes") or "").strip().casefold()
+                   for owner in owner_elements)
+    owners = {}
+    for owner in owner_elements:
+        identity = owner.get("Id", "")
+        refdes = (owner.findtext("./RefDes") or "").strip().casefold()
+        if not identity or ids[identity] != 1:
+            issue("missing_or_duplicate_owner_id", identity)
+            continue
+        if not refdes or (not schematic and refs[refdes] != 1):
+            issue("missing_or_duplicate_refdes", identity)
+            continue
+        owners[identity] = (refdes, owner)
+
+    bindings = schematic_pin_pad_numbers(snapshot.document) if schematic else {}
+    board_numbers: dict[tuple[str, str], str] = {}
+    if not schematic:
+        patterns = snapshot.document.root.findall(".//Patterns/Pattern")
+        for identity, (_, owner) in owners.items():
+            candidates = [pattern for pattern in patterns
+                          if pattern.get("PatternStyle") == owner.get("PatternStyle")]
+            pads = owner.findall("./Pads/Pad")
+            pad_ids = Counter(pad.get("Id", "") for pad in pads)
+            for pad in pads:
+                pad_id = pad.get("Id", "")
+                number = (pad.get("Number") or pad.findtext("./Number") or "").strip()
+                if not number and len(candidates) == 1:
+                    definitions = [item for item in candidates[0].findall("./Pads/Pad")
+                                   if item.get("Id") == pad_id]
+                    if len(definitions) == 1:
+                        number = (definitions[0].findtext("./Number") or "").strip()
+                if not pad_id or pad_ids[pad_id] != 1 or not number:
+                    issue("unresolved_pad_number", f"{identity}:{pad_id}")
+                else:
+                    board_numbers[(identity, pad_id)] = number
+
+    result: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    nets = container.findall("./Nets/Net")
+    net_ids = Counter(net.get("Id", "") for net in nets)
+    membership: dict[tuple[str, str], str] = {}
+    raw_membership: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for net in nets:
+        identity = net.get("Id", "")
+        name = (net.findtext("./Name") or "").strip().casefold()
+        if not name or name in result:
+            issue("missing_or_duplicate_net_name", identity)
+        if not identity or net_ids[identity] != 1:
+            issue("missing_or_duplicate_net_id", identity)
+        endpoints = result[name]  # Preserve all endpoints, never overwrite duplicate names.
+        for item in net.findall(f"./{item_tag}/Item"):
+            owner_id, pin_id = item.get(owner_key, ""), item.get(endpoint_key, "")
+            if owner_id not in owners:
+                issue("unresolved_endpoint_owner", f"{identity}:{owner_id}")
+                continue
+            refdes, owner = owners[owner_id]
+            raw_membership[(owner_id, pin_id)].add(identity)
+            mapped_number: str | None = None
+            if schematic:
+                try:
+                    index = int(pin_id)
+                except ValueError:
+                    index = -1
+                if 0 <= index < len(owner.findall("./Pins/Pin")):
+                    mapped_number = bindings.get((owner_id, index))
+            else:
+                mapped_number = board_numbers.get((owner_id, pin_id))
+            if mapped_number is None:
+                issue("unverified_pin_pad_mapping", f"{owner_id}:{pin_id}")
+                continue
+            endpoint = (refdes, mapped_number)
+            if endpoint in endpoints:
+                issue("duplicate_endpoint", f"{identity}:{refdes}:{mapped_number}")
+            if endpoint in membership and membership[endpoint] != identity:
+                issue("endpoint_in_multiple_nets", f"{refdes}:{mapped_number}")
+            membership[endpoint] = identity
+            endpoints.add(endpoint)
+    for owner_id, (_, owner) in owners.items():
+        endpoint_tag = "Pin" if schematic else "Pad"
+        for index, endpoint_element in enumerate(owner.findall(f"./{item_tag}/{endpoint_tag}")):
+            pin_id = str(index) if schematic else endpoint_element.get("Id", "")
+            observed = raw_membership.get((owner_id, pin_id), set())
+            declared = endpoint_element.get("NetId")
+            if declared is not None and observed != ({declared} if declared != "-1" else set()):
+                issue("inconsistent_endpoint_netid", f"{owner_id}:{pin_id}")
+            if endpoint_element.get("NotConnected") == "Y" and observed:
+                issue("explicit_nc_pin_connected", f"{owner_id}:{pin_id}")
+    return dict(result), issue_count
 
 
 def compare_schematic_to_pcb(
@@ -67,8 +148,10 @@ def compare_schematic_to_pcb(
         for refdes in sorted(set(schematic_components) & set(pcb_components))
         if schematic_components[refdes] != pcb_components[refdes]
     ]
-    schematic_nets = _net_endpoints(schematic)
-    pcb_nets = _net_endpoints(pcb)
+    issues: list[dict[str, str]] = []
+    schematic_nets, schematic_issue_count = _net_endpoints(schematic, issues)
+    pcb_nets, pcb_issue_count = _net_endpoints(pcb, issues)
+    ambiguity_count = schematic_issue_count + pcb_issue_count
     missing_nets = sorted(set(schematic_nets) - set(pcb_nets))
     extra_nets = sorted(set(pcb_nets) - set(schematic_nets))
     endpoint_mismatches: list[dict[str, Any]] = []
@@ -78,8 +161,14 @@ def compare_schematic_to_pcb(
         endpoint_mismatches.append(
             {
                 "net": net_name,
-                "missing_on_pcb": sorted(schematic_nets[net_name] - pcb_nets[net_name]),
-                "extra_on_pcb": sorted(pcb_nets[net_name] - schematic_nets[net_name]),
+                "missing_on_pcb": [
+                    f"{refdes}:{number}"
+                    for refdes, number in sorted(schematic_nets[net_name] - pcb_nets[net_name])
+                ],
+                "extra_on_pcb": [
+                    f"{refdes}:{number}"
+                    for refdes, number in sorted(pcb_nets[net_name] - schematic_nets[net_name])
+                ],
             }
         )
     difference_count = sum(
@@ -93,7 +182,14 @@ def compare_schematic_to_pcb(
         )
     )
     return {
-        "matches": difference_count == 0,
+        "matches": difference_count == 0 and not issues,
+        "comparison_complete": not issues,
+        "comparison_basis": "explicit_physical_pad_numbers",
+        "status": "inconclusive" if issues else "different" if difference_count else "matches",
+        "ambiguities": issues,
+        "ambiguity_count": ambiguity_count,
+        "ambiguities_truncated": ambiguity_count > len(issues),
+        "sources": {"schematic_sha256": schematic.info.sha256, "pcb_sha256": pcb.info.sha256},
         "difference_count": difference_count,
         "components": {
             "schematic_count": len(schematic_components),
@@ -109,10 +205,11 @@ def compare_schematic_to_pcb(
             "extra_on_pcb": extra_nets,
             "endpoint_mismatches": endpoint_mismatches,
         },
-        "confidence": "medium",
+        "confidence": "low" if issues else "medium",
         "limitations": [
-            "Endpoint comparison assumes schematic Pin indices map to PCB Pad ids.",
+            "Only explicit cached pin-to-pad bindings and declared PCB pad numbers are compared.",
+            "Missing mappings and ambiguous identities prevent a positive match claim.",
             "Hierarchical aliases and hidden power-net equivalence are not inferred.",
-            "Run library pin-to-pad validation before treating endpoint differences as final."
+            "This compares exported logical membership, not routed copper or native ERC/DRC."
         ],
     }

--- a/src/diptrace_mcp/domain.py
+++ b/src/diptrace_mcp/domain.py
@@ -124,7 +124,7 @@ def requires_diptrace_verification(level: FixtureValidationLevel) -> bool:
     """Return True if a document at this trust level still needs DipTrace verification.
 
     Only a full round-trip (open/save/re-export with semantic comparison) or an
-    external tool round-trip can免除 further verification.
+    external tool round-trip can satisfy that verification requirement.
     """
     return level in {
         FixtureValidationLevel.synthetic_parser_only,

--- a/src/diptrace_mcp/exports.py
+++ b/src/diptrace_mcp/exports.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
 import json
+import math
 import uuid
 from collections.abc import Callable
 from datetime import datetime
@@ -11,6 +13,7 @@ from typing import Literal
 
 from .adapters import DocumentSnapshot
 from .bom import extract_bom, group_bom
+from .connectivity import build_connectivity_graph
 from .domain import ExportRecord
 from .errors import ObjectNotFoundError
 from .record_ids import (
@@ -24,6 +27,7 @@ from .record_ids import (
     require_record_id,
 )
 from .record_store import RecordStore
+from .release_readiness import run_release_readiness
 from .retention import (
     RetentionCandidate,
     RetentionPolicy,
@@ -38,8 +42,16 @@ ExportType = Literal["bom", "fabrication_manifest", "assembly_manifest", "si_geo
 
 
 def _safe_csv(value: object) -> str:
+    # Coordinates are numbers, not untrusted spreadsheet expressions. Escaping a
+    # negative float corrupts machine-readable placement data.
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("CSV numeric values must be finite")
+        return str(value)
     rendered = str(value)
-    if rendered.startswith(("=", "+", "-", "@")):
+    if rendered.lstrip().startswith(("=", "+", "-", "@")) or rendered.startswith(
+        ("\t", "\r", "\n")
+    ):
         return f"'{rendered}"
     return rendered
 
@@ -249,7 +261,8 @@ class ExportStore(RecordStore):
                 name,
                 kind="export",
             )
-            payload = path.read_bytes()
+            with path.open("rb") as stream:
+                payload = stream.read(self.max_artifact_bytes + 1)
         except (
             InvalidRecordId,
             InvalidRecordPath,
@@ -260,6 +273,16 @@ class ExportStore(RecordStore):
             ) from exc
         if len(payload) > self.max_artifact_bytes:
             raise ValueError(f"Export artifact exceeds read limit: {name}")
+        if record.manifest.get("schema_version") == 2:
+            if name == "manifest.json":
+                if json.loads(payload) != record.manifest:
+                    raise ValueError("Export manifest integrity check failed")
+            else:
+                inventory = record.manifest.get("artifact_integrity", {})
+                expected = inventory.get(name) if isinstance(inventory, dict) else None
+                actual = {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+                if expected != actual:
+                    raise ValueError(f"Export artifact integrity check failed: {name}")
         return payload
 
     def list(self) -> list[ExportRecord]:
@@ -311,9 +334,15 @@ def bom_csv(snapshot: DocumentSnapshot, *, include_dnp: bool = True) -> bytes:
     )
 
 
-def placement_csv(snapshot: DocumentSnapshot) -> bytes:
+def placement_csv(snapshot: DocumentSnapshot, *, include_dnp: bool = True) -> bytes:
     if snapshot.board is None:
         return b""
+    excluded = {
+        object_id
+        for record in extract_bom(snapshot)
+        if record.dnp and not include_dnp
+        for object_id in record.source_object_ids
+    }
     rows = [
         {
             "RefDes": item.refdes or "",
@@ -327,6 +356,7 @@ def placement_csv(snapshot: DocumentSnapshot) -> bytes:
             "GeometryConfidence": item.confidence,
         }
         for item in snapshot.board.components
+        if item.stable_id not in excluded
     ]
     return _csv_bytes(
         rows,
@@ -383,8 +413,47 @@ def create_release_manifest(
         "Placement CSV is generic and must be mapped to the assembler's coordinate convention.",
         "The bundle is a release-review manifest, not fabrication-ready artwork.",
     ]
+    bom = extract_bom(snapshot)
+    included = [record for record in bom if include_dnp or not record.dnp]
+    readiness = run_release_readiness(snapshot)
+    graph = build_connectivity_graph(snapshot)
+    preflight = {
+        "source_sha256": snapshot.info.sha256,
+        "status": (
+            "blocked"
+            if readiness["status"] == "blocked" or graph.unrouted_connections
+            else "manual_review_required"
+        ),
+        "native_acceptance": "not_run",
+        "offline_drc": "not_run",
+        "readiness": readiness,
+        "explicit_unrouted_connections": graph.unrouted_connections,
+        "manual_gates": readiness["manual_gates"],
+        "limitations": [
+            *graph.warnings,
+            "No ratlines does not prove copper continuity or native DRC acceptance.",
+            "Run the registered PCB review separately for geometric/clearance checks.",
+        ],
+    }
     manifest: dict[str, object] = {
+        "schema_version": 2,
         "kind": export_type,
+        "include_dnp": include_dnp,
+        "population": {
+            "total_components": len(bom),
+            "included_components": len(included),
+            "excluded_refdes": sorted(
+                refdes for record in bom if record.dnp and not include_dnp
+                for refdes in record.refdes
+            ),
+        },
+        "placement_convention": {
+            "units": "mm",
+            "origin": "exported_document_origin",
+            "rotation_units": "degrees",
+            "bottom_side_transform": "none; assembler convention requires review",
+        },
+        "preflight_status": preflight["status"],
         "document_id": snapshot.info.document_id,
         "source_type": snapshot.info.source_type,
         "source_version": snapshot.info.version,
@@ -412,14 +481,15 @@ def create_release_manifest(
             "placement.csv",
             "stackup.json",
             "board-geometry.json",
+            "preflight.json",
         ],
         "not_generated": ["gerber", "nc_drill", "odb++", "ipc-2581", "final_pours"],
         "limitations": limitations,
     }
     artifacts = {
-        "manifest.json": json.dumps(manifest, indent=2).encode("utf-8"),
         "bom.csv": bom_csv(snapshot, include_dnp=include_dnp),
-        "placement.csv": placement_csv(snapshot),
+        "placement.csv": placement_csv(snapshot, include_dnp=include_dnp),
+        "preflight.json": json.dumps(preflight, indent=2).encode("utf-8"),
         "stackup.json": json.dumps(
             snapshot.board.stackup.model_dump(mode="json"), indent=2
         ).encode("utf-8"),
@@ -435,6 +505,13 @@ def create_release_manifest(
             indent=2,
         ).encode("utf-8"),
     }
+    # The manifest cannot hash itself; record.json stores the same manifest.
+    # These digests establish byte identity, not a signature or engineering approval.
+    manifest["artifact_integrity"] = {
+        name: {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+        for name, payload in sorted(artifacts.items())
+    }
+    artifacts["manifest.json"] = json.dumps(manifest, indent=2).encode("utf-8")
     return store.create(snapshot, export_type, artifacts, manifest, limitations)
 
 

--- a/src/diptrace_mcp/library_mutation.py
+++ b/src/diptrace_mcp/library_mutation.py
@@ -25,6 +25,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .errors import DocumentError, EditError
+from .pin_mapping import part_pin_pad_numbers
 from .xml_document import DipTraceDocument, RawTreeSnapshot
 
 CollisionPolicy = Literal["error", "keep", "update"]
@@ -672,7 +673,7 @@ def attach_pattern(
 def validate_explicit_pin_pad_mapping(document: DipTraceDocument, component_name: str) -> list[str]:
     """Return deterministic mapping errors for one component.
 
-    This is intentionally strict: every mapped pin must carry both ``PadId`` and
+    This is intentionally strict: every mapped pin must carry ``PadId`` (or ``PadIndex``) and
     ``PadNumber`` and must resolve to the attached embedded pattern.
     """
 
@@ -685,32 +686,17 @@ def validate_explicit_pin_pad_mapping(document: DipTraceDocument, component_name
     if len(matches) != 1:
         return [f"component selector matched {len(matches)} entries"]
     pattern_root = _pattern_library_root(document)
-    patterns = {
-        item.get("PatternStyle", ""): item
-        for item in pattern_root.findall("./Patterns/Pattern")
-        if item.get("PatternStyle")
-    }
+    patterns: dict[str, list[ET.Element]] = {}
+    for item in pattern_root.findall("./Patterns/Pattern"):
+        patterns.setdefault(item.get("PatternStyle", ""), []).append(item)
     errors: list[str] = []
     for part_index, part in enumerate(matches[0].findall("./Part")):
         pattern = part.find("./Pattern")
         style = pattern.get("Style", "") if pattern is not None else ""
-        resolved = patterns.get(style)
-        if resolved is None:
-            errors.append(f"part {part_index}: attached pattern {style!r} is missing")
+        candidates = patterns.get(style, [])
+        if not style or len(candidates) != 1:
+            errors.append(f"part {part_index}: attached pattern {style!r} is missing or ambiguous")
             continue
-        valid_ids = {pad.get("Id", "") for pad in resolved.findall("./Pads/Pad")}
-        valid_numbers = {_child_text(pad, "Number") for pad in resolved.findall("./Pads/Pad")}
-        for pin in part.findall("./Pins/Pin"):
-            pad_id = pin.get("PadId")
-            pad_number = _child_text(pin, "PadNumber")
-            label = _child_text(pin, "Name") or pin.get("Id", "<unknown>")
-            if pad_id is None or not pad_number:
-                errors.append(f"part {part_index} pin {label}: mapping is incomplete")
-                continue
-            if pad_id not in valid_ids:
-                errors.append(f"part {part_index} pin {label}: PadId {pad_id!r} is absent")
-            if pad_number not in valid_numbers:
-                errors.append(
-                    f"part {part_index} pin {label}: PadNumber {pad_number!r} is absent"
-                )
+        _, mapping_errors = part_pin_pad_numbers(part, candidates[0])
+        errors.extend(f"part {part_index}: {message}" for message in mapping_errors)
     return errors

--- a/src/diptrace_mcp/native_cad.py
+++ b/src/diptrace_mcp/native_cad.py
@@ -74,7 +74,14 @@ def _dump(path: Path, value: dict[str, Any]) -> None:
 
 
 def _visible(app: Any, *classes: str) -> list[Any]:
-    return [window for window in app.windows(visible_only=True) if window.class_name() in classes]
+    found: list[Any] = []
+    # Delphi destroys splash/dialog HWNDs while pywinauto enumerates them.
+    with suppress(Exception):
+        for window in app.windows(visible_only=True):
+            with suppress(Exception):
+                if window.class_name() in classes:
+                    found.append(window)
+    return found
 
 
 def _dialog(app: Any, timeout: float, *classes: str) -> Any:
@@ -108,7 +115,7 @@ def _children(hwnd: int) -> list[int]:
 
 
 def _control_info(hwnd: int) -> dict[str, Any]:
-    import win32gui  # type: ignore[import-not-found]
+    import win32gui
 
     return {
         "handle": hwnd,
@@ -129,8 +136,8 @@ def _capture(window: Any, path: Path) -> Any:
     """PrintWindow renders only the owned window, even on a hidden desktop."""
     from ctypes import wintypes
 
-    import win32gui  # type: ignore[import-not-found]
-    import win32ui  # type: ignore[import-not-found]
+    import win32gui
+    import win32ui
     from PIL import Image
 
     left, top, right, bottom = win32gui.GetWindowRect(window.handle)
@@ -144,7 +151,7 @@ def _capture(window: Any, path: Path) -> Any:
     try:
         bitmap.CreateCompatibleBitmap(source_dc, width, height)
         memory_dc.SelectObject(bitmap)
-        windll = ctypes.windll
+        windll = ctypes.__dict__["windll"]
         render = windll.user32.PrintWindow
         render.argtypes = [wintypes.HWND, wintypes.HDC, wintypes.UINT]
         render.restype = wintypes.BOOL
@@ -292,8 +299,18 @@ def _save_filename(dialog: Any, target: Path, *, native_extension: str | None = 
 
 
 def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[str, Any]:
-    import win32gui  # type: ignore[import-not-found]
+    import win32gui
 
+    _post_menu_item(window, window.menu_item("#0->#9->#5"))
+    drill = _dialog(app, min(timeout, 20), "TDrillForm")
+    time.sleep(0.2)
+    _dump(output / "drill-controls.json", {"controls": _controls(drill)})
+    _set_checked(drill, "Metric", True)
+    _set_checked(drill, "Use Design Origin", True)
+    _set_checked(drill, "Mirror", False)
+    _capture(drill, output / "drill-settings.png")
+    _click_caption(drill, "Close")
+    time.sleep(0.2)
     _post_menu_item(window, window.menu_item("#0->#9->#4"))  # observed 5.3.0.3 Export/Gerber X2
     dialog = _dialog(app, timeout, "TExpForm")
     _dump(output / "gerber-controls.json", {"controls": _controls(dialog)})
@@ -307,20 +324,90 @@ def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[
     menu = win32gui.SendMessage(popup.handle, 0x01E1, 0, 0)  # MN_GETHMENU
     if not menu or win32gui.GetMenuItemCount(menu) != 3:
         raise HeadlessGuiError("Unexpected native Export All popup")
-    command = win32gui.GetMenuItemID(menu, 1)  # ZIP: Gerber + NC Drill
-    win32gui.PostMessage(dialog.handle, 0x001F, 0, 0)  # WM_CANCELMODE: dismiss owned popup
-    win32gui.PostMessage(dialog.handle, 0x0111, command, 0)
-    save = _dialog(app, timeout, "#32770")
+    # Select the measured item in the owned popup. Delphi popup menus can use
+    # a hidden menu owner, so posting WM_COMMAND to the form is not equivalent.
+    left, top, right, bottom = win32gui.GetMenuItemRect(int(popup.handle), menu, 1)
+    x, y = win32gui.ScreenToClient(int(popup.handle), ((left + right) // 2, (top + bottom) // 2))
+    coordinates = (x & 0xFFFF) | ((y & 0xFFFF) << 16)
+    _dump(output / "gerber-popup.json", {"menu": int(menu), "rect": [left, top, right, bottom]})
+    _capture(popup, output / "gerber-popup.png")
+    for message, flags in ((0x0200, 0), (0x0201, 1), (0x0202, 0)):
+        _post_window_message(int(popup.handle), message, flags, coordinates)
+    save = _dialog(app, min(timeout, 20), "#32770")
     _save_filename(save, output / "native-fabrication.zip")
     _wait_for_export(app, output / "native-fabrication.zip", timeout)
     _post_window_message(dialog.handle, 0x0010)
+    time.sleep(0.2)
+    _native_placement(app, window, output, timeout)
     return {
+        "assembly_exporter": "DipTrace Pick and Place",
         "exporter": "DipTrace Gerber X2 + NC Drill ZIP",
         "ui_profile": PROFILE,
         "units_requested": "mm",
         "origin": "design_origin",
         "mirror": False,
     }
+
+
+def _combo_items(hwnd: int) -> list[str]:
+    api = _Win32Api()
+    count = int(api.user32.SendMessageW(hwnd, 0x0146, 0, 0))
+    if not 0 < count <= 64:
+        raise HeadlessGuiError("Unexpected native combo size")
+    result = []
+    for index in range(count):
+        length = int(api.user32.SendMessageW(hwnd, 0x0149, index, 0))
+        if not 0 <= length < 1024:
+            raise HeadlessGuiError("Native combo text exceeds the bound")
+        text = ctypes.create_unicode_buffer(length + 1)
+        api.user32.SendMessageW(hwnd, 0x0148, index, ctypes.addressof(text))
+        result.append(text.value)
+    return result
+
+
+def _choose_combo(hwnd: int, index: int) -> None:
+    import win32gui
+
+    api = _Win32Api()
+    api.user32.SendMessageW(hwnd, 0x014E, index, 0)
+    parent, control_id = win32gui.GetParent(hwnd), win32gui.GetDlgCtrlID(hwnd)
+    for notification in (9, 1, 8):
+        _post_window_message(parent, 0x0111, (control_id & 0xFFFF) | (notification << 16), hwnd)
+    if int(api.user32.SendMessageW(hwnd, 0x0147, 0, 0)) != index:
+        raise HeadlessGuiError("Native combo selection did not persist")
+
+
+def _native_placement(app: Any, window: Any, output: Path, timeout: float) -> None:
+    _post_menu_item(window, window.menu_item("#0->#9->#12"))
+    dialog = _dialog(app, min(timeout, 20), "TForm54")
+    time.sleep(0.2)
+    _dump(output / "placement-controls.json", {"controls": _controls(dialog)})
+    _capture(dialog, output / "placement-before.png")
+    _set_checked(dialog, "Use Design Origin", True)
+    _set_checked(dialog, "Mirror", False)
+    selected_units = False
+    for control in _controls(dialog):
+        if control["class"] not in {"TComboBox", "ComboBox"}:
+            continue
+        hwnd = int(control["handle"])
+        options = _combo_items(hwnd)
+        lowered = [name.casefold() for name in options]
+        if "millimeters" in lowered:
+            _choose_combo(hwnd, lowered.index("millimeters"))
+            selected_units = True
+        elif set(lowered) == {"all", "top", "bottom"}:
+            _choose_combo(hwnd, lowered.index("all"))
+        elif set(options) == {".", ","}:
+            _choose_combo(hwnd, options.index("."))
+    if not selected_units:
+        raise HeadlessGuiError("Native placement metric units were not resolved")
+    _capture(dialog, output / "placement-settings.png")
+    _click_caption(dialog, "Export to File")
+    save = _dialog(app, min(timeout, 20), "#32770")
+    time.sleep(0.2)
+    _save_filename(save, output / "native-placement.csv", native_extension=".csv")
+    _wait_for_export(app, output / "native-placement.csv", timeout)
+    _post_window_message(int(dialog.handle), 0x0010)
 
 
 def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
@@ -333,7 +420,7 @@ def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
         raise HeadlessGuiError("Unsupported native editor")
     executable_name, xml_extension, binary_extension = EXTENSIONS[source.kind]
     executable = request.diptrace_root / executable_name
-    import win32api  # type: ignore[import-not-found]
+    import win32api
 
     version_info = win32api.GetFileVersionInfo(str(executable), "\\")
     ms, ls = version_info["FileVersionMS"], version_info["FileVersionLS"]
@@ -365,8 +452,16 @@ def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
                 subprocess.list2cmdline([str(executable), str(opened)]),
                 timeout=request.timeout_seconds,
             )
-            _acknowledge_startup(app, output)
-            window = _main_window(app, opened, request.timeout_seconds)
+            deadline = time.monotonic() + request.timeout_seconds
+            while True:
+                try:
+                    _acknowledge_startup(app, output)
+                    window = _main_window(app, opened, min(2.0, request.timeout_seconds))
+                    break
+                except Exception:
+                    if time.monotonic() >= deadline:
+                        raise
+                    time.sleep(0.1)
             report["steps"].append({"step": phase, "pid": int(app.process)})
             if phase == "open_save_close":
                 _save_as(app, window, binary, request.timeout_seconds, xml=False)
@@ -477,7 +572,7 @@ def run_native_cad(request: NativeCadRequest) -> dict[str, Any]:
         raise HeadlessGuiError("Native evidence exceeds size limit")
     report = json.loads(result_path.read_text(encoding="utf-8"))
     report["worker_exit_code"] = code
-    report["input_desktop_unchanged"] = input_desktop_name() == before
+    report["input_desktop_unchanged"] = before is not None and input_desktop_name() == before
     report["source_unchanged"] = sha256_bytes(request.source.read_bytes()) == source_sha
     if code != 0 or not report["input_desktop_unchanged"] or not report["source_unchanged"]:
         report["completed"] = False

--- a/src/diptrace_mcp/native_cad.py
+++ b/src/diptrace_mcp/native_cad.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import ctypes
+import hashlib
 import json
 import os
 import subprocess
@@ -188,6 +189,46 @@ def _click_caption(window: Any, caption: str) -> None:
     _post_window_message(int(matches[0]["handle"]), 0x00F5)  # BM_CLICK, no input desktop
 
 
+def _set_checked(window: Any, caption: str, checked: bool) -> None:
+    matches = [
+        item
+        for item in _controls(window)
+        if str(item["title"]).replace("&", "").strip() == caption
+        and item["visible"]
+        and item["enabled"]
+    ]
+    if len(matches) != 1:
+        raise HeadlessGuiError(f"Native checkbox is not unique: {caption}")
+    hwnd = int(matches[0]["handle"])
+    api = _Win32Api()
+    if int(api.user32.SendMessageW(hwnd, 0x00F0, 0, 0)) != int(checked):
+        _post_window_message(hwnd, 0x00F5)
+    deadline = time.monotonic() + 3
+    while int(api.user32.SendMessageW(hwnd, 0x00F0, 0, 0)) != int(checked):
+        if time.monotonic() >= deadline:
+            raise HeadlessGuiError(f"Native checkbox state did not change: {caption}")
+        time.sleep(0.05)
+
+
+def _drc_bitmap_status(image: Any, dialog_class: str) -> str:
+    # Exact message-glyph fingerprint, observed in two independent runs of
+    # DipTrace 5.3.0.3 EN / Win32 96-DPI. This is not OCR or a class-name heuristic.
+    # Different DPI/font/text must stay unknown. Full-window evidence is retained.
+    if dialog_class != "TFMyMessage" or image.size != (306, 117):
+        return "visual_review_required"
+    body = image.crop((8, 30, image.width - 8, image.height - 42)).convert("L")
+    pixels = body.point(lambda value: 255 if value < 128 else 0)
+    box = pixels.getbbox()
+    if box is None:
+        return "visual_review_required"
+    glyphs = pixels.crop(box)
+    if glyphs.size == (84, 10) and hashlib.sha256(glyphs.tobytes()).hexdigest() == (
+        "8c8fc31460a31b05a3a51824dd3d11b03a2847c21095eddbe317b65eef2ee5f1"
+    ):
+        return "pass"
+    return "visual_review_required"
+
+
 def _acknowledge_startup(app: Any, output: Path) -> None:
     # A private desktop may start with a graphics-backend warning. Record it;
     # acknowledging on a disposable copy cannot certify a successfully loaded design.
@@ -257,8 +298,11 @@ def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[
     dialog = _dialog(app, timeout, "TExpForm")
     _dump(output / "gerber-controls.json", {"controls": _controls(dialog)})
     _capture(dialog, output / "gerber-dialog.png")
-    _click_caption(dialog, "Metric")
-    _click_caption(dialog, "Export All")
+    _set_checked(dialog, "Metric", True)
+    _set_checked(dialog, "Use Design Origin", True)
+    _set_checked(dialog, "Mirror", False)
+    _capture(dialog, output / "gerber-settings.png")
+    _click_caption(dialog, "Export All...")
     popup = _dialog(app, timeout, "#32768")
     menu = win32gui.SendMessage(popup.handle, 0x01E1, 0, 0)  # MN_GETHMENU
     if not menu or win32gui.GetMenuItemCount(menu) != 3:
@@ -274,7 +318,8 @@ def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[
         "exporter": "DipTrace Gerber X2 + NC Drill ZIP",
         "ui_profile": PROFILE,
         "units_requested": "mm",
-        "origin": "native_export_settings_recorded_in_capture",
+        "origin": "design_origin",
+        "mirror": False,
     }
 
 
@@ -332,7 +377,7 @@ def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
                     dialog = _dialog(app, request.timeout_seconds, "TFMyMessage", "TForm60")
                     report["drc_texts"] = _texts(dialog, app)
                     report["drc_dialog_class"] = dialog.class_name()
-                    _capture(dialog, output / "drc.png")
+                    image = _capture(dialog, output / "drc.png")
                     report["drc_status"] = (
                         "pass"
                         if any(
@@ -341,8 +386,9 @@ def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
                         )
                         else "fail"
                         if dialog.class_name() == "TForm60"
-                        else "visual_review_required"
+                        else _drc_bitmap_status(image, dialog.class_name())
                     )
+                    report["drc_recognition"] = "text_or_version_bound_message_bitmap"
                     _post_window_message(dialog.handle, 0x0010)
                 _save_as(app, window, reexport, request.timeout_seconds, xml=True)
                 if request.export_manufacturing:

--- a/src/diptrace_mcp/native_cad.py
+++ b/src/diptrace_mcp/native_cad.py
@@ -31,6 +31,7 @@ from .headless_gui import (
     _save_dialog_as_xml,
     _save_dialog_controls,
     _wait_for_export,
+    _Win32Api,
     input_desktop_name,
     thread_desktop_name,
 )
@@ -87,22 +88,40 @@ def _dialog(app: Any, timeout: float, *classes: str) -> Any:
     raise HeadlessGuiError(f"Expected native dialog did not appear: {classes}")
 
 
+def _children(hwnd: int) -> list[int]:
+    """Enumerate owned HWND children without filtering by the input desktop."""
+    from ctypes import wintypes
+
+    api = _Win32Api()
+    handles: list[int] = []
+    callback_type = ctypes.__dict__["WINFUNCTYPE"](wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+    def collect(child: int, _data: int) -> bool:
+        if len(handles) >= 512:
+            return False
+        handles.append(int(child))
+        return True
+
+    api.user32.EnumChildWindows(hwnd, callback_type(collect), 0)
+    return handles
+
+
+def _control_info(hwnd: int) -> dict[str, Any]:
+    import win32gui  # type: ignore[import-not-found]
+
+    return {
+        "handle": hwnd,
+        "title": win32gui.GetWindowText(hwnd),
+        "class": win32gui.GetClassName(hwnd),
+        "id": win32gui.GetDlgCtrlID(hwnd),
+        "rect": list(win32gui.GetWindowRect(hwnd)),
+        "visible": bool(win32gui.IsWindowVisible(hwnd)),
+        "enabled": bool(win32gui.IsWindowEnabled(hwnd)),
+    }
+
+
 def _controls(window: Any) -> list[dict[str, Any]]:
-    result = []
-    for control in window.descendants()[:256]:
-        with suppress(Exception):
-            item = {
-                "title": control.window_text(),
-                "class": control.class_name(),
-                "id": control.control_id(),
-                "rect": list(control.rectangle()),
-                "visible": control.is_visible(),
-                "enabled": control.is_enabled(),
-            }
-            if control.class_name() in {"TComboBox", "ComboBox", "TListBox", "ListBox"}:
-                item["items"] = control.texts()
-            result.append(item)
-    return result
+    return [_control_info(hwnd) for hwnd in _children(int(window.handle))]
 
 
 def _capture(window: Any, path: Path) -> Any:
@@ -159,15 +178,28 @@ def _texts(window: Any, app: Any) -> list[str]:
 def _click_caption(window: Any, caption: str) -> None:
     matches = [
         control
-        for control in window.descendants()
-        if control.window_text().replace("&", "").strip().casefold() == caption.casefold()
-        and control.is_visible()
-        and control.is_enabled()
+        for control in _controls(window)
+        if str(control["title"]).replace("&", "").strip().casefold() == caption.casefold()
+        and control["visible"]
+        and control["enabled"]
     ]
     if len(matches) != 1:
         raise HeadlessGuiError(f"Native control not uniquely resolved: {caption}")
-    # click uses WM_* messages; click_input is deliberately never used.
-    matches[0].click()
+    _post_window_message(int(matches[0]["handle"]), 0x00F5)  # BM_CLICK, no input desktop
+
+
+def _acknowledge_startup(app: Any, output: Path) -> None:
+    # A private desktop may start with a graphics-backend warning. Record it;
+    # acknowledging on a disposable copy cannot certify a successfully loaded design.
+    time.sleep(1.0)
+    for index, dialog in enumerate(_visible(app, "TFMyMessage")):
+        _capture(dialog, output / f"startup-{index}.png")
+        _dump(
+            output / f"startup-{index}.json",
+            {"texts": _texts(dialog, app), "controls": _controls(dialog)},
+        )
+        _post_window_message(int(dialog.handle), 0x0010)
+    time.sleep(0.2)
 
 
 def _save_as(app: Any, window: Any, target: Path, timeout: float, *, xml: bool) -> None:
@@ -175,6 +207,15 @@ def _save_as(app: Any, window: Any, target: Path, timeout: float, *, xml: bool) 
         raise HeadlessGuiError("Native output must not overwrite an existing file")
     _post_menu_item(window, window.menu_item("#0->#4"))
     dialog = _dialog(app, timeout, "#32770")
+    deadline = time.monotonic() + min(timeout, 10)
+    while True:
+        try:
+            _save_dialog_controls(int(dialog.handle))
+            break
+        except HeadlessGuiError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.1)
     if xml:
         _save_dialog_as_xml(int(dialog.handle), target)
     else:
@@ -183,25 +224,30 @@ def _save_as(app: Any, window: Any, target: Path, timeout: float, *, xml: bool) 
 
 
 def _save_filename(dialog: Any, target: Path, *, native_extension: str | None = None) -> None:
-    import win32gui  # type: ignore[import-not-found]
-    from pywinauto.controls.hwndwrapper import HwndWrapper
-
+    api = _Win32Api()
     edit, combo = _save_dialog_controls(int(dialog.handle))
     if native_extension is not None:
-        from pywinauto.controls.win32_controls import ComboBoxWrapper
-
-        wrapper = ComboBoxWrapper(combo)
-        choices = wrapper.texts()[1:]
-        matching = [
-            index
-            for index, name in enumerate(choices)
-            if "xml" not in name.casefold() and f"*{native_extension}" in name.casefold()
-        ]
+        count = int(api.user32.SendMessageW(combo, 0x0146, 0, 0))  # CB_GETCOUNT
+        matching: list[int] = []
+        choices: list[str] = []
+        for index in range(max(0, min(count, 100))):
+            text = ctypes.create_unicode_buffer(1024)
+            api.user32.SendMessageW(combo, 0x0148, index, ctypes.addressof(text))
+            choices.append(text.value)
+            if (
+                "xml" not in text.value.casefold()
+                and f"*{native_extension}" in text.value.casefold()
+            ):
+                matching.append(index)
         if len(matching) != 1:
             raise HeadlessGuiError(f"Native file format not unique: {choices}")
-        wrapper.select(matching[0])
-    HwndWrapper(edit).set_window_text(str(target))
-    win32gui.PostMessage(int(dialog.handle), 0x0111, 1, 0)
+        api.user32.SendMessageW(combo, 0x014E, matching[0], 0)  # CB_SETCURSEL
+        for notification in (9, 1, 8):  # CBN_SELENDOK, SELCHANGE, CLOSEUP
+            _post_window_message(int(dialog.handle), 0x0111, 1136 | (notification << 16), combo)
+        time.sleep(0.2)
+    text = ctypes.create_unicode_buffer(str(target))
+    api.user32.SendMessageW(edit, 0x000C, 0, ctypes.addressof(text))
+    _post_window_message(int(dialog.handle), 0x0111, 1, 0)
 
 
 def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[str, Any]:
@@ -274,6 +320,7 @@ def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
                 subprocess.list2cmdline([str(executable), str(opened)]),
                 timeout=request.timeout_seconds,
             )
+            _acknowledge_startup(app, output)
             window = _main_window(app, opened, request.timeout_seconds)
             report["steps"].append({"step": phase, "pid": int(app.process)})
             if phase == "open_save_close":
@@ -388,7 +435,7 @@ def run_native_cad(request: NativeCadRequest) -> dict[str, Any]:
     report["source_unchanged"] = sha256_bytes(request.source.read_bytes()) == source_sha
     if code != 0 or not report["input_desktop_unchanged"] or not report["source_unchanged"]:
         report["completed"] = False
-        report["error"] = "Native isolation invariant failed"
+        report.setdefault("error", "Native isolation invariant failed")
     _dump(result_path, report)
     return dict(report)
 

--- a/src/diptrace_mcp/native_cad.py
+++ b/src/diptrace_mcp/native_cad.py
@@ -1,0 +1,413 @@
+"""Version-bounded native CAD round-trips on a private Win32 desktop.
+
+Only copies are opened. GUI messages target owned HWNDs; there is no physical
+mouse/keyboard fallback. Native evidence is not a fabrication approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .domain import StrictModel
+from .headless_gui import (
+    HeadlessGuiError,
+    HiddenDesktop,
+    _main_window,
+    _post_menu_item,
+    _post_window_message,
+    _pywinauto_application,
+    _save_dialog_as_xml,
+    _save_dialog_controls,
+    _wait_for_export,
+    input_desktop_name,
+    thread_desktop_name,
+)
+from .windows_configurator import detect_diptrace_installations, validate_diptrace_directory
+from .windows_job import KillOnCloseJob
+from .xml_document import DipTraceDocument, sha256_bytes
+
+PROFILE = "diptrace-5.3.0.3-en"
+EXTENSIONS = {
+    "pcb": ("Pcb.exe", ".dipxml", ".dip"),
+    "schematic": ("Schematic.exe", ".dchxml", ".dch"),
+    "component_library": ("CompEdit.exe", ".elixml", ".eli"),
+    "pattern_library": ("PattEdit.exe", ".libxml", ".lib"),
+}
+
+
+class NativeCadRequest(StrictModel):
+    source: Path
+    output_dir: Path
+    diptrace_root: Path
+    expected_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    timeout_seconds: float = Field(default=120.0, gt=0, le=300, allow_inf_nan=False)
+    export_manufacturing: bool = False
+
+
+def installation_root() -> Path:
+    """Installation choice is server-owned configuration, never an MCP executable argument."""
+    configured = os.environ.get("DIPTRACE_MCP_DIPTRACE_ROOT")
+    if configured:
+        return validate_diptrace_directory(Path(configured)).root
+    installations = detect_diptrace_installations()
+    if not installations:
+        raise HeadlessGuiError("A configured DipTrace 5.3.0.3 installation is required")
+    return installations[0].root
+
+
+def _dump(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def _visible(app: Any, *classes: str) -> list[Any]:
+    return [window for window in app.windows(visible_only=True) if window.class_name() in classes]
+
+
+def _dialog(app: Any, timeout: float, *classes: str) -> Any:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        found = _visible(app, *classes)
+        if len(found) == 1:
+            return found[0]
+        if len(found) > 1:
+            raise HeadlessGuiError("Ambiguous native dialog identity")
+        time.sleep(0.1)
+    raise HeadlessGuiError(f"Expected native dialog did not appear: {classes}")
+
+
+def _controls(window: Any) -> list[dict[str, Any]]:
+    result = []
+    for control in window.descendants()[:256]:
+        with suppress(Exception):
+            item = {
+                "title": control.window_text(),
+                "class": control.class_name(),
+                "id": control.control_id(),
+                "rect": list(control.rectangle()),
+                "visible": control.is_visible(),
+                "enabled": control.is_enabled(),
+            }
+            if control.class_name() in {"TComboBox", "ComboBox", "TListBox", "ListBox"}:
+                item["items"] = control.texts()
+            result.append(item)
+    return result
+
+
+def _capture(window: Any, path: Path) -> Any:
+    """PrintWindow renders only the owned window, even on a hidden desktop."""
+    from ctypes import wintypes
+
+    import win32gui  # type: ignore[import-not-found]
+    import win32ui  # type: ignore[import-not-found]
+    from PIL import Image
+
+    left, top, right, bottom = win32gui.GetWindowRect(window.handle)
+    width, height = right - left, bottom - top
+    if not 0 < width * height <= 16_000_000:
+        raise HeadlessGuiError("Native capture dimensions exceed the bound")
+    window_dc = win32gui.GetWindowDC(window.handle)
+    source_dc = win32ui.CreateDCFromHandle(window_dc)
+    memory_dc = source_dc.CreateCompatibleDC()
+    bitmap = win32ui.CreateBitmap()
+    try:
+        bitmap.CreateCompatibleBitmap(source_dc, width, height)
+        memory_dc.SelectObject(bitmap)
+        windll = ctypes.windll
+        render = windll.user32.PrintWindow
+        render.argtypes = [wintypes.HWND, wintypes.HDC, wintypes.UINT]
+        render.restype = wintypes.BOOL
+        rendered = render(window.handle, memory_dc.GetSafeHdc(), 0)
+        if not rendered:
+            raise HeadlessGuiError("Native window refused off-screen rendering")
+        image = Image.frombuffer(
+            "RGB", (width, height), bitmap.GetBitmapBits(True), "raw", "BGRX", 0, 1
+        )
+        image.save(path)
+        return image
+    finally:
+        win32gui.DeleteObject(bitmap.GetHandle())
+        memory_dc.DeleteDC()
+        source_dc.DeleteDC()
+        win32gui.ReleaseDC(window.handle, window_dc)
+
+
+def _texts(window: Any, app: Any) -> list[str]:
+    texts = [str(window.window_text())]
+    texts.extend(str(control.window_text()) for control in window.descendants()[:256])
+    # UIA may expose labels which have no HWND in a Delphi dialog.
+    with suppress(Exception):
+        uia = _pywinauto_application()(backend="uia").connect(process=app.process)
+        texts.extend(
+            str(control.window_text())
+            for control in uia.window(handle=window.handle).descendants()[:256]
+        )
+    return list(dict.fromkeys(text.strip() for text in texts if text.strip()))
+
+
+def _click_caption(window: Any, caption: str) -> None:
+    matches = [
+        control
+        for control in window.descendants()
+        if control.window_text().replace("&", "").strip().casefold() == caption.casefold()
+        and control.is_visible()
+        and control.is_enabled()
+    ]
+    if len(matches) != 1:
+        raise HeadlessGuiError(f"Native control not uniquely resolved: {caption}")
+    # click uses WM_* messages; click_input is deliberately never used.
+    matches[0].click()
+
+
+def _save_as(app: Any, window: Any, target: Path, timeout: float, *, xml: bool) -> None:
+    if target.exists():
+        raise HeadlessGuiError("Native output must not overwrite an existing file")
+    _post_menu_item(window, window.menu_item("#0->#4"))
+    dialog = _dialog(app, timeout, "#32770")
+    if xml:
+        _save_dialog_as_xml(int(dialog.handle), target)
+    else:
+        _save_filename(dialog, target, native_extension=target.suffix)
+    _wait_for_export(app, target, timeout)
+
+
+def _save_filename(dialog: Any, target: Path, *, native_extension: str | None = None) -> None:
+    import win32gui  # type: ignore[import-not-found]
+    from pywinauto.controls.hwndwrapper import HwndWrapper
+
+    edit, combo = _save_dialog_controls(int(dialog.handle))
+    if native_extension is not None:
+        from pywinauto.controls.win32_controls import ComboBoxWrapper
+
+        wrapper = ComboBoxWrapper(combo)
+        choices = wrapper.texts()[1:]
+        matching = [
+            index
+            for index, name in enumerate(choices)
+            if "xml" not in name.casefold() and f"*{native_extension}" in name.casefold()
+        ]
+        if len(matching) != 1:
+            raise HeadlessGuiError(f"Native file format not unique: {choices}")
+        wrapper.select(matching[0])
+    HwndWrapper(edit).set_window_text(str(target))
+    win32gui.PostMessage(int(dialog.handle), 0x0111, 1, 0)
+
+
+def _native_export(app: Any, window: Any, output: Path, timeout: float) -> dict[str, Any]:
+    import win32gui  # type: ignore[import-not-found]
+
+    _post_menu_item(window, window.menu_item("#0->#9->#4"))  # observed 5.3.0.3 Export/Gerber X2
+    dialog = _dialog(app, timeout, "TExpForm")
+    _dump(output / "gerber-controls.json", {"controls": _controls(dialog)})
+    _capture(dialog, output / "gerber-dialog.png")
+    _click_caption(dialog, "Metric")
+    _click_caption(dialog, "Export All")
+    popup = _dialog(app, timeout, "#32768")
+    menu = win32gui.SendMessage(popup.handle, 0x01E1, 0, 0)  # MN_GETHMENU
+    if not menu or win32gui.GetMenuItemCount(menu) != 3:
+        raise HeadlessGuiError("Unexpected native Export All popup")
+    command = win32gui.GetMenuItemID(menu, 1)  # ZIP: Gerber + NC Drill
+    win32gui.PostMessage(dialog.handle, 0x001F, 0, 0)  # WM_CANCELMODE: dismiss owned popup
+    win32gui.PostMessage(dialog.handle, 0x0111, command, 0)
+    save = _dialog(app, timeout, "#32770")
+    _save_filename(save, output / "native-fabrication.zip")
+    _wait_for_export(app, output / "native-fabrication.zip", timeout)
+    _post_window_message(dialog.handle, 0x0010)
+    return {
+        "exporter": "DipTrace Gerber X2 + NC Drill ZIP",
+        "ui_profile": PROFILE,
+        "units_requested": "mm",
+        "origin": "native_export_settings_recorded_in_capture",
+    }
+
+
+def _worker(request: NativeCadRequest, desktop: str) -> dict[str, Any]:
+    if thread_desktop_name() != desktop:
+        raise HeadlessGuiError("Worker desktop does not match its isolated launch")
+    source = DipTraceDocument.load(request.source, 64 * 1024 * 1024)
+    if source.sha256 != request.expected_sha256:
+        raise HeadlessGuiError("Native source hash is stale")
+    if source.kind not in EXTENSIONS:
+        raise HeadlessGuiError("Unsupported native editor")
+    executable_name, xml_extension, binary_extension = EXTENSIONS[source.kind]
+    executable = request.diptrace_root / executable_name
+    import win32api  # type: ignore[import-not-found]
+
+    version_info = win32api.GetFileVersionInfo(str(executable), "\\")
+    ms, ls = version_info["FileVersionMS"], version_info["FileVersionLS"]
+    version = ".".join(str(value) for value in (ms >> 16, ms & 65535, ls >> 16, ls & 65535))
+    if version != "5.3.0.3":
+        raise HeadlessGuiError(f"Unsupported native UI build {version}; expected 5.3.0.3")
+    output = request.output_dir
+    working = output / ("input" + xml_extension)
+    working.write_bytes(source.raw_bytes)
+    binary = output / ("saved" + binary_extension)
+    reexport = output / ("reexport" + xml_extension)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "source_sha256": source.sha256,
+        "source_type": source.source_type,
+        "ui_profile": PROFILE,
+        "version": version,
+        "executable_sha256": sha256_bytes(executable.read_bytes()),
+        "desktop": desktop,
+        "steps": [],
+        "drc_status": "not_applicable" if source.kind != "pcb" else "not_run",
+        "completed": False,
+        "fabrication_approved": False,
+    }
+    app: Any = None
+    try:
+        for phase, opened in (("open_save_close", working), ("reopen_reexport", binary)):
+            app = _pywinauto_application()(backend="win32").start(
+                subprocess.list2cmdline([str(executable), str(opened)]),
+                timeout=request.timeout_seconds,
+            )
+            window = _main_window(app, opened, request.timeout_seconds)
+            report["steps"].append({"step": phase, "pid": int(app.process)})
+            if phase == "open_save_close":
+                _save_as(app, window, binary, request.timeout_seconds, xml=False)
+            else:
+                if source.kind == "pcb":
+                    _post_menu_item(window, window.menu_item("#3->#14"))
+                    _post_menu_item(window, window.menu_item("#7->#0"))
+                    dialog = _dialog(app, request.timeout_seconds, "TFMyMessage", "TForm60")
+                    report["drc_texts"] = _texts(dialog, app)
+                    report["drc_dialog_class"] = dialog.class_name()
+                    _capture(dialog, output / "drc.png")
+                    report["drc_status"] = (
+                        "pass"
+                        if any(
+                            text.casefold() in {"no errors", "no errors found"}
+                            for text in report["drc_texts"]
+                        )
+                        else "fail"
+                        if dialog.class_name() == "TForm60"
+                        else "visual_review_required"
+                    )
+                    _post_window_message(dialog.handle, 0x0010)
+                _save_as(app, window, reexport, request.timeout_seconds, xml=True)
+                if request.export_manufacturing:
+                    if source.kind != "pcb":
+                        raise HeadlessGuiError("Manufacturing export requires PCB")
+                    report["manufacturing"] = _native_export(
+                        app, window, output, request.timeout_seconds
+                    )
+            _post_window_message(int(window.handle), 0x0010)
+            app.wait_for_process_exit(timeout=15)
+            app = None
+        report["reexport_sha256"] = sha256_bytes(reexport.read_bytes())
+        report["binary_sha256"] = sha256_bytes(binary.read_bytes())
+        report["completed"] = True
+    except Exception as exc:
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        if app is not None:
+            report["windows"] = []
+            for window in app.windows(visible_only=True):
+                if window.class_name() != "TApplication":
+                    with suppress(Exception):
+                        report["windows"].append(
+                            {
+                                "title": window.window_text(),
+                                "class": window.class_name(),
+                                "controls": _controls(window),
+                            }
+                        )
+                        _capture(
+                            window,
+                            output / ("failed-" + window.class_name().replace("#", "") + ".png"),
+                        )
+    finally:
+        if app is not None:
+            with suppress(Exception):
+                app.kill(soft=False)
+        _dump(output / "native-result.json", report)
+    return report
+
+
+def run_native_cad(request: NativeCadRequest) -> dict[str, Any]:
+    if os.name != "nt":
+        raise HeadlessGuiError("Native CAD adapter currently requires Windows")
+    request = request.model_copy(
+        update={
+            "source": request.source.resolve(),
+            "output_dir": request.output_dir.resolve(),
+            "diptrace_root": request.diptrace_root.resolve(),
+        }
+    )
+    if request.output_dir.exists():
+        raise HeadlessGuiError("Native output directory must be new")
+    source_sha = DipTraceDocument.load(request.source, 64 * 1024 * 1024).sha256
+    if source_sha != request.expected_sha256:
+        raise HeadlessGuiError("Native input hash is stale")
+    request.output_dir.mkdir(parents=True)
+    name = "DipTracePlatform-" + uuid.uuid4().hex[:16]
+    before = input_desktop_name()
+    request_file = request.output_dir / "request.json"
+    _dump(request_file, request.model_dump(mode="json"))
+    start_signal = request.output_dir / "worker-start"
+    with HiddenDesktop(name) as hidden:
+        argv = [
+            sys.executable,
+            "-m",
+            "diptrace_mcp.native_cad",
+            "--worker",
+            str(request_file),
+            "--desktop",
+            name,
+        ]
+        with hidden.launch(argv) as child:
+            job = KillOnCloseJob.create()
+            try:
+                job.assign(child.pid)
+                start_signal.write_text("start", encoding="ascii")
+                code = child.wait(request.timeout_seconds + 30)
+                if code is None:
+                    raise HeadlessGuiError("Native CAD worker timeout")
+            finally:
+                job.terminate_and_close()
+    result_path = request.output_dir / "native-result.json"
+    if not result_path.is_file():
+        raise HeadlessGuiError("Native worker did not produce evidence")
+    if result_path.stat().st_size > 2 * 1024 * 1024:
+        raise HeadlessGuiError("Native evidence exceeds size limit")
+    report = json.loads(result_path.read_text(encoding="utf-8"))
+    report["worker_exit_code"] = code
+    report["input_desktop_unchanged"] = input_desktop_name() == before
+    report["source_unchanged"] = sha256_bytes(request.source.read_bytes()) == source_sha
+    if code != 0 or not report["input_desktop_unchanged"] or not report["source_unchanged"]:
+        report["completed"] = False
+        report["error"] = "Native isolation invariant failed"
+    _dump(result_path, report)
+    return dict(report)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", type=Path, required=True)
+    parser.add_argument("--desktop", required=True)
+    args = parser.parse_args()
+    request = NativeCadRequest.model_validate_json(args.worker.read_bytes())
+    # No CAD process starts before the parent has assigned its kill-on-close Job.
+    deadline = time.monotonic() + 15
+    while not (request.output_dir / "worker-start").is_file():
+        if time.monotonic() >= deadline:
+            raise HeadlessGuiError("Parent failed to establish process ownership")
+        time.sleep(0.05)
+    report = _worker(request, args.desktop)
+    raise SystemExit(0 if report["completed"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/diptrace_mcp/pcb_whole_board.py
+++ b/src/diptrace_mcp/pcb_whole_board.py
@@ -4,7 +4,6 @@ import difflib
 import hashlib
 import json
 import math
-import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -78,7 +77,7 @@ class PCBWholeBoardResult:
 
 def _rectangular_outline_box(document: DipTraceDocument) -> BBox | None:
     points = document.container.findall("./BoardOutline/Points/Point")
-    if len(points) != 4:
+    if len(points) != 4 or any(set(point.attrib) - {"X", "Y"} for point in points):
         return None
     coordinates = [
         Point(
@@ -93,6 +92,11 @@ def _rectangular_outline_box(document: DipTraceDocument) -> BBox | None:
     ys = sorted(set(point.y for point in coordinates))
     if len(xs) != 2 or len(ys) != 2:
         return None
+    # Four corner coordinates alone do not prove a rectangle: a bowtie has
+    # the same extrema. Every successive edge must be nonzero and axis-aligned.
+    for first, second in zip(coordinates, coordinates[1:] + coordinates[:1], strict=True):
+        if (first.x == second.x) == (first.y == second.y):
+            return None
     return BBox(xs[0], ys[0], xs[1], ys[1])
 
 
@@ -107,7 +111,13 @@ def compact_rectangular_board_outline(
 
     if document.kind != "pcb":
         raise EditError("Board-outline compaction requires a PCB document")
-    if margin_mm < 0.0 or minimum_width_mm <= 0.0 or minimum_height_mm <= 0.0:
+    dimensions = (margin_mm, minimum_width_mm, minimum_height_mm)
+    if (
+        not all(math.isfinite(value) for value in dimensions)
+        or margin_mm < 0.0
+        or minimum_width_mm <= 0.0
+        or minimum_height_mm <= 0.0
+    ):
         raise EditError("Board-outline compaction dimensions are invalid")
     outline = document.container.find("./BoardOutline")
     before = _rectangular_outline_box(document)
@@ -121,7 +131,14 @@ def compact_rectangular_board_outline(
         + snapshot.board.keepouts
         + snapshot.board.testpoints
         + snapshot.board.traces
+        + snapshot.board.vias
+        + snapshot.board.copper_pours
+        + snapshot.board.texts
     )
+    # Cutouts and unbounded physical objects need a mechanical review, not a
+    # guessed rectangular crop. Existing pours/markings/via annuli also occupy space.
+    if snapshot.board.cutouts or any(item.bbox is None for item in records):
+        return document, False, before.as_dict(), None
     boxes = [BBox(**item.bbox) for item in records if item.bbox is not None]
     if not boxes:
         return document, False, before.as_dict(), before.as_dict()
@@ -140,6 +157,11 @@ def compact_rectangular_board_outline(
         center.x + width / 2.0,
         center.y + height / 2.0,
     )
+    if (
+        after.min_x < before.min_x or after.min_y < before.min_y
+        or after.max_x > before.max_x or after.max_y > before.max_y
+    ):
+        return document, False, before.as_dict(), None
     if all(
         math.isclose(first, second, abs_tol=1e-9)
         for first, second in zip(
@@ -154,25 +176,21 @@ def compact_rectangular_board_outline(
     raw_tree = RawTreeSnapshot.capture(working)
     points = working.container.find("./BoardOutline/Points")
     assert points is not None
-    points.clear()
-
     def unit(value: float) -> str:
         return f"{from_mm(value, working.units):.9g}"
 
-    for point in (
-        Point(after.min_x, after.min_y),
-        Point(after.max_x, after.min_y),
-        Point(after.max_x, after.max_y),
-        Point(after.min_x, after.max_y),
-    ):
-        ET.SubElement(points, "Point", {"X": unit(point.x), "Y": unit(point.y)})
+    # Update existing corners in place: preserve winding, corner order, point
+    # container metadata and raw XML outside the coordinate changes.
+    for point in points.findall("./Point"):
+        x = to_mm(float(point.get("X", "nan")), working.units)
+        y = to_mm(float(point.get("Y", "nan")), working.units)
+        point.set("X", unit(after.min_x if x == before.min_x else after.max_x))
+        point.set("Y", unit(after.min_y if y == before.min_y else after.max_y))
     compiled = raw_tree.compile(working.root, working.path)
-    return (
-        DipTraceDocument.from_bytes(working.path, compiled),
-        True,
-        before.as_dict(),
-        after.as_dict(),
-    )
+    result = DipTraceDocument.from_bytes(working.path, compiled)
+    serialized_box = _rectangular_outline_box(result)
+    assert serialized_box is not None
+    return result, True, before.as_dict(), serialized_box.as_dict()
 
 
 def _ground_name(document: DipTraceDocument, requested: str | None) -> str | None:
@@ -248,8 +266,8 @@ def optimize_pcb_whole_board(
         )
         if outline_after is None:
             warnings.append(
-                "Outline compaction was skipped because the outline is locked or "
-                "not a simple rectangle."
+                "Outline compaction was skipped: locked/unsupported outline, cutouts, "
+                "incomplete occupied bounds, or required expansion needs mechanical review."
             )
 
     ground = _ground_name(working, config.ground_net)

--- a/src/diptrace_mcp/pin_mapping.py
+++ b/src/diptrace_mcp/pin_mapping.py
@@ -1,0 +1,96 @@
+"""Resolve explicit cached symbol-pin/footprint-pad bindings, never pin order guesses."""
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from collections import Counter
+
+from .xml_document import DipTraceDocument
+
+
+def part_pin_pad_numbers(
+    part: ET.Element, pattern: ET.Element
+) -> tuple[dict[int, str], list[str]]:
+    """Validate PadId/PadIndex and PadNumber as a pair against one pattern."""
+    errors: list[str] = []
+    pads: dict[str, str] = {}
+    for pad in pattern.findall("./Pads/Pad"):
+        identity = pad.get("Id", "")
+        number = (pad.findtext("./Number") or pad.get("Number") or "").strip()
+        if not identity or not number or identity in pads:
+            errors.append("pattern pad identity is incomplete or ambiguous")
+        pads[identity] = number
+    if errors:
+        return {}, errors
+    result: dict[int, str] = {}
+    for index, pin in enumerate(part.findall("./Pins/Pin")):
+        target_id = pin.get("PadId", pin.get("PadIndex"))
+        number = (pin.findtext("./PadNumber") or "").strip()
+        label = (pin.findtext("./Name") or pin.get("Id") or str(index)).strip()
+        if target_id is None or not number:
+            errors.append(f"pin {label}: mapping is incomplete")
+        elif pin.get("PadId") is not None and pin.get("PadIndex", target_id) != target_id:
+            errors.append(f"pin {label}: conflicting PadId/PadIndex")
+        elif target_id not in pads:
+            errors.append(f"pin {label}: PadId {target_id!r} is absent")
+        elif pads[target_id] != number:
+            errors.append(
+                f"pin {label}: PadNumber {number!r} does not match "
+                f"PadId {target_id!r} ({pads[target_id]!r})"
+            )
+        else:
+            result[index] = number
+    # Do not partially certify a section with inconsistent library data.
+    return ({}, errors) if errors else (result, [])
+
+
+def schematic_pin_pad_numbers(document: DipTraceDocument) -> dict[tuple[str, int], str]:
+    """Resolve only exact embedded cache bindings; missing/ambiguous data stays absent.
+
+    CompTypeN selects a cache component by position; ComponentPart selects its
+    section. Schematic Pin indices are section-local, not physical pad IDs.
+    External libraries, name similarity and datasheet interpretation belong to
+    the caller, not to this resolver.
+    """
+    if document.kind != "schematic":
+        return {}
+    libraries = document.root.findall("./Library[@Type='DipTrace-ComponentLibrary']")
+    if len(libraries) != 1:
+        return {}
+    library = libraries[0]
+    components = library.findall("./Components/Component")
+    patterns: dict[str, list[ET.Element]] = {}
+    for pattern in library.findall(
+        "./Library[@Type='DipTrace-PatternLibrary']/Patterns/Pattern"
+    ):
+        patterns.setdefault(pattern.get("PatternStyle", ""), []).append(pattern)
+    parts = document.container.findall("./Components/Part")
+    id_counts = Counter(part.get("Id", "") for part in parts)
+    result: dict[tuple[str, int], str] = {}
+    for part in parts:
+        identity = part.get("Id", "")
+        match = re.fullmatch(r"CompType(\d+)", part.get("ComponentStyle", ""))
+        section_text = part.get("ComponentPart", "")
+        if not identity or id_counts[identity] != 1 or match is None or not section_text.isdigit():
+            continue
+        component_index, section_index = int(match[1]), int(section_text)
+        if component_index >= len(components):
+            continue
+        component = components[component_index]
+        if component.get("Id", str(component_index)) != str(component_index):
+            continue
+        sections = component.findall("./Part")
+        if section_index >= len(sections):
+            continue
+        section = sections[section_index]
+        if len(section.findall("./Pins/Pin")) != len(part.findall("./Pins/Pin")):
+            continue
+        attachment = section.find("./Pattern")
+        style = attachment.get("Style", "") if attachment is not None else ""
+        candidates = patterns.get(style, [])
+        if not style or len(candidates) != 1:
+            continue
+        mapping, errors = part_pin_pad_numbers(section, candidates[0])
+        if not errors:
+            result.update({(identity, index): number for index, number in mapping.items()})
+    return result

--- a/src/diptrace_mcp/pin_mapping.py
+++ b/src/diptrace_mcp/pin_mapping.py
@@ -1,7 +1,6 @@
 """Resolve explicit cached symbol-pin/footprint-pad bindings, never pin order guesses."""
 from __future__ import annotations
 
-import re
 import xml.etree.ElementTree as ET
 from collections import Counter
 
@@ -58,7 +57,16 @@ def schematic_pin_pad_numbers(document: DipTraceDocument) -> dict[tuple[str, int
     if len(libraries) != 1:
         return {}
     library = libraries[0]
-    components = library.findall("./Components/Component")
+    # Literal identities avoid coercing Unicode digits or oversized integers
+    # from untrusted XML into apparently valid native cache indices.
+    sections_by_style = {
+        f"CompType{index}": {
+            str(section_index): section
+            for section_index, section in enumerate(component.findall("./Part"))
+        }
+        for index, component in enumerate(library.findall("./Components/Component"))
+        if component.get("Id", str(index)) == str(index)
+    }
     patterns: dict[str, list[ET.Element]] = {}
     for pattern in library.findall(
         "./Library[@Type='DipTrace-PatternLibrary']/Patterns/Pattern"
@@ -69,20 +77,13 @@ def schematic_pin_pad_numbers(document: DipTraceDocument) -> dict[tuple[str, int
     result: dict[tuple[str, int], str] = {}
     for part in parts:
         identity = part.get("Id", "")
-        match = re.fullmatch(r"CompType(\d+)", part.get("ComponentStyle", ""))
-        section_text = part.get("ComponentPart", "")
-        if not identity or id_counts[identity] != 1 or match is None or not section_text.isdigit():
+        if not identity or id_counts[identity] != 1:
             continue
-        component_index, section_index = int(match[1]), int(section_text)
-        if component_index >= len(components):
+        section = sections_by_style.get(part.get("ComponentStyle", ""), {}).get(
+            part.get("ComponentPart", "")
+        )
+        if section is None:
             continue
-        component = components[component_index]
-        if component.get("Id", str(component_index)) != str(component_index):
-            continue
-        sections = component.findall("./Part")
-        if section_index >= len(sections):
-            continue
-        section = sections[section_index]
         if len(section.findall("./Pins/Pin")) != len(part.findall("./Pins/Pin")):
             continue
         attachment = section.find("./Pattern")

--- a/src/diptrace_mcp/release_readiness.py
+++ b/src/diptrace_mcp/release_readiness.py
@@ -11,18 +11,7 @@ from collections import Counter
 from typing import Any
 
 from .adapters import DocumentSnapshot
-
-_DNP_TRUE = {"1", "true", "yes", "y"}
-_MPN_KEYS = ("mpn", "manufacturer part number", "manufacturer_part_number")
-
-
-def _fields(item: Any) -> dict[str, str]:
-    raw = item.attributes.get("additional_fields", {})
-    return {str(key).casefold(): str(value).strip() for key, value in raw.items()}
-
-
-def _is_dnp(item: Any) -> bool:
-    return _fields(item).get("dnp", "").casefold() in _DNP_TRUE
+from .bom import extract_bom
 
 
 def _finding(
@@ -56,9 +45,26 @@ def run_release_readiness(snapshot: DocumentSnapshot) -> dict[str, Any]:
         }
 
     components = list(snapshot.board.components)
-    populated = [item for item in components if not _is_dnp(item)]
+    # One population/procurement interpretation for BOM, placement and readiness.
+    bom_by_object = {
+        object_id: record
+        for record in extract_bom(snapshot)
+        for object_id in record.source_object_ids
+    }
+    populated = [item for item in components if not bom_by_object[item.stable_id].dnp]
     metrics["components"] = len(components)
     metrics["populated_components"] = len(populated)
+
+    for item in populated:
+        if not (item.refdes or "").strip():
+            findings.append(
+                _finding(
+                    "release.missing_refdes",
+                    "error",
+                    "A populated component has no reference designator for assembly matching.",
+                    object_ids=[item.stable_id],
+                )
+            )
 
     refdes_counts = Counter((item.refdes or "").casefold() for item in components if item.refdes)
     duplicate_refdes = {value for value, count in refdes_counts.items() if count > 1}
@@ -108,11 +114,9 @@ def run_release_readiness(snapshot: DocumentSnapshot) -> dict[str, Any]:
 
     missing_procurement_identity = []
     for item in populated:
-        fields = _fields(item)
-        mpn = next((fields[key] for key in _MPN_KEYS if fields.get(key)), "")
-        manufacturer = fields.get("manufacturer") or str(
-            item.attributes.get("manufacturer", "")
-        ).strip()
+        record = bom_by_object[item.stable_id]
+        mpn = record.mpn
+        manufacturer = record.manufacturer
         if not mpn or not manufacturer:
             missing_procurement_identity.append(item)
             findings.append(

--- a/src/diptrace_mcp/synchronization.py
+++ b/src/diptrace_mcp/synchronization.py
@@ -10,6 +10,7 @@ from .domain import StrictModel
 from .errors import AmbiguousSelectorError, DocumentError, EditError, ObjectNotFoundError
 from .numeric_inputs import xml_integer, xml_number_mm
 from .operations import SyncSchematicToPcbOperation
+from .pin_mapping import schematic_pin_pad_numbers
 from .xml_document import DipTraceDocument
 
 _MM_FIELD_DESCRIPTION = "Distance in millimetres."
@@ -257,6 +258,7 @@ def build_sync_plan(
     row_min_y = float("-inf")
     component_specs: list[dict[str, Any]] = []
     pin_to_pad: dict[tuple[str, int], tuple[str, str]] = {}
+    cached_pin_map = schematic_pin_pad_numbers(schematic)
     copied_patterns: dict[str, str] = {}
     copied_pad_styles: dict[str, str] = {}
     warnings: list[str] = []
@@ -360,15 +362,9 @@ def build_sync_plan(
             ]
         elif pattern_entry is not None:
             pad_numbers = _pattern_pad_numbers(pattern_entry[1])
-        elif len(parts) == 1:
-            pad_numbers = [str(index + 1) for index, _ in enumerate(parts[0].findall("./Pins/Pin"))]
-            warnings.append(
-                f"{refdes}: pad numbers were inferred from single-part pin order because "
-                f"pattern {pattern_style!r} was not available"
-            )
         else:
             raise EditError(
-                f"Pad numbers are required for multi-part component {refdes}",
+                f"Explicit pad numbers or an embedded pattern are required for {refdes}",
                 details={"refdes": refdes},
             )
         if not pad_numbers:
@@ -390,18 +386,15 @@ def build_sync_plan(
                 if pad_number.casefold() not in {item.casefold() for item in pad_numbers}:
                     raise EditError(f"Pin map for {refdes} references missing pad {pad_number}")
                 pin_to_pad[(part_id, pin_index)] = (refdes, pad_number)
-        elif len(parts) == 1:
-            pins = parts[0].findall("./Pins/Pin")
-            if len(pins) > len(pad_numbers):
-                raise EditError(
-                    f"Component {refdes} has more schematic pins than PCB pads",
-                    details={"pins": len(pins), "pads": len(pad_numbers)},
-                )
-            for pin_index in range(len(pins)):
-                pin_to_pad[(parts[0].get("Id", ""), pin_index)] = (
-                    refdes,
-                    pad_numbers[pin_index],
-                )
+        else:
+            # Pin indices are local to symbol sections. Never guess that pin N
+            # corresponds to the Nth footprint pad, even for a single-part IC.
+            for part in parts:
+                for pin_index, _ in enumerate(part.findall("./Pins/Pin")):
+                    pin_key = (part.get("Id", ""), pin_index)
+                    number = cached_pin_map.get(pin_key)
+                    if number is not None and number in pad_numbers:
+                        pin_to_pad[pin_key] = (refdes, number)
 
         fields: dict[str, str] = {}
         for part in parts:
@@ -453,15 +446,22 @@ def build_sync_plan(
 
     nets: list[dict[str, Any]] = []
     endpoint_owner: dict[tuple[str, str], str] = {}
+    net_names: set[str] = set()
+    net_ids: set[str] = set()
     for net in schematic.container.findall("./Nets/Net"):
         name = _text(net, "Name")
         if not name:
             raise EditError("Every synchronized schematic net requires a name")
+        net_id = net.get("Id", "")
+        if name.casefold() in net_names or not net_id or net_id in net_ids:
+            raise EditError("Synchronized nets require unique names and nonempty unique IDs")
+        net_names.add(name.casefold())
+        net_ids.add(net_id)
         endpoints: list[dict[str, str]] = []
         for item in net.findall("./Pins/Item"):
             part_id = item.get("Part", "")
             pin_text = item.get("Pin", "")
-            if not pin_text.isdigit():
+            if not pin_text.isascii() or not pin_text.isdecimal():
                 raise EditError(f"Net {name} has an invalid pin index: {pin_text!r}")
             pin_key = (part_id, int(pin_text))
             endpoint = pin_to_pad.get(pin_key)
@@ -471,6 +471,14 @@ def build_sync_plan(
                 raise EditError(
                     f"Pin-to-pad mapping is required for {refdes} part {part_id} pin {pin_text}",
                     details={"net": name, "part_id": part_id, "pin": int(pin_text)},
+                )
+            pin_element = parts_by_id[part_id].findall("./Pins/Pin")[int(pin_text)]
+            if (
+                pin_element.get("NetId", net_id) != net_id
+                or pin_element.get("NotConnected") == "Y"
+            ):
+                raise EditError(
+                    f"Schematic pin {part_id}:{pin_text} contradicts net membership or no-connect"
                 )
             endpoint_key = (endpoint[0].casefold(), endpoint[1].casefold())
             previous_net = endpoint_owner.setdefault(endpoint_key, name)
@@ -511,7 +519,7 @@ def build_sync_plan(
         operation=operation,
         warnings=warnings,
         limitations=[
-            "Multi-part components require explicit part-id/pin to pad-number mappings.",
+            "Connected pins require verified embedded bindings or explicit part-id/pin mappings.",
             (
                 "Exact reconciliation covers components, net endpoint sets, and traces on "
                 "changed nets; derived ratline cache is invalidated when connectivity changes. "

--- a/tests/test_advanced_review.py
+++ b/tests/test_advanced_review.py
@@ -166,7 +166,8 @@ def test_schematic_pcb_comparison_is_structured() -> None:
     assert result["components"]["schematic_count"] == 2
     assert result["components"]["pcb_count"] == 2
     assert result["difference_count"] >= 1
-    assert result["confidence"] == "medium"
+    assert result["confidence"] == "low"
+    assert result["comparison_complete"] is False
 
 
 def test_advanced_service_contract(tmp_path: Path) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -54,3 +54,92 @@ def test_release_manifest_is_explicitly_not_native_fabrication(tmp_path: Path) -
 
     with pytest.raises(CapabilityUnavailableError):
         service.export_fabrication_outputs("board.xml", request_native_outputs=True)
+
+
+@pytest.mark.parametrize("include_dnp", [False, True])
+@pytest.mark.parametrize("field,value", [("DNP", "dnp"), ("Populate", "no")])
+def test_assembly_population_is_consistent(
+    tmp_path: Path, include_dnp: bool, field: str, value: str
+) -> None:
+    import csv
+    import io
+
+    raw = (FIXTURES / "pcb.xml").read_bytes().replace(
+        b"<RefDes>R1</RefDes>",
+        (f"<RefDes>R1</RefDes><AddFields><AddField><Name>{field}</Name>"
+         f"<Text>{value}</Text></AddField></AddFields>").encode(),
+    )
+    service = _service(tmp_path, raw)
+    result = service.export_assembly_outputs("board.xml", include_dnp=include_dnp)
+    record = result["result"]["export"]
+    rows = {}
+    for name in ("bom.csv", "placement.csv"):
+        text = service.export_resource(record["export_id"], name)
+        rows[name] = list(csv.DictReader(io.StringIO(text)))
+    assert {row["RefDes"] for row in rows["placement.csv"]} == (
+        {"R1", "U1"} if include_dnp else {"U1"}
+    )
+    assert sum(int(row["Quantity"]) for row in rows["bom.csv"]) == len(rows["placement.csv"])
+    assert record["manifest"]["include_dnp"] is include_dnp
+
+
+def test_placement_negative_coordinates_remain_numbers(tmp_path: Path) -> None:
+    import csv
+    import io
+
+    raw = (FIXTURES / "pcb.xml").read_bytes().replace(b'X="10"', b'X="-10"')
+    service = _service(tmp_path, raw)
+    record = service.export_assembly_outputs("board.xml")["result"]["export"]
+    rows = list(csv.DictReader(io.StringIO(
+        service.export_resource(record["export_id"], "placement.csv")
+    )))
+    assert float(rows[0]["X_mm"]) == -10.0
+
+
+@pytest.mark.parametrize("value", ["=cmd", " +cmd", "\t@cmd", "\r-cmd", "-1+2"])
+def test_csv_text_is_formula_safe_without_corrupting_numbers(value: str) -> None:
+    from diptrace_mcp.exports import _safe_csv
+
+    assert _safe_csv(value) == "'" + value
+    assert _safe_csv(-1.25) == "-1.25"
+    assert _safe_csv(-90) == "-90"
+
+
+def test_release_bundle_has_source_bound_preflight_and_artifact_digests(tmp_path: Path) -> None:
+    import hashlib
+    import json
+
+    service = _service(tmp_path)
+    record = service.export_assembly_outputs("board.xml")["result"]["export"]
+    manifest = record["manifest"]
+    export_id = record["export_id"]
+    preflight = json.loads(service.export_resource(export_id, "preflight.json"))
+    assert preflight["source_sha256"] == record["source_sha256"]
+    assert preflight["status"] == "blocked"  # The synthetic board has an explicit ratline.
+    assert preflight["native_acceptance"] == "not_run"
+    assert preflight["manual_gates"]
+    assert manifest["preflight_status"] == preflight["status"]
+    for name, identity in manifest["artifact_integrity"].items():
+        payload = service.export_resource(export_id, name).encode("utf-8")
+        assert identity == {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+    assert set(manifest["artifact_integrity"]) == set(record["artifacts"]) - {"manifest.json"}
+    assert (tmp_path / "project" / "board.xml").read_bytes() == (FIXTURES / "pcb.xml").read_bytes()
+
+
+
+@pytest.mark.parametrize("name", ["placement.csv", "preflight.json", "manifest.json"])
+def test_release_artifact_tampering_is_detected(tmp_path: Path, name: str) -> None:
+    service = _service(tmp_path)
+    record = service.export_assembly_outputs("board.xml")["result"]["export"]
+    artifact = tmp_path / "state" / "exports" / record["export_id"] / name
+    artifact.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="integrity check failed"):
+        service.export_resource(record["export_id"], name)
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_csv_rejects_non_finite_numbers(value: float) -> None:
+    from diptrace_mcp.exports import _safe_csv
+
+    with pytest.raises(ValueError, match="finite"):
+        _safe_csv(value)

--- a/tests/test_library_mutation.py
+++ b/tests/test_library_mutation.py
@@ -177,3 +177,32 @@ def test_pin_mapping_requires_id_and_number_together() -> None:
             number="1",
             pad_id="0",
         )
+
+
+
+def test_pin_mapping_rejects_crossed_id_number_pair() -> None:
+    document = _document("component_library.xml")
+    raw = document.raw_bytes.replace(b'PadId="0"', b'PadId="1"', 1)
+    mutated = DipTraceDocument.from_bytes(document.path, raw)
+    errors = validate_explicit_pin_pad_mapping(mutated, "RES_0603")
+    assert any("does not match" in message for message in errors)
+
+
+def test_pin_mapping_rejects_ambiguous_pattern_identity() -> None:
+    import xml.etree.ElementTree as ET
+
+    document = _document("component_library.xml")
+    root = ET.fromstring(document.raw_bytes)
+    patterns = root.find("./Library/Patterns")
+    assert patterns is not None
+    patterns.append(ET.fromstring(ET.tostring(patterns[0])))
+    mutated = DipTraceDocument.from_bytes(document.path, ET.tostring(root))
+    assert validate_explicit_pin_pad_mapping(mutated, "RES_0603")
+
+
+def test_pin_mapping_accepts_documented_padindex_alias() -> None:
+    document = _document("component_library.xml")
+    mutated = DipTraceDocument.from_bytes(
+        document.path, document.raw_bytes.replace(b"PadId=", b"PadIndex=")
+    )
+    assert validate_explicit_pin_pad_mapping(mutated, "RES_0603") == []

--- a/tests/test_pcb_quality.py
+++ b/tests/test_pcb_quality.py
@@ -198,3 +198,64 @@ def test_guarded_whole_board_plan_binds_preview_identity_and_stale_sha(tmp_path:
             dry_run=True,
             expected_sha256=document.sha256,
         )
+
+
+def test_compaction_preserves_freestanding_via_and_existing_silkscreen() -> None:
+    root = ET.fromstring(_via_in_pad_document().raw_bytes)
+    via = root.find("./Board/Components/Component[@Type='Via']")
+    assert via is not None
+    via.set("X", "40")
+    via.set("Y", "25")
+    document = DipTraceDocument.from_bytes(Path("via-edge.xml"), ET.tostring(root))
+    compacted, _, _, _ = compact_rectangular_board_outline(document)
+    snapshot = build_snapshot(compacted)
+    assert snapshot.board is not None and snapshot.board.outline is not None
+    boundary = snapshot.board.outline["bbox"]
+    for item in [*snapshot.board.vias, *snapshot.board.texts]:
+        if item.bbox:
+            assert boundary["min_x"] <= item.bbox["min_x"]
+            assert item.bbox["max_x"] <= boundary["max_x"]
+            assert boundary["min_y"] <= item.bbox["min_y"]
+            assert item.bbox["max_y"] <= boundary["max_y"]
+
+
+def test_compaction_does_not_repair_bowtie_outline_by_guessing() -> None:
+    root = ET.fromstring(_document().raw_bytes)
+    points = root.find("./Board/BoardOutline/Points")
+    assert points is not None
+    points[1], points[2] = points[2], points[1]
+    document = DipTraceDocument.from_bytes(Path("bowtie.xml"), ET.tostring(root))
+    compacted, changed, _, _ = compact_rectangular_board_outline(document)
+    assert changed is False
+    assert compacted.raw_bytes == document.raw_bytes
+
+
+def test_compaction_preserves_point_container_metadata_and_winding() -> None:
+    root = ET.fromstring(_document().raw_bytes)
+    points = root.find("./Board/BoardOutline/Points")
+    assert points is not None
+    points.set("FutureMetadata", "preserve-me")
+    points[:] = list(reversed(points))
+    document = DipTraceDocument.from_bytes(Path("metadata.xml"), ET.tostring(root))
+    compacted, changed, _, _ = compact_rectangular_board_outline(document)
+    assert changed is True
+    result = compacted.container.find("./BoardOutline/Points")
+    assert result is not None and result.get("FutureMetadata") == "preserve-me"
+    assert float(result[0].get("Y", "0")) > float(result[-1].get("Y", "0"))
+
+
+def test_compaction_never_enlarges_the_mechanical_outline() -> None:
+    document = _document()
+    compacted, changed, _, _ = compact_rectangular_board_outline(document, minimum_width_mm=100)
+    assert changed is False
+    assert compacted.raw_bytes == document.raw_bytes
+
+
+def test_compaction_rejects_non_finite_dimensions() -> None:
+    import pytest
+
+    from diptrace_mcp.errors import EditError
+
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(EditError, match="dimensions"):
+            compact_rectangular_board_outline(_document(), margin_mm=value)

--- a/tests/test_pin_mapping.py
+++ b/tests/test_pin_mapping.py
@@ -147,9 +147,18 @@ def test_sync_uses_verified_cache_without_manual_mapping() -> None:
     assert plan.operation.nets[1].endpoints[0].pad_number == "2"
 
 
-@pytest.mark.parametrize("attribute,value", [("ComponentStyle", "CompType999"),
-                                            ("ComponentPart", "999"),
-                                            ("ComponentPart", "-1")])
+@pytest.mark.parametrize(
+    "attribute,value",
+    [
+        ("ComponentStyle", "CompType999"),
+        ("ComponentPart", "999"),
+        ("ComponentPart", "-1"),
+        pytest.param("ComponentPart", "²", id="non-decimal-digit"),
+        pytest.param("ComponentPart", "٠", id="non-native-digit"),
+        pytest.param("ComponentPart", "9" * 5000, id="oversized-section"),
+        pytest.param("ComponentStyle", "CompType" + "9" * 5000, id="oversized-style"),
+    ],
+)
 def test_invalid_cache_binding_is_not_guessed(attribute: str, value: str) -> None:
     roots = _pair()
     part = roots[0].find("./Schematic/Components/Part")

--- a/tests/test_pin_mapping.py
+++ b/tests/test_pin_mapping.py
@@ -1,0 +1,192 @@
+"""Synthetic regression data: not real-DipTrace acceptance evidence."""
+from __future__ import annotations
+
+import copy
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from diptrace_mcp.adapters import build_snapshot
+from diptrace_mcp.design_compare import compare_schematic_to_pcb
+from diptrace_mcp.pin_mapping import schematic_pin_pad_numbers
+from diptrace_mcp.scaffolding import build_pcb_document
+from diptrace_mcp.synchronization import ComponentSyncMapping, build_sync_plan
+from diptrace_mcp.xml_document import DipTraceDocument
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _pair() -> tuple[ET.Element, ET.Element]:
+    schematic = ET.fromstring((FIXTURES / "schematic.xml").read_bytes())
+    library = schematic.find("./Library")
+    assert library is not None
+    schematic.remove(library)
+    schematic.insert(0, ET.fromstring((FIXTURES / "component_library.xml").read_bytes()))
+    parts = schematic.find("./Schematic/Components")
+    assert parts is not None
+    for part in list(parts)[1:]:
+        parts.remove(part)
+    for net in schematic.findall("./Schematic/Nets/Net"):
+        pins = net.find("./Pins")
+        assert pins is not None
+        for item in list(pins)[1:]:
+            pins.remove(item)
+    pcb = ET.fromstring((FIXTURES / "pcb.xml").read_bytes())
+    components = pcb.find("./Board/Components")
+    assert components is not None
+    for component in list(components)[1:]:
+        components.remove(component)
+    for net in pcb.findall("./Board/Nets/Net"):
+        pads = net.find("./Pads")
+        assert pads is not None
+        for item in list(pads)[1:]:
+            pads.remove(item)
+    return schematic, pcb
+
+
+def _document(root: ET.Element) -> DipTraceDocument:
+    return DipTraceDocument.from_bytes(Path("synthetic.xml"), ET.tostring(root))
+
+
+def _compare(roots: tuple[ET.Element, ET.Element]) -> dict:
+    return compare_schematic_to_pcb(*(build_snapshot(_document(root)) for root in roots))
+
+
+def test_exact_cached_mapping_compares_physical_numbers_not_indices() -> None:
+    roots = _pair()
+    result = _compare(roots)
+    assert result["matches"] is True
+    assert result["comparison_complete"] is True
+    assert result["comparison_basis"] == "explicit_physical_pad_numbers"
+    assert result["sources"]["schematic_sha256"] == _document(roots[0]).sha256
+
+
+@pytest.mark.parametrize("net_name", ["", "SAME"])
+def test_duplicate_or_empty_net_names_cannot_produce_false_match(net_name: str) -> None:
+    roots = _pair()
+    for root in roots:
+        for name in root.findall(".//Nets/Net/Name"):
+            name.text = net_name
+    result = _compare(roots)
+    assert result["matches"] is False
+    assert result["comparison_complete"] is False
+    assert any(item["code"] == "missing_or_duplicate_net_name" for item in result["ambiguities"])
+
+
+def test_unresolved_endpoint_cannot_match_another_unresolved_endpoint() -> None:
+    roots = _pair()
+    for root, tag, key in ((roots[0], "Pins", "Part"), (roots[1], "Pads", "Comp")):
+        for item in root.findall(f".//Nets/Net/{tag}/Item"):
+            item.set(key, "999")
+    result = _compare(roots)
+    assert result["matches"] is False
+    assert result["status"] == "inconclusive"
+
+
+def test_missing_library_prevents_positive_electrical_match() -> None:
+    roots = _pair()
+    library = roots[0].find("./Library")
+    assert library is not None
+    roots[0].remove(library)
+    assert _compare(roots)["matches"] is False
+
+
+def test_remapped_symbol_pins_are_not_confused_with_their_indices() -> None:
+    roots = _pair()
+    pins = roots[0].findall("./Library/Components/Component/Part/Pins/Pin")
+    for index, pin in enumerate(pins):
+        pin.set("PadId", str(1 - index))
+        number = pin.find("./PadNumber")
+        assert number is not None
+        number.text = str(2 - index)
+    result = _compare(roots)
+    assert result["comparison_complete"] is True
+    assert result["matches"] is False
+    assert len(result["nets"]["endpoint_mismatches"]) == 2
+    for net in roots[1].findall("./Board/Nets/Net"):
+        for item in net.findall("./Pads/Item"):
+            item.set("Pad", str(1 - int(item.get("Pad", "0"))))
+    assert _compare(roots)["matches"] is True
+
+
+def test_multi_unit_pin_zero_is_resolved_in_its_own_section() -> None:
+    roots = _pair()
+    schematic = roots[0]
+    component = schematic.find("./Library/Components/Component")
+    parts = schematic.find("./Schematic/Components")
+    assert component is not None and parts is not None
+    second_section = copy.deepcopy(component[0])
+    second_pins = second_section.find("./Pins")
+    assert second_pins is not None
+    second_pins.remove(second_pins[0])
+    second_pins[0].set("Id", "0")
+    component.append(second_section)
+    second_part = copy.deepcopy(parts[0])
+    second_part.set("Id", "1")
+    second_part.set("ComponentPart", "1")
+    pins = second_part.find("./Pins")
+    assert pins is not None
+    pins.remove(pins[0])
+    parts.append(second_part)
+    bindings = schematic_pin_pad_numbers(_document(schematic))
+    assert bindings[("0", 0)] == "1"
+    assert bindings[("1", 0)] == "2"
+
+
+def test_sync_uses_verified_cache_without_manual_mapping() -> None:
+    roots = _pair()
+    document = _document(roots[0])
+    pcb = DipTraceDocument.from_bytes(Path("board.xml"), build_pcb_document())
+    plan = build_sync_plan(
+        document, pcb,
+        mappings=[ComponentSyncMapping(refdes="R1", pattern_style="PatType0")],
+        pattern_documents=[DipTraceDocument.load(FIXTURES / "pattern_library.xml", 10_000_000)],
+    )
+    assert plan.operation.nets[0].endpoints[0].pad_number == "1"
+    assert plan.operation.nets[1].endpoints[0].pad_number == "2"
+
+
+@pytest.mark.parametrize("attribute,value", [("ComponentStyle", "CompType999"),
+                                            ("ComponentPart", "999"),
+                                            ("ComponentPart", "-1")])
+def test_invalid_cache_binding_is_not_guessed(attribute: str, value: str) -> None:
+    roots = _pair()
+    part = roots[0].find("./Schematic/Components/Part")
+    assert part is not None
+    part.set(attribute, value)
+    assert schematic_pin_pad_numbers(_document(roots[0])) == {}
+
+
+
+def test_stale_pin_net_cache_prevents_positive_match() -> None:
+    roots = _pair()
+    pin = roots[0].find("./Schematic/Components/Part/Pins/Pin")
+    assert pin is not None
+    pin.set("NetId", "999")
+    result = _compare(roots)
+    assert result["matches"] is False
+    assert any(item["code"] == "inconsistent_endpoint_netid" for item in result["ambiguities"])
+
+
+def test_declared_no_connect_pin_cannot_be_certified_as_connected() -> None:
+    roots = _pair()
+    pin = roots[0].find("./Schematic/Components/Part/Pins/Pin")
+    assert pin is not None
+    pin.set("NotConnected", "Y")
+    result = _compare(roots)
+    assert result["matches"] is False
+    assert any(item["code"] == "explicit_nc_pin_connected" for item in result["ambiguities"])
+
+
+def test_ambiguity_output_is_bounded_without_hiding_incompleteness() -> None:
+    roots = _pair()
+    pins = roots[0].find("./Schematic/Nets/Net/Pins")
+    assert pins is not None
+    for index in range(250):
+        ET.SubElement(pins, "Item", {"Part": str(1000 + index), "Pin": "0"})
+    result = _compare(roots)
+    assert result["matches"] is False
+    assert len(result["ambiguities"]) == 200
+    assert result["ambiguity_count"] == 250
+    assert result["ambiguities_truncated"] is True

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -40,3 +40,29 @@ def test_release_readiness_is_not_applicable_to_schematic() -> None:
     report = run_release_readiness(snapshot)
     assert report["status"] == "not_applicable"
     assert report["findings"] == []
+
+
+
+def test_readiness_uses_bom_population_and_manufacturer_aliases() -> None:
+    raw = (FIXTURES / "pcb.xml").read_bytes().replace(
+        b"<RefDes>R1</RefDes>",
+        b"<RefDes>R1</RefDes><AddFields><AddField><Name>Populate</Name>"
+        b"<Text>no</Text></AddField></AddFields>",
+    ).replace(
+        b"<RefDes>U1</RefDes>",
+        b"<RefDes>U1</RefDes><AddFields><AddField><Name>mfr</Name>"
+        b"<Text>Synthetic</Text></AddField><AddField><Name>MPN</Name>"
+        b"<Text>TEST-1</Text></AddField></AddFields>",
+    )
+    snapshot = build_snapshot(DipTraceDocument.from_bytes(Path("test.xml"), raw))
+    report = run_release_readiness(snapshot)
+    assert report["metrics"]["populated_components"] == 1
+    assert report["metrics"]["missing_procurement_identity_count"] == 0
+
+
+def test_readiness_blocks_unidentified_assembly_component() -> None:
+    raw = (FIXTURES / "pcb.xml").read_bytes().replace(b"<RefDes>R1</RefDes>", b"<RefDes />")
+    snapshot = build_snapshot(DipTraceDocument.from_bytes(Path("test.xml"), raw))
+    report = run_release_readiness(snapshot)
+    assert report["status"] == "blocked"
+    assert any(item["check_id"] == "release.missing_refdes" for item in report["findings"])

--- a/tests/test_schematic_pcb_sync.py
+++ b/tests/test_schematic_pcb_sync.py
@@ -31,7 +31,13 @@ def _load(name: str) -> DipTraceDocument:
 
 def _mapping() -> list[ComponentSyncMapping]:
     return [
-        ComponentSyncMapping(refdes="R1", pattern_style="PatType0"),
+        ComponentSyncMapping(
+            refdes="R1", pattern_style="PatType0",
+            pin_map=[
+                {"part_id": "0", "pin": 0, "pad_number": "1"},
+                {"part_id": "0", "pin": 1, "pad_number": "2"},
+            ],
+        ),
         ComponentSyncMapping(
             refdes="U1",
             pattern_style="PatType1",
@@ -623,3 +629,45 @@ def test_sync_pattern_cache_normalization_edge_cases() -> None:
     )
     with pytest.raises(EditError, match="duplicate pad number"):
         _sync_pattern_pad_ids(duplicate_map)
+
+
+
+def test_sync_never_guesses_connected_single_part_pin_order() -> None:
+    mappings = _mapping()
+    mappings[0] = ComponentSyncMapping(refdes="R1", pattern_style="PatType0")
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    with pytest.raises(EditError, match="Pin-to-pad mapping is required for R1"):
+        build_sync_plan(
+            _load("schematic.xml"), pcb, mappings=mappings,
+            pattern_documents=[_load("pattern_library.xml")],
+        )
+    assert pcb.raw_bytes == build_pcb_document()
+
+
+
+@pytest.mark.parametrize("attribute,value", [("NetId", "999"), ("NotConnected", "Y")])
+def test_sync_rejects_contradictory_source_pin_state(attribute: str, value: str) -> None:
+    source = _load("schematic.xml")
+    root = ET.fromstring(source.raw_bytes)
+    pin = root.find("./Schematic/Components/Part/Pins/Pin")
+    assert pin is not None
+    pin.set(attribute, value)
+    schematic = DipTraceDocument.from_bytes(source.path, ET.tostring(root))
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    with pytest.raises(EditError, match="contradicts net membership"):
+        build_sync_plan(
+            schematic, pcb, mappings=_mapping(),
+            pattern_documents=[_load("pattern_library.xml")],
+        )
+
+
+def test_sync_rejects_duplicate_net_names() -> None:
+    source = _load("schematic.xml")
+    raw = source.raw_bytes.replace(b"<Name>SIGNAL</Name>", b"<Name>VCC</Name>")
+    schematic = DipTraceDocument.from_bytes(source.path, raw)
+    pcb = DipTraceDocument.from_bytes(Path("board.dip"), build_pcb_document())
+    with pytest.raises(EditError, match="unique names"):
+        build_sync_plan(
+            schematic, pcb, mappings=_mapping(),
+            pattern_documents=[_load("pattern_library.xml")],
+        )

--- a/tests/test_write_path_trust_closure.py
+++ b/tests/test_write_path_trust_closure.py
@@ -129,7 +129,13 @@ def test_schematic_to_pcb_sync_invalidates_trust_after_real_commit(tmp_path: Pat
         str(schematic),
         str(board),
         component_mappings=[
-            {"refdes": "R1", "pattern_style": "PatType0"},
+            {
+                "refdes": "R1", "pattern_style": "PatType0",
+                "pin_map": [
+                    {"part_id": "0", "pin": 0, "pad_number": "1"},
+                    {"part_id": "0", "pin": 1, "pad_number": "2"},
+                ],
+            },
             {
                 "refdes": "U1",
                 "pattern_style": "PatType1",


### PR DESCRIPTION
## Implemented platform review

Baseline: `main` at `24d4106ca7436cc2f1a052885b289bb48bffe734`.
Final head: `ade96ce687bc4d3aec55c30f59b43029964bb841` on `astra`.
Verified Git tree: `eb3f583b12112a5af5f419716eaa0bf91e4d104b` — identical to the locally tested source tree.

**20 changed files, +1141 / -137, two implementation commits.** The final diff contains only source, tests and documentation. Temporary snapshot/transport/publication infrastructure is excluded from both the final tree and PR commit range. `main`, trusted acceptance fixtures and provenance entries were not changed.

Full report: [docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md](https://github.com/fireostendere/mcp_diptrace/blob/astra/docs/ASTRA_PLATFORM_REVIEW_2026-09-09.md).

## Reproduced defects corrected

- **P1 — pinout validation:** PadId/PadIndex and PadNumber must identify the same physical pad. Duplicate pattern identities and conflicting aliases are rejected.
- **P1 — unsafe synchronization:** remove Nth-pin-to-Nth-pad and invented-pad-number fallbacks. Connected pins require verified embedded-cache bindings or an explicit caller-reviewed pin map.
- **P1 — false electrical matches:** compare verified physical pad numbers, retain ambiguous net evidence, reject unresolved identities and contradictory NetId/no-connect declarations. Incomplete evidence produces `inconclusive`, never `matches=true`.
- **P1 — outline compaction:** include via annuli, pours and markings; reject bowties and non-finite dimensions; preserve winding and metadata; skip cutouts/incomplete bounds; never enlarge the mechanical outline.
- **P2 — inconsistent assembly population:** BOM, placement and readiness share population/procurement interpretation. Both BOM and placement honor `include_dnp`.
- **P2 — CSV corruption and escaping:** negative finite numeric coordinates remain numeric; NaN/infinity are rejected; whitespace-prefixed untrusted spreadsheet expressions are guarded.
- **P2 — export integrity/read bounds:** add artifact SHA-256 and byte counts, verify resource reads and bound bytes read before processing.
- **P3 — stale/duplicated implementation:** remove redundant DNP/procurement parsing, unsafe mapping guesses and nonexistent development commands; correct outdated version/entry-point documentation.
- **Follow-up — malformed XML cache indices:** exact native cache-key lookup replaces integer coercion. Unicode and oversized index strings stay unresolved instead of raising conversion errors or aliasing valid indices. Four additional synthetic regression cases cover this boundary.

## Useful functionality added

Existing assembly/fabrication export calls now produce a coherent **source-bound review bundle**: consistent BOM/placement, stackup, board geometry, `preflight.json`, coordinate conventions and a version-2 integrity manifest. Preflight combines readiness with explicitly exported ratlines and returns `blocked` or `manual_review_required`, **not** fabrication approval. Native acceptance and offline geometric DRC are explicitly `not_run` in this export operation.

A shared exact cache resolver supports section-local indices in multi-unit symbols and non-positional pin permutations. Electrical comparison adds source hashes, completeness, bounded ambiguity evidence and physical endpoint differences.

**OpenCode/mcp-rag owns retrieval, model interpretation and orchestration. No embeddings, RAG, inference loop or network lookup was added. The public tools/list contract remains 167 tools.**

## Compatibility

Older callers relying on positional pin mapping must supply a reviewed `component_mappings.pin_map` or exact embedded-cache bindings. Pad-number lists alone are not electrical pin maps. `docs/DEVELOPMENT.md` includes a synthetic migration example. Existing preview/SHA/backup/transaction boundaries remain in use; legacy export records remain readable.

## Validation

Final local Linux/CPython 3.13.5/dev+geometry validation:

- **1619 passed, 6 platform skips** — **49 additional passing cases** against the baseline.
- Global Ruff: pass.
- Strict Mypy: pass, **136 source files**.
- **19/19 additional gates passed**, rerun on the final source: metadata, skills, privacy, provenance, compliance, event-loop, discovery/tools snapshot, XML inventory, format/probe/fixture audits, actual GEOS selection, process-level bridge handshake, wheel/sdist build and release-artifact allowlist/integrity.

Final-head CI: [run 34347069950](https://github.com/fireostendere/mcp_diptrace/actions/runs/34347069950). Use checks attached to `ade96ce`; the first implementation commit `89cf1f8` separately passed all four workflows, but those earlier results are not substituted for final-head verification. The final verification comment records observed CI outcomes.

Both commits identify AI assistance and contain DCO sign-offs. DCO is not a cryptographic signature or independent human approval.

## Explicit limitations and remaining platform work

Native DipTrace open/save/reopen/re-export, native DRC/refill and manufacturing/CAM acceptance were **not executed locally**. A bridge-process handshake or cross-platform Python suite is not native CAD acceptance. The PR remains draft for review and claim-specific native acceptance; no merge or new release is requested.

The report prioritizes a version-pinned native Gerber/NC Drill export adapter, deliberate public exposure of the existing library-authoring core, a resumable project-level workflow built on existing transactions, real-board end-to-end benchmarks, and fabricator/assembler profiles. These remaining capabilities are not represented as implemented. Tested engines, installers and optional presentation features were not deleted merely because they are large.