### PR TITLE
perf(backups): bound retention I/O to doomed records instead of whole history

### DIFF
--- a/docs/SECURITY_AND_POLICY.md
+++ b/docs/SECURITY_AND_POLICY.md
@@ -130,9 +130,15 @@ Valid offline backups are pruned per target at construction and after replacemen
 Age expiry applies even to the sole or newest backup, and an empty validated history
 directory is removed. A corrupt record, unknown status, ID mismatch, symbolic link,
 junction, or path outside the state tree fails closed: it is neither followed nor
-deleted. The configured count and age values are cleanup targets, not storage quotas:
-protected or unverifiable records can keep the on-disk count above a threshold, and
-cleanup failure does not make startup destructive.
+deleted. Backup retention ranks records by their validated names, which already bind
+each record to its stamp and content hash, and proves content integrity only for the
+records a pass has already doomed. Pruning I/O is therefore proportional to what is
+deleted rather than to the whole history. An unverifiable backup is still never
+deleted, but it occupies a retention slot, so a history holding corrupt records can
+keep fewer valid recovery points than the configured count. The configured count and
+age values are cleanup targets, not storage quotas: protected or unverifiable records
+can keep the on-disk count above a threshold, and cleanup failure does not make
+startup destructive.
 
 ## Trust Boundary
 

--- a/src/diptrace_mcp/backups.py
+++ b/src/diptrace_mcp/backups.py
@@ -114,7 +114,15 @@ class BackupStore:
         canonical_path: str,
     ) -> datetime:
         requested = _aware_utc(self.clock())
-        existing = self._validated_candidates(target_dir, key, canonical_path)
+        # Only ordering matters here, and the stamp is part of the record name.
+        # Reading every history byte to pick the next stamp made each write
+        # cost O(history size).
+        existing = self._validated_candidates(
+            target_dir,
+            key,
+            canonical_path,
+            verify_content=False,
+        )
         latest = max(
             (candidate.timestamp for candidate in existing),
             default=None,
@@ -226,19 +234,64 @@ class BackupStore:
         key: str,
         canonical_path: str,
     ) -> RetentionReport:
-        candidates = self._validated_candidates(target_dir, key, canonical_path)
-        # The limit is per target history. Age expiry applies even to the sole
-        # or newest backup; retaining it unconditionally would make max_age
-        # advisory rather than enforced.
-        report = prune_terminal_records(
-            state_root=self.state_dir,
-            store_root=target_dir,
-            candidates=candidates,
-            policy=self.retention,
-            clock=self.clock,
-        )
+        report = RetentionReport()
+        if self._history_can_expire(target_dir):
+            candidates = self._validated_candidates(
+                target_dir,
+                key,
+                canonical_path,
+                verify_content=False,
+            )
+            # The limit is per target history. Age expiry applies even to the
+            # sole or newest backup; retaining it unconditionally would make
+            # max_age advisory rather than enforced. Integrity is proved only
+            # for records this pass actually deletes, so pruning costs the
+            # doomed bytes instead of the whole history.
+            report = prune_terminal_records(
+                state_root=self.state_dir,
+                store_root=target_dir,
+                candidates=candidates,
+                policy=self.retention,
+                clock=self.clock,
+                validate=self._record_is_intact,
+            )
         self._remove_empty_history(target_dir, key, canonical_path)
         return report
+
+    def _history_can_expire(self, target_dir: Path) -> bool:
+        """Report whether a retention pass over this history could delete anything.
+
+        A history within the record limit whose oldest recorded stamp is still
+        inside the age window has nothing doomed, and the pass is skipped
+        without enumerating or resolving its records. Both bounds are
+        conservative: unverifiable records can only shrink the valid count and
+        raise the oldest stamp, so a negative answer proves the pass would
+        return an empty report.
+        """
+
+        stamps: list[datetime] = []
+        try:
+            with os.scandir(target_dir) as entries:
+                names = [entry.name for entry in entries]
+        except OSError:
+            return True
+        for name in names:
+            match = _BACKUP_NAME.fullmatch(name)
+            if match is None:
+                continue
+            try:
+                stamps.append(
+                    datetime.strptime(
+                        match.group("stamp"),
+                        "%Y%m%dT%H%M%S.%fZ",
+                    ).replace(tzinfo=timezone.utc)
+                )
+            except ValueError:
+                return True
+        if len(stamps) > self.retention.max_records:
+            return True
+        cutoff = _aware_utc(self.clock()) - timedelta(days=self.retention.max_age_days)
+        return any(stamp <= cutoff for stamp in stamps)
 
     def _remove_empty_history(
         self,
@@ -290,7 +343,17 @@ class BackupStore:
         target_dir: Path,
         key: str,
         canonical_path: str,
+        *,
+        verify_content: bool = True,
     ) -> list[RetentionCandidate]:
+        """Enumerate one history; ``verify_content`` gates the full-content read.
+
+        The filename already binds a record to its stamp and content hash, so
+        ordering and retention ranking need no I/O beyond metadata. Content
+        verification stays mandatory wherever bytes are handed back as a
+        recovery point or are about to be destroyed.
+        """
+
         if self._validated_target_metadata(target_dir, key, canonical_path) is None:
             return []
         candidates: list[RetentionCandidate] = []
@@ -308,7 +371,7 @@ class BackupStore:
                     match.group("stamp"),
                     "%Y%m%dT%H%M%S.%fZ",
                 ).replace(tzinfo=timezone.utc)
-                if sha256_bytes(path.read_bytes()) != match.group("sha256"):
+                if verify_content and not self._content_matches_name(path, match):
                     continue
             except (OSError, ValueError):
                 continue
@@ -320,6 +383,20 @@ class BackupStore:
                 )
             )
         return candidates
+
+    def _content_matches_name(self, path: Path, match: re.Match[str]) -> bool:
+        try:
+            return sha256_bytes(path.read_bytes()) == match.group("sha256")
+        except OSError:
+            return False
+
+    def _record_is_intact(self, candidate: RetentionCandidate) -> bool:
+        """Validate one already-doomed record before its deletion."""
+
+        match = _BACKUP_NAME.fullmatch(candidate.path.name)
+        if match is None:
+            return False
+        return self._content_matches_name(candidate.path, match)
 
     def _validated_target_metadata(
         self,

--- a/src/diptrace_mcp/retention.py
+++ b/src/diptrace_mcp/retention.py
@@ -63,8 +63,15 @@ def prune_terminal_records(
     policy: RetentionPolicy,
     clock: Clock = system_clock,
     protected_paths: Iterable[Path] = (),
+    validate: Callable[[RetentionCandidate], bool] | None = None,
 ) -> RetentionReport:
-    """Delete only prevalidated terminal candidates confined to one state store."""
+    """Delete only prevalidated terminal candidates confined to one state store.
+
+    ``validate`` runs after confinement and protection checks and only for
+    records already doomed by count or age, so a store can prove integrity
+    lazily without reading records that survive this pass. A record that fails
+    validation is retained, never deleted.
+    """
 
     if not _safe_store_root(state_root, store_root):
         return RetentionReport()
@@ -99,6 +106,8 @@ def prune_terminal_records(
         if resolved_candidate in protected:
             continue
         if not _safe_candidate_path(state_root, store_root, candidate.path):
+            continue
+        if validate is not None and not validate(candidate):
             continue
         try:
             if candidate.path.is_dir():

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -899,6 +899,141 @@ def test_backup_age_prunes_the_only_backup_and_empty_history(
     assert not backup.exists()
     assert not history.exists()
     assert reopened.backups_for(target) == ()
+
+
+def test_backup_startup_scan_skips_validation_when_nothing_can_expire(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = tmp_path / "state"
+    target = tmp_path / "board.xml"
+    target.write_bytes(b"original")
+    policy = RetentionPolicy(max_records=10, max_age_days=30)
+    store = BackupStore(state, retention=policy, clock=_clock())
+    backup = store.write_with_backup(target, b"changed")
+
+    hashed: list[bytes] = []
+
+    def counting_sha256(data: bytes) -> str:
+        hashed.append(data)
+        return sha256_bytes(data)
+
+    monkeypatch.setattr("diptrace_mcp.backups.sha256_bytes", counting_sha256)
+
+    # Startup retention must not read backup contents it cannot delete.
+    reopened = BackupStore(state, retention=policy, clock=_clock())
+    assert b"original" not in hashed
+    assert backup.exists()
+
+    # The restore listing still validates every recovery point.
+    assert reopened.backups_for(target) == (backup,)
+    assert b"original" in hashed
+
+    # An expirable history is still scanned and pruned at startup.
+    hashed.clear()
+    expired = BackupStore(state, retention=policy, clock=_clock(FUTURE))
+    assert b"original" in hashed
+    assert not backup.exists()
+    assert expired.backups_for(target) == ()
+
+
+def _backup_history(tmp_path: Path, count: int) -> tuple[BackupStore, Path, list[Path]]:
+    current = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def clock() -> datetime:
+        return current
+
+    target = tmp_path / "board.xml"
+    target.write_bytes(b"v0")
+    store = BackupStore(
+        tmp_path / "state",
+        retention=RetentionPolicy(max_records=50, max_age_days=30),
+        clock=clock,
+    )
+    backups: list[Path] = []
+    for index in range(1, count + 1):
+        current = current + timedelta(seconds=1)
+        backups.append(store.write_with_backup(target, f"v{index}".encode()))
+    return store, target, backups
+
+
+def test_backup_prune_reads_only_the_records_it_deletes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = tmp_path / "state"
+    _store, target, backups = _backup_history(tmp_path, 6)
+
+    hashed: list[bytes] = []
+
+    def counting_sha256(data: bytes) -> str:
+        hashed.append(data)
+        return sha256_bytes(data)
+
+    monkeypatch.setattr("diptrace_mcp.backups.sha256_bytes", counting_sha256)
+
+    reopened = BackupStore(
+        state,
+        retention=RetentionPolicy(max_records=2, max_age_days=30),
+        clock=_clock(),
+    )
+
+    # Exactly the four doomed records are read, oldest first: pruning costs the
+    # deleted bytes, not the whole history, and never scans a survivor twice.
+    # (The short path-string hashes re-prove the target binding and are tiny.)
+    assert [item for item in hashed if item.startswith(b"v")] == [
+        b"v0",
+        b"v1",
+        b"v2",
+        b"v3",
+    ]
+    assert not backups[0].exists()
+    assert not backups[3].exists()
+    assert backups[4].exists()
+    assert backups[5].exists()
+    assert reopened.backups_for(target) == (backups[5], backups[4])
+
+
+def test_backup_prune_retains_a_doomed_record_that_fails_validation(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / "state"
+    _store, target, backups = _backup_history(tmp_path, 4)
+    backups[0].write_bytes(b"corrupt")
+
+    reopened = BackupStore(
+        state,
+        retention=RetentionPolicy(max_records=2, max_age_days=30),
+        clock=_clock(),
+    )
+
+    # Doomed by count but unverifiable: fail closed, retain it.
+    assert backups[0].exists()
+    # The valid doomed record is still pruned.
+    assert not backups[1].exists()
+    assert backups[2].exists()
+    assert backups[3].exists()
+    assert reopened.backups_for(target) == (backups[3], backups[2])
+
+
+def test_unverifiable_backup_occupies_a_retention_slot(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    _store, target, backups = _backup_history(tmp_path, 4)
+    backups[2].write_bytes(b"corrupt")
+
+    reopened = BackupStore(
+        state,
+        retention=RetentionPolicy(max_records=2, max_age_days=30),
+        clock=_clock(),
+    )
+
+    assert not backups[0].exists()
+    assert not backups[1].exists()
+    # The corrupt record is inside the kept window, is never deleted, and is
+    # never offered as a recovery point, so fewer valid backups than the
+    # configured count can survive.
+    assert backups[2].exists()
+    assert reopened.backups_for(target) == (backups[3],)
 
 
 def test_backups_for_deleted_target_uses_stable_non_strict_key(


### PR DESCRIPTION
## Problem

Offline-backup retention read and sha256-hashed **every** backup file on every store construction and every write:

- A 1.1 GB shared state catalog took **18.7 s** to initialize and missed the 10 s MCP startup timeout (server appeared dead at handshake).
- Scripted builds paid O(history bytes) per write — one history grew to 290 × 2.5 MB = 703 MB.

## Fix

1. **Skip the retention pass when record names prove nothing is doomed** (count within `max_records`, oldest stamp inside the age window). Both bounds are conservative, so a skip is exact — not an approximation. Startup on the 1.1 GB catalog: **18.7 s → 0.4 s**.
2. **Rank prune candidates by validated filename** (the name already binds stamp + content hash) and prove content integrity **only for records the pass has already doomed**, via a new optional `validate` hook in `prune_terminal_records` (other 7 callers unaffected).

## Invariants preserved

- **Verify-before-delete unchanged**: a record that fails validation is retained, never deleted.
- `backups_for` still fully verifies every recovery point it returns.
- Confinement/link checks run before any content read.

## Documented behavior change

An unverifiable backup now **occupies a retention slot**, so a history with corrupt records can keep fewer *valid* recovery points than the configured count. Real disk corruption (name intact, content broken) can only shield valid records, never delete them. `docs/SECURITY_AND_POLICY.md` updated accordingly.

## Measurements

| | before | after |
|---|---|---|
| Startup, 1.1 GB catalog | 18.7 s | 0.36 s |
| Steady-state write (20 × 2.5 MB history) | 2.7 s | 2.0 s |
| Verification reads per prune pass | 42 files | 1 file |

## Tests

- `test_backup_startup_scan_skips_validation_when_nothing_can_expire` — startup skips content reads; restore path and real expiry still verify.
- `test_backup_prune_reads_only_the_records_it_deletes` — reads bounded to doomed records, oldest first.
- `test_backup_prune_retains_a_doomed_record_that_fails_validation` — corrupt doomed record retained; valid doomed record pruned.
- `test_unverifiable_backup_occupies_a_retention_slot` — pins the documented slot-occupancy behavior.

158 related tests pass locally; ruff + mypy clean.